### PR TITLE
Implement single-account AWS CloudFormation onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## Unreleased
+- Implement the **single-account AWS CloudFormation one-click backend** (#1749).
+  `POST /v1/connectors/aws` now safely resumes an existing setup when the same
+  connector ID is supplied, preserving the encrypted External ID, launch URL,
+  role name, stack name, permission preview, setup summary, onboarding status,
+  and typed next actions instead of rotating trust parameters during retries.
+  Poll/status responses keep lifecycle and launch metadata available to the app
+  while continuing to hide the External ID outside the start/resume response.
 - Add the **AWS connector scope contract** (#1748). `POST /v1/connectors/aws`
   and AWS connection status now expose explicit setup intent for
   `scope_type`, `deployment_method`, onboarding lifecycle, target regions,

--- a/docs/auth/aws-connector.md
+++ b/docs/auth/aws-connector.md
@@ -1,6 +1,6 @@
 # AWS Connector
 
-PR 7 adds the hosted AWS connector onboarding path behind two feature flags:
+The hosted AWS connector onboarding path is behind two feature flags:
 
 - Backend: `IDENTRAIL_FEATURE_CONNECTOR_AWS=true`
 - Frontend: `VITE_FEATURE_CONNECTOR_AWS=true`
@@ -30,11 +30,13 @@ When a persistent database is configured and AWS connector setup is enabled, `ID
 
 ## Flow
 
-1. The UI calls `POST /v1/connectors/aws` with `workspace_id` and `project_id`.
-2. The API generates a 32-byte External ID, stores it encrypted, creates a pending AWS connector, and returns an AWS CloudFormation launch URL.
+1. The UI calls `POST /v1/connectors/aws` with `workspace_id`, `project_id`, and optional connector display fields.
+2. The API normalizes the single-account CloudFormation setup, generates a 32-byte External ID, stores it encrypted, creates a pending AWS connector, and returns an AWS CloudFormation launch URL.
 3. The user launches the stack in AWS. The stack creates an `IdentrailReadOnly` role with a trust policy requiring the External ID.
 4. The user pastes the created role ARN back into Identrail.
 5. The API uses the stored External ID, assumes the role with STS, verifies caller identity, checks scanner-critical IAM read access, and marks the connector active or degraded.
+
+If the app calls `POST /v1/connectors/aws` again with the same `connector_id`, the API resumes the existing setup instead of rotating the External ID or changing the launch parameters. This keeps the AWS trust policy, CloudFormation stack parameters, and Identrail connector record aligned while a user retries or returns to setup. Poll and status responses expose lifecycle fields, setup summary, launch URL, template URL, policy hash, diagnostics, and next actions, but they do not serialize the External ID.
 
 The read-only policy and rationale live together under `deploy/connectors/aws/policies/`.
 
@@ -69,11 +71,10 @@ organization and selected scopes must use a StackSet deployment method,
 selected OUs/accounts must include targets, and malformed AWS account IDs, OU
 IDs, and regions fail validation.
 
-This foundation only establishes the shared contract. The executable
-`POST /v1/connectors/aws` setup path still starts the existing
-`single_account`/`cloudformation` read-only connector. Organization,
-selected-OU, selected-account, Terraform, and full manual app flows are reserved
-for the follow-on implementation issues.
+The executable `POST /v1/connectors/aws` setup path currently supports
+`single_account`/`cloudformation` read-only onboarding. Organization,
+selected-OU, selected-account, Terraform, and full manual app flows remain
+reserved for the follow-on implementation issues.
 
 ## Account and Region Coverage Registry
 

--- a/docs/source-onboarding.md
+++ b/docs/source-onboarding.md
@@ -35,8 +35,8 @@ POST /v1/connectors/aws/{connector_id}/validate
 POST /v1/connectors/aws/{connector_id}/refresh-policy
 ```
 
-`POST /v1/connectors/aws` starts onboarding and returns an AWS launch URL plus permission preview.
-`GET /v1/connectors/aws/{connector_id}/poll` returns status for long-running setup.
+`POST /v1/connectors/aws` starts onboarding and returns an AWS launch URL plus permission preview. Repeating the call with the same `connector_id` resumes the existing setup and preserves the External ID and launch parameters.
+`GET /v1/connectors/aws/{connector_id}/poll` returns status for long-running setup without serializing the External ID.
 `POST /v1/connectors/aws/{connector_id}/validate` validates the role created by that flow with scanner-critical IAM checks, permission checks, and diagnostics that are surfaced in the connector status.
 `POST /v1/connectors/aws/{connector_id}/refresh-policy` regenerates the read-only policy preview and capability matrix for the same connector.
 

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -23,8 +22,6 @@ var (
 	awsAccountIDPattern = regexp.MustCompile(`^[0-9]{12}$`)
 	awsOUIDPattern      = regexp.MustCompile(`^ou-[a-z0-9]{4,32}-[a-z0-9]{8,32}$`)
 )
-
-var awsConnectorStartLocks sync.Map
 
 const (
 	awsExternalIDSecretName     = "external_id"
@@ -341,8 +338,6 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 	if connectorID == "" {
 		connectorID = "aws-" + uuid.NewString()
 	} else {
-		unlock := lockAWSConnectorStart(scope.TenantID, project.WorkspaceID, project.ProjectID, connectorID)
-		defer unlock()
 		stored, err := s.Store.GetTenancyConnector(ctx, project.WorkspaceID, project.ProjectID, connectorID)
 		if err == nil {
 			return s.resumeAWSConnectorStart(ctx, stored, setup, request, templateURL, accountID)
@@ -426,15 +421,16 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 		ObservedAt:   now,
 		UpdatedAt:    now,
 	}
-	if err := s.Store.UpsertTenancyConnector(ctx, connector, state); err != nil {
-		return AWSConnectorStartResponse{}, fmt.Errorf("persist aws connector: %w", err)
-	}
-	if err := s.persistAWSExternalID(ctx, scope.TenantID, project.WorkspaceID, project.ProjectID, connectorID, externalID, now); err != nil {
+	envelope, err := s.newAWSExternalIDSecretEnvelope(scope.TenantID, project.WorkspaceID, project.ProjectID, connectorID, externalID, now)
+	if err != nil {
 		return AWSConnectorStartResponse{}, err
 	}
-	stored, err := s.Store.GetTenancyConnector(ctx, project.WorkspaceID, project.ProjectID, connectorID)
+	stored, created, err := s.Store.CreateTenancyConnectorWithSecretEnvelopeIfAbsent(ctx, connector, state, envelope)
 	if err != nil {
-		return AWSConnectorStartResponse{}, fmt.Errorf("load persisted aws connector: %w", err)
+		return AWSConnectorStartResponse{}, fmt.Errorf("create aws connector: %w", err)
+	}
+	if !created {
+		return s.resumeAWSConnectorStart(ctx, stored, setup, request, templateURL, accountID)
 	}
 	status := s.awsConnectionStatusFromStored(ctx, stored)
 	status.ExternalID = externalID
@@ -492,6 +488,7 @@ func (s *Service) resumeAWSConnectorStart(
 	if !generatedExternalID {
 		launchURL = awsMetadataString(stored.State.Metadata, "launch_url")
 	}
+	rebuiltLaunchMetadata := launchURL == ""
 	if launchURL == "" {
 		launchURL = awsconnector.BuildCloudFormationLaunchURL(awsconnector.CloudFormationLaunchInput{
 			TemplateURL:        templateURL,
@@ -502,7 +499,10 @@ func (s *Service) resumeAWSConnectorStart(
 			RoleName:           roleName,
 		})
 	}
-	if generatedExternalID {
+	if generatedExternalID || rebuiltLaunchMetadata {
+		if rotatedAt.IsZero() {
+			rotatedAt = s.Now().UTC()
+		}
 		stored = persistRecoveredAWSConnectorLaunchState(stored, externalID, region, roleName, stackName, templateURL, launchURL, policyHash, s.connectorSecretManager().ActiveKeyVersion(), rotatedAt)
 		if err := s.Store.UpsertTenancyConnector(ctx, stored.Connector, stored.State); err != nil {
 			return AWSConnectorStartResponse{}, fmt.Errorf("persist recovered aws connector launch state: %w", err)
@@ -517,19 +517,6 @@ func (s *Service) resumeAWSConnectorStart(
 	status.TemplateURL = firstNonEmptyAWSValue(status.TemplateURL, templateURL)
 	status.PolicyHash = firstNonEmptyAWSValue(status.PolicyHash, policyHash)
 	return awsConnectorStartResponse(status, externalID, launchURL, status.TemplateURL, roleName, stackName, policyHash), nil
-}
-
-func lockAWSConnectorStart(tenantID string, workspaceID string, projectID string, connectorID string) func() {
-	key := strings.Join([]string{
-		strings.TrimSpace(tenantID),
-		strings.TrimSpace(workspaceID),
-		strings.TrimSpace(projectID),
-		strings.TrimSpace(connectorID),
-	}, "/")
-	value, _ := awsConnectorStartLocks.LoadOrStore(key, &sync.Mutex{})
-	lock := value.(*sync.Mutex)
-	lock.Lock()
-	return lock.Unlock
 }
 
 func persistRecoveredAWSConnectorLaunchState(
@@ -1300,14 +1287,28 @@ func (s *Service) awsExternalIDFromStored(ctx context.Context, stored db.Tenancy
 }
 
 func (s *Service) persistAWSExternalID(ctx context.Context, tenantID string, workspaceID string, projectID string, connectorID string, externalID string, rotatedAt time.Time) error {
+	if strings.TrimSpace(externalID) == "" {
+		return nil
+	}
+	secret, err := s.newAWSExternalIDSecretEnvelope(tenantID, workspaceID, projectID, connectorID, externalID, rotatedAt)
+	if err != nil {
+		return err
+	}
+	if err := s.Store.UpsertTenancyConnectorSecretEnvelope(db.WithScope(ctx, db.Scope{TenantID: tenantID, WorkspaceID: workspaceID}), secret); err != nil {
+		return fmt.Errorf("persist aws connector external id envelope: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) newAWSExternalIDSecretEnvelope(tenantID string, workspaceID string, projectID string, connectorID string, externalID string, rotatedAt time.Time) (db.TenancyConnectorSecretEnvelope, error) {
 	externalID = strings.TrimSpace(externalID)
 	if externalID == "" {
-		return nil
+		return db.TenancyConnectorSecretEnvelope{}, nil
 	}
 	manager := s.connectorSecretManager()
 	envelope, err := manager.Encrypt([]byte(externalID), awsExternalIDAAD(tenantID, workspaceID, projectID, connectorID))
 	if err != nil {
-		return fmt.Errorf("encrypt aws connector external id: %w", err)
+		return db.TenancyConnectorSecretEnvelope{}, fmt.Errorf("encrypt aws connector external id: %w", err)
 	}
 	secret := db.TenancyConnectorSecretEnvelope{
 		TenantID:        tenantID,
@@ -1322,10 +1323,7 @@ func (s *Service) persistAWSExternalID(ctx context.Context, tenantID string, wor
 		CreatedAt:       rotatedAt,
 		UpdatedAt:       rotatedAt,
 	}
-	if err := s.Store.UpsertTenancyConnectorSecretEnvelope(db.WithScope(ctx, db.Scope{TenantID: tenantID, WorkspaceID: workspaceID}), secret); err != nil {
-		return fmt.Errorf("persist aws connector external id envelope: %w", err)
-	}
-	return nil
+	return secret, nil
 }
 
 func (s *Service) clearAWSExternalID(ctx context.Context, tenantID string, workspaceID string, projectID string, connectorID string) error {

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,6 +23,8 @@ var (
 	awsAccountIDPattern = regexp.MustCompile(`^[0-9]{12}$`)
 	awsOUIDPattern      = regexp.MustCompile(`^ou-[a-z0-9]{4,32}-[a-z0-9]{8,32}$`)
 )
+
+var awsConnectorStartLocks sync.Map
 
 const (
 	awsExternalIDSecretName     = "external_id"
@@ -338,6 +341,8 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 	if connectorID == "" {
 		connectorID = "aws-" + uuid.NewString()
 	} else {
+		unlock := lockAWSConnectorStart(scope.TenantID, project.WorkspaceID, project.ProjectID, connectorID)
+		defer unlock()
 		stored, err := s.Store.GetTenancyConnector(ctx, project.WorkspaceID, project.ProjectID, connectorID)
 		if err == nil {
 			return s.resumeAWSConnectorStart(ctx, stored, setup, request, templateURL, accountID)
@@ -454,6 +459,7 @@ func (s *Service) resumeAWSConnectorStart(
 
 	externalID := s.awsExternalIDFromStored(ctx, stored)
 	generatedExternalID := false
+	var rotatedAt time.Time
 	if externalID == "" {
 		var err error
 		externalID, err = generateAWSExternalID()
@@ -461,8 +467,8 @@ func (s *Service) resumeAWSConnectorStart(
 			return AWSConnectorStartResponse{}, err
 		}
 		generatedExternalID = true
-		now := s.Now().UTC()
-		if err := s.persistAWSExternalID(ctx, stored.Connector.TenantID, stored.Connector.WorkspaceID, stored.Connector.ProjectID, stored.Connector.ConnectorID, externalID, now); err != nil {
+		rotatedAt = s.Now().UTC()
+		if err := s.persistAWSExternalID(ctx, stored.Connector.TenantID, stored.Connector.WorkspaceID, stored.Connector.ProjectID, stored.Connector.ConnectorID, externalID, rotatedAt); err != nil {
 			return AWSConnectorStartResponse{}, err
 		}
 	}
@@ -496,6 +502,12 @@ func (s *Service) resumeAWSConnectorStart(
 			RoleName:           roleName,
 		})
 	}
+	if generatedExternalID {
+		stored = persistRecoveredAWSConnectorLaunchState(stored, externalID, region, roleName, stackName, templateURL, launchURL, policyHash, s.connectorSecretManager().ActiveKeyVersion(), rotatedAt)
+		if err := s.Store.UpsertTenancyConnector(ctx, stored.Connector, stored.State); err != nil {
+			return AWSConnectorStartResponse{}, fmt.Errorf("persist recovered aws connector launch state: %w", err)
+		}
+	}
 
 	status := s.awsConnectionStatusFromStored(ctx, stored)
 	status.ExternalID = externalID
@@ -504,7 +516,60 @@ func (s *Service) resumeAWSConnectorStart(
 	status.LaunchURL = firstNonEmptyAWSValue(launchURL, status.LaunchURL)
 	status.TemplateURL = firstNonEmptyAWSValue(status.TemplateURL, templateURL)
 	status.PolicyHash = firstNonEmptyAWSValue(status.PolicyHash, policyHash)
-	return awsConnectorStartResponse(status, externalID, launchURL, templateURL, roleName, stackName, policyHash), nil
+	return awsConnectorStartResponse(status, externalID, launchURL, status.TemplateURL, roleName, stackName, policyHash), nil
+}
+
+func lockAWSConnectorStart(tenantID string, workspaceID string, projectID string, connectorID string) func() {
+	key := strings.Join([]string{
+		strings.TrimSpace(tenantID),
+		strings.TrimSpace(workspaceID),
+		strings.TrimSpace(projectID),
+		strings.TrimSpace(connectorID),
+	}, "/")
+	value, _ := awsConnectorStartLocks.LoadOrStore(key, &sync.Mutex{})
+	lock := value.(*sync.Mutex)
+	lock.Lock()
+	return lock.Unlock
+}
+
+func persistRecoveredAWSConnectorLaunchState(
+	stored db.TenancyConnectorWithState,
+	externalID string,
+	region string,
+	roleName string,
+	stackName string,
+	templateURL string,
+	launchURL string,
+	policyHash string,
+	secretRefVersion string,
+	rotatedAt time.Time,
+) db.TenancyConnectorWithState {
+	metadata := copyAWSMetadata(stored.State.Metadata)
+	metadata["external_id_configured"] = strings.TrimSpace(externalID) != ""
+	metadata["region"] = region
+	metadata["role_name"] = roleName
+	metadata["stack_name"] = stackName
+	metadata["template_url"] = templateURL
+	metadata["launch_url"] = launchURL
+	metadata["policy_hash"] = policyHash
+	metadata["last_started_at"] = rotatedAt.Format(time.RFC3339Nano)
+	stored.State.Metadata = metadata
+	stored.State.ObservedAt = rotatedAt
+	stored.State.UpdatedAt = rotatedAt
+	stored.Connector.SecretProvider = "secret-envelope"
+	stored.Connector.SecretRefID = awsExternalIDSecretRef(stored.Connector.ConnectorID)
+	stored.Connector.SecretRefVersion = secretRefVersion
+	stored.Connector.SecretLastRotatedAt = &rotatedAt
+	stored.Connector.UpdatedAt = rotatedAt
+	return stored
+}
+
+func copyAWSMetadata(metadata map[string]any) map[string]any {
+	out := make(map[string]any, len(metadata))
+	for key, value := range metadata {
+		out[key] = value
+	}
+	return out
 }
 
 func awsConnectorStartResponse(status AWSConnectionStatus, externalID string, launchURL string, templateURL string, roleName string, stackName string, policyHash string) AWSConnectorStartResponse {

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -334,19 +334,30 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 	if templateURL == "" || accountID == "" {
 		return AWSConnectorStartResponse{}, ErrAWSConnectorConfigUnavailable
 	}
-	externalID, err := generateAWSExternalID()
-	if err != nil {
-		return AWSConnectorStartResponse{}, err
-	}
-	now := s.Now().UTC()
 	connectorID := strings.TrimSpace(request.ConnectorID)
 	if connectorID == "" {
 		connectorID = "aws-" + uuid.NewString()
+	} else {
+		stored, err := s.Store.GetTenancyConnector(ctx, project.WorkspaceID, project.ProjectID, connectorID)
+		if err == nil {
+			return s.resumeAWSConnectorStart(ctx, stored, setup, request, templateURL, accountID)
+		}
+		if !errors.Is(err, db.ErrNotFound) {
+			return AWSConnectorStartResponse{}, err
+		}
 	}
 	displayName := strings.TrimSpace(request.DisplayName)
 	if displayName == "" {
 		displayName = "AWS account"
 	}
+	if err := validateAWSConnectorStartIdentity(connectorID, displayName); err != nil {
+		return AWSConnectorStartResponse{}, err
+	}
+	externalID, err := generateAWSExternalID()
+	if err != nil {
+		return AWSConnectorStartResponse{}, err
+	}
+	now := s.Now().UTC()
 	region := setup.TargetRegions[0]
 	roleName := firstNonEmptyAWSValue(strings.TrimSpace(request.RoleName), "IdentrailReadOnly")
 	stackName := firstNonEmptyAWSValue(strings.TrimSpace(request.StackName), "identrail-readonly-connector")
@@ -422,9 +433,84 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 	}
 	status := s.awsConnectionStatusFromStored(ctx, stored)
 	status.ExternalID = externalID
+	return awsConnectorStartResponse(status, externalID, launchURL, templateURL, roleName, stackName, policyHash), nil
+}
+
+func (s *Service) resumeAWSConnectorStart(
+	ctx context.Context,
+	stored db.TenancyConnectorWithState,
+	requestedSetup awsConnectorSetupContract,
+	request AWSConnectorStartRequest,
+	templateURL string,
+	accountID string,
+) (AWSConnectorStartResponse, error) {
+	if stored.Connector.Type != domain.ConnectorTypeAWS {
+		return AWSConnectorStartResponse{}, ErrInvalidAWSConnectionRequest
+	}
+	setup := awsMetadataSetupContract(stored.State.Metadata, AWSConnectorScopeSingleAccount, AWSConnectorDeploymentCloudFormation)
+	if setup.ScopeType != AWSConnectorScopeSingleAccount || setup.DeploymentMethod != AWSConnectorDeploymentCloudFormation {
+		return AWSConnectorStartResponse{}, ErrInvalidAWSConnectionRequest
+	}
+
+	externalID := s.awsExternalIDFromStored(ctx, stored)
+	generatedExternalID := false
+	if externalID == "" {
+		var err error
+		externalID, err = generateAWSExternalID()
+		if err != nil {
+			return AWSConnectorStartResponse{}, err
+		}
+		generatedExternalID = true
+		now := s.Now().UTC()
+		if err := s.persistAWSExternalID(ctx, stored.Connector.TenantID, stored.Connector.WorkspaceID, stored.Connector.ProjectID, stored.Connector.ConnectorID, externalID, now); err != nil {
+			return AWSConnectorStartResponse{}, err
+		}
+	}
+
+	region := firstAWSRegion(setup.TargetRegions)
+	if region == "" {
+		region = firstAWSRegion(requestedSetup.TargetRegions)
+	}
+	region = firstNonEmptyAWSValue(awsMetadataString(stored.State.Metadata, "region"), region, "us-east-1")
+	roleName := firstNonEmptyAWSValue(awsMetadataString(stored.State.Metadata, "role_name"), strings.TrimSpace(request.RoleName), "IdentrailReadOnly")
+	stackName := firstNonEmptyAWSValue(awsMetadataString(stored.State.Metadata, "stack_name"), strings.TrimSpace(request.StackName), "identrail-readonly-connector")
+	policyHash := awsMetadataString(stored.State.Metadata, "policy_hash")
+	if policyHash == "" {
+		hash, err := awsconnector.ReadOnlyPolicyHash()
+		if err != nil {
+			return AWSConnectorStartResponse{}, err
+		}
+		policyHash = hash
+	}
+	launchURL := ""
+	if !generatedExternalID {
+		launchURL = awsMetadataString(stored.State.Metadata, "launch_url")
+	}
+	if launchURL == "" {
+		launchURL = awsconnector.BuildCloudFormationLaunchURL(awsconnector.CloudFormationLaunchInput{
+			TemplateURL:        templateURL,
+			Region:             region,
+			StackName:          stackName,
+			IdentrailAccountID: accountID,
+			ExternalID:         externalID,
+			RoleName:           roleName,
+		})
+	}
+
+	status := s.awsConnectionStatusFromStored(ctx, stored)
+	status.ExternalID = externalID
+	status.ExternalIDConfigured = true
+	status.Region = firstNonEmptyAWSValue(status.Region, region)
+	status.LaunchURL = firstNonEmptyAWSValue(launchURL, status.LaunchURL)
+	status.TemplateURL = firstNonEmptyAWSValue(status.TemplateURL, templateURL)
+	status.PolicyHash = firstNonEmptyAWSValue(status.PolicyHash, policyHash)
+	return awsConnectorStartResponse(status, externalID, launchURL, templateURL, roleName, stackName, policyHash), nil
+}
+
+func awsConnectorStartResponse(status AWSConnectionStatus, externalID string, launchURL string, templateURL string, roleName string, stackName string, policyHash string) AWSConnectorStartResponse {
 	return AWSConnectorStartResponse{
 		Connection:             status,
-		ConnectorID:            connectorID,
+		ConnectorID:            status.ConnectorID,
 		ExternalID:             externalID,
 		LaunchURL:              launchURL,
 		TemplateURL:            templateURL,
@@ -443,7 +529,29 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 		NextActions:            copyAWSConnectorNextActions(status.NextActions),
 		PermissionPreview:      awsconnector.PermissionPreview(),
 		PermissionTiers:        awsconnector.CapabilityPermissionTiers(),
-	}, nil
+	}
+}
+
+func validateAWSConnectorStartIdentity(connectorID string, displayName string) error {
+	connector := domain.Connector{
+		ID:          connectorID,
+		WorkspaceID: "workspace-placeholder",
+		ProjectID:   "project-placeholder",
+		Type:        domain.ConnectorTypeAWS,
+		DisplayName: displayName,
+		Status:      domain.ConnectorStatusPending,
+	}
+	if err := connector.Validate(); err != nil {
+		return ErrInvalidAWSConnectionRequest
+	}
+	return nil
+}
+
+func firstAWSRegion(regions []string) string {
+	if len(regions) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(regions[0])
 }
 
 func (s *Service) ValidateAWSConnector(ctx context.Context, connectorID string, request AWSConnectorValidateRequest) (AWSConnectionStatus, error) {

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -453,10 +453,13 @@ func (s *Service) resumeAWSConnectorStart(
 		return AWSConnectorStartResponse{}, ErrInvalidAWSConnectionRequest
 	}
 
-	externalID := s.awsExternalIDFromStored(ctx, stored)
+	externalID, externalIDConfigured, err := s.awsExternalIDFromStoredStrict(ctx, stored)
+	if err != nil {
+		return AWSConnectorStartResponse{}, err
+	}
 	generatedExternalID := false
 	var rotatedAt time.Time
-	if externalID == "" {
+	if !externalIDConfigured || externalID == "" {
 		var err error
 		externalID, err = generateAWSExternalID()
 		if err != nil {
@@ -464,8 +467,21 @@ func (s *Service) resumeAWSConnectorStart(
 		}
 		generatedExternalID = true
 		rotatedAt = s.Now().UTC()
-		if err := s.persistAWSExternalID(ctx, stored.Connector.TenantID, stored.Connector.WorkspaceID, stored.Connector.ProjectID, stored.Connector.ConnectorID, externalID, rotatedAt); err != nil {
+		secret, err := s.newAWSExternalIDSecretEnvelope(stored.Connector.TenantID, stored.Connector.WorkspaceID, stored.Connector.ProjectID, stored.Connector.ConnectorID, externalID, rotatedAt)
+		if err != nil {
 			return AWSConnectorStartResponse{}, err
+		}
+		secret, created, err := s.Store.CreateTenancyConnectorSecretEnvelopeIfAbsent(db.WithScope(ctx, db.Scope{TenantID: stored.Connector.TenantID, WorkspaceID: stored.Connector.WorkspaceID}), secret)
+		if err != nil {
+			return AWSConnectorStartResponse{}, fmt.Errorf("recover aws connector external id envelope: %w", err)
+		}
+		if !created {
+			recoveredExternalID, err := s.decryptAWSExternalIDEnvelope(stored.Connector, secret)
+			if err != nil {
+				return AWSConnectorStartResponse{}, err
+			}
+			externalID = recoveredExternalID
+			generatedExternalID = false
 		}
 	}
 
@@ -488,8 +504,8 @@ func (s *Service) resumeAWSConnectorStart(
 	if !generatedExternalID {
 		launchURL = awsMetadataString(stored.State.Metadata, "launch_url")
 	}
-	rebuiltLaunchMetadata := launchURL == ""
-	if launchURL == "" {
+	rebuiltLaunchMetadata := launchURL == "" || (externalID != "" && !strings.Contains(launchURL, externalID))
+	if rebuiltLaunchMetadata {
 		launchURL = awsconnector.BuildCloudFormationLaunchURL(awsconnector.CloudFormationLaunchInput{
 			TemplateURL:        templateURL,
 			Region:             region,
@@ -1266,8 +1282,17 @@ func (s *Service) awsConnectionStatusFromStored(ctx context.Context, stored db.T
 }
 
 func (s *Service) awsExternalIDFromStored(ctx context.Context, stored db.TenancyConnectorWithState) string {
+	externalID, _, err := s.awsExternalIDFromStoredStrict(ctx, stored)
+	if err != nil {
+		return ""
+	}
+	return externalID
+}
+
+func (s *Service) awsExternalIDFromStoredStrict(ctx context.Context, stored db.TenancyConnectorWithState) (string, bool, error) {
 	if s == nil || s.Store == nil {
-		return awsMetadataString(stored.State.Metadata, "external_id")
+		externalID := awsMetadataString(stored.State.Metadata, "external_id")
+		return externalID, externalID != "", nil
 	}
 	secret, err := s.Store.GetTenancyConnectorSecretEnvelope(
 		db.WithScope(ctx, db.Scope{TenantID: stored.Connector.TenantID, WorkspaceID: stored.Connector.WorkspaceID}),
@@ -1277,13 +1302,28 @@ func (s *Service) awsExternalIDFromStored(ctx context.Context, stored db.Tenancy
 		awsExternalIDSecretName,
 	)
 	if err != nil {
-		return awsMetadataString(stored.State.Metadata, "external_id")
+		externalID := awsMetadataString(stored.State.Metadata, "external_id")
+		if errors.Is(err, db.ErrNotFound) {
+			return externalID, externalID != "", nil
+		}
+		if externalID != "" {
+			return externalID, true, nil
+		}
+		return "", false, fmt.Errorf("load aws connector external id envelope: %w", err)
 	}
-	plaintext, err := s.connectorSecretManager().Decrypt(secret.Envelope, awsExternalIDAAD(stored.Connector.TenantID, stored.Connector.WorkspaceID, stored.Connector.ProjectID, stored.Connector.ConnectorID))
+	externalID, err := s.decryptAWSExternalIDEnvelope(stored.Connector, secret)
 	if err != nil {
-		return ""
+		return "", true, err
 	}
-	return strings.TrimSpace(string(plaintext))
+	return externalID, true, nil
+}
+
+func (s *Service) decryptAWSExternalIDEnvelope(connector db.TenancyConnector, secret db.TenancyConnectorSecretEnvelope) (string, error) {
+	plaintext, err := s.connectorSecretManager().Decrypt(secret.Envelope, awsExternalIDAAD(connector.TenantID, connector.WorkspaceID, connector.ProjectID, connector.ConnectorID))
+	if err != nil {
+		return "", fmt.Errorf("decrypt aws connector external id envelope: %w", err)
+	}
+	return strings.TrimSpace(string(plaintext)), nil
 }
 
 func (s *Service) persistAWSExternalID(ctx context.Context, tenantID string, workspaceID string, projectID string, connectorID string, externalID string, rotatedAt time.Time) error {

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -640,7 +640,11 @@ func (s *Service) ValidateAWSConnector(ctx context.Context, connectorID string, 
 	}
 	externalID := strings.TrimSpace(request.ExternalID)
 	if externalID == "" {
-		externalID = s.awsExternalIDFromStored(ctx, stored)
+		var err error
+		externalID, _, err = s.awsExternalIDFromStoredStrict(ctx, stored)
+		if err != nil {
+			return AWSConnectionStatus{}, err
+		}
 	}
 	requestedCapabilities := request.Capabilities
 	if len(requestedCapabilities) == 0 {

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -506,7 +507,7 @@ func (s *Service) resumeAWSConnectorStart(
 	if !generatedExternalID {
 		launchURL = awsMetadataString(stored.State.Metadata, "launch_url")
 	}
-	rebuiltLaunchMetadata := launchURL == "" || (externalID != "" && !strings.Contains(launchURL, externalID))
+	rebuiltLaunchMetadata := launchURL == "" || (externalID != "" && !awsCloudFormationLaunchURLMatchesExternalID(launchURL, externalID))
 	if rebuiltLaunchMetadata {
 		launchURL = awsconnector.BuildCloudFormationLaunchURL(awsconnector.CloudFormationLaunchInput{
 			TemplateURL:        templateURL,
@@ -592,12 +593,37 @@ func awsConnectorLaunchMetadata(metadata map[string]any) map[string]any {
 }
 
 func awsConnectorLaunchMetadataForExternalID(metadata map[string]any, externalID string) map[string]any {
-	externalID = strings.TrimSpace(externalID)
 	launchURL := awsMetadataString(metadata, "launch_url")
-	if externalID == "" || launchURL == "" || !strings.Contains(launchURL, externalID) {
+	if !awsCloudFormationLaunchURLMatchesExternalID(launchURL, externalID) {
 		return nil
 	}
 	return awsConnectorLaunchMetadata(metadata)
+}
+
+func awsCloudFormationLaunchURLMatchesExternalID(launchURL string, externalID string) bool {
+	externalID = strings.TrimSpace(externalID)
+	if externalID == "" {
+		return false
+	}
+	return awsCloudFormationLaunchURLExternalID(launchURL) == externalID
+}
+
+func awsCloudFormationLaunchURLExternalID(launchURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(launchURL))
+	if err != nil {
+		return ""
+	}
+	rawQuery := parsed.RawQuery
+	if fragment := parsed.EscapedFragment(); fragment != "" {
+		if index := strings.Index(fragment, "?"); index >= 0 {
+			rawQuery = fragment[index+1:]
+		}
+	}
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(values.Get("param_ExternalId"))
 }
 
 func preserveAWSConnectorLaunchMetadata(metadata map[string]any, preserved map[string]any) {

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -113,6 +113,7 @@ type AWSConnectionUpsertRequest struct {
 	ExcludedAccountIDs     []string                     `json:"excluded_account_ids,omitempty"`
 	AutoOnboardNewAccounts bool                         `json:"auto_onboard_new_accounts,omitempty"`
 	allowSetupContract     bool
+	preserveLaunchMetadata map[string]any
 }
 
 // AWSConnectorStartRequest starts the CloudFormation-based AWS connector flow.
@@ -520,7 +521,7 @@ func (s *Service) resumeAWSConnectorStart(
 		if rotatedAt.IsZero() {
 			rotatedAt = s.Now().UTC()
 		}
-		stored = persistRecoveredAWSConnectorLaunchState(stored, externalID, region, roleName, stackName, templateURL, launchURL, policyHash, s.connectorSecretManager().ActiveKeyVersion(), rotatedAt)
+		stored = persistRecoveredAWSConnectorLaunchState(stored, externalID, region, roleName, stackName, templateURL, launchURL, policyHash, s.connectorSecretManager().ActiveKeyVersion(), rotatedAt, generatedExternalID)
 		if err := s.Store.UpsertTenancyConnector(ctx, stored.Connector, stored.State); err != nil {
 			return AWSConnectorStartResponse{}, fmt.Errorf("persist recovered aws connector launch state: %w", err)
 		}
@@ -547,6 +548,7 @@ func persistRecoveredAWSConnectorLaunchState(
 	policyHash string,
 	secretRefVersion string,
 	rotatedAt time.Time,
+	updateSecretRef bool,
 ) db.TenancyConnectorWithState {
 	metadata := copyAWSMetadata(stored.State.Metadata)
 	metadata["external_id_configured"] = strings.TrimSpace(externalID) != ""
@@ -560,10 +562,12 @@ func persistRecoveredAWSConnectorLaunchState(
 	stored.State.Metadata = metadata
 	stored.State.ObservedAt = rotatedAt
 	stored.State.UpdatedAt = rotatedAt
-	stored.Connector.SecretProvider = "secret-envelope"
-	stored.Connector.SecretRefID = awsExternalIDSecretRef(stored.Connector.ConnectorID)
-	stored.Connector.SecretRefVersion = secretRefVersion
-	stored.Connector.SecretLastRotatedAt = &rotatedAt
+	if updateSecretRef {
+		stored.Connector.SecretProvider = "secret-envelope"
+		stored.Connector.SecretRefID = awsExternalIDSecretRef(stored.Connector.ConnectorID)
+		stored.Connector.SecretRefVersion = secretRefVersion
+		stored.Connector.SecretLastRotatedAt = &rotatedAt
+	}
 	stored.Connector.UpdatedAt = rotatedAt
 	return stored
 }
@@ -574,6 +578,26 @@ func copyAWSMetadata(metadata map[string]any) map[string]any {
 		out[key] = value
 	}
 	return out
+}
+
+func awsConnectorLaunchMetadata(metadata map[string]any) map[string]any {
+	keys := []string{"role_name", "stack_name", "template_url", "launch_url", "policy_hash"}
+	out := map[string]any{}
+	for _, key := range keys {
+		if value, ok := metadata[key]; ok {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func preserveAWSConnectorLaunchMetadata(metadata map[string]any, preserved map[string]any) {
+	if metadata == nil || len(preserved) == 0 {
+		return
+	}
+	for key, value := range preserved {
+		metadata[key] = value
+	}
 }
 
 func awsConnectorStartResponse(status AWSConnectionStatus, externalID string, launchURL string, templateURL string, roleName string, stackName string, policyHash string) AWSConnectorStartResponse {
@@ -671,6 +695,7 @@ func (s *Service) ValidateAWSConnector(ctx context.Context, connectorID string, 
 		ExcludedAccountIDs:     setup.ExcludedAccountIDs,
 		AutoOnboardNewAccounts: setup.AutoOnboardNewAccounts,
 		allowSetupContract:     true,
+		preserveLaunchMetadata: awsConnectorLaunchMetadata(stored.State.Metadata),
 	})
 }
 
@@ -804,6 +829,7 @@ func (s *Service) UpsertAWSConnection(ctx context.Context, workspaceID string, p
 		"last_validated_at":      now.Format(time.RFC3339Nano),
 	}
 	applyAWSConnectorSetupMetadata(metadata, setup, onboardingStatus)
+	preserveAWSConnectorLaunchMetadata(metadata, normalized.preserveLaunchMetadata)
 	state := db.TenancyConnectorState{
 		TenantID:     scope.TenantID,
 		WorkspaceID:  project.WorkspaceID,

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -448,7 +448,8 @@ func (s *Service) resumeAWSConnectorStart(
 	if stored.Connector.Type != domain.ConnectorTypeAWS {
 		return AWSConnectorStartResponse{}, ErrInvalidAWSConnectionRequest
 	}
-	setup := awsMetadataSetupContract(stored.State.Metadata, AWSConnectorScopeSingleAccount, AWSConnectorDeploymentCloudFormation)
+	defaultScope, defaultDeployment := awsMetadataSetupFallback(stored.State.Metadata)
+	setup := awsMetadataSetupContract(stored.State.Metadata, defaultScope, defaultDeployment)
 	if setup.ScopeType != AWSConnectorScopeSingleAccount || setup.DeploymentMethod != AWSConnectorDeploymentCloudFormation {
 		return AWSConnectorStartResponse{}, ErrInvalidAWSConnectionRequest
 	}

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -591,6 +591,15 @@ func awsConnectorLaunchMetadata(metadata map[string]any) map[string]any {
 	return out
 }
 
+func awsConnectorLaunchMetadataForExternalID(metadata map[string]any, externalID string) map[string]any {
+	externalID = strings.TrimSpace(externalID)
+	launchURL := awsMetadataString(metadata, "launch_url")
+	if externalID == "" || launchURL == "" || !strings.Contains(launchURL, externalID) {
+		return nil
+	}
+	return awsConnectorLaunchMetadata(metadata)
+}
+
 func preserveAWSConnectorLaunchMetadata(metadata map[string]any, preserved map[string]any) {
 	if metadata == nil || len(preserved) == 0 {
 		return
@@ -695,7 +704,7 @@ func (s *Service) ValidateAWSConnector(ctx context.Context, connectorID string, 
 		ExcludedAccountIDs:     setup.ExcludedAccountIDs,
 		AutoOnboardNewAccounts: setup.AutoOnboardNewAccounts,
 		allowSetupContract:     true,
-		preserveLaunchMetadata: awsConnectorLaunchMetadata(stored.State.Metadata),
+		preserveLaunchMetadata: awsConnectorLaunchMetadataForExternalID(stored.State.Metadata, externalID),
 	})
 }
 

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -609,9 +609,14 @@ func preserveAWSConnectorLaunchMetadata(metadata map[string]any, preserved map[s
 	}
 }
 
+func publicAWSConnectionStatus(status AWSConnectionStatus) AWSConnectionStatus {
+	status.LaunchURL = ""
+	return status
+}
+
 func awsConnectorStartResponse(status AWSConnectionStatus, externalID string, launchURL string, templateURL string, roleName string, stackName string, policyHash string) AWSConnectorStartResponse {
 	return AWSConnectorStartResponse{
-		Connection:             status,
+		Connection:             publicAWSConnectionStatus(status),
 		ConnectorID:            status.ConnectorID,
 		ExternalID:             externalID,
 		LaunchURL:              launchURL,
@@ -720,7 +725,7 @@ func (s *Service) PollAWSConnector(ctx context.Context, connectorID string, requ
 	if err != nil {
 		return AWSConnectionStatus{}, err
 	}
-	return s.awsConnectionStatusFromStored(ctx, stored), nil
+	return publicAWSConnectionStatus(s.awsConnectionStatusFromStored(ctx, stored)), nil
 }
 
 func (s *Service) AWSConnectorPolicy(ctx context.Context, connectorID string, request AWSConnectorPollRequest) (AWSConnectorPolicyResponse, error) {
@@ -885,7 +890,7 @@ func (s *Service) UpsertAWSConnection(ctx context.Context, workspaceID string, p
 	}
 	response := s.awsConnectionStatusFromStored(ctx, stored)
 
-	return response, nil
+	return publicAWSConnectionStatus(response), nil
 }
 
 func (s *Service) GetAWSConnection(ctx context.Context, workspaceID string, projectID string) (AWSConnectionStatus, error) {
@@ -919,7 +924,7 @@ func (s *Service) GetAWSConnection(ctx context.Context, workspaceID string, proj
 			Capabilities:           defaultAWSConnectorCapabilities(),
 		}, nil
 	}
-	return s.awsConnectionStatusFromStored(ctx, items[0]), nil
+	return publicAWSConnectionStatus(s.awsConnectionStatusFromStored(ctx, items[0])), nil
 }
 
 // UpsertAWSAccountRegionCoverage stores account/region coverage for future AWS fan-out.

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -822,6 +822,25 @@ func TestAWSConnectorStartFailsOnUnreadableExternalIDEnvelope(t *testing.T) {
 	}); err == nil || !strings.Contains(err.Error(), "decrypt aws connector external id envelope") {
 		t.Fatalf("expected decrypt failure instead of external id rotation, got %v", err)
 	}
+	validator := &fakeAWSConnectorValidator{
+		result: AWSConnectionValidationResult{
+			AccountID:    "123456789012",
+			PrincipalARN: "arn:aws:sts::123456789012:assumed-role/IdentrailReadOnly/identrail-connector-validation",
+			UserID:       "AROATEST:identrail-connector-validation",
+			Region:       "us-east-1",
+		},
+	}
+	svc.AWSConnectorValidator = validator
+	if _, err := svc.ValidateAWSConnector(ctx, "aws-prod", AWSConnectorValidateRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		RoleARN:     "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+	}); err == nil || !strings.Contains(err.Error(), "decrypt aws connector external id envelope") {
+		t.Fatalf("expected validate to surface decrypt failure instead of clearing external id, got %v", err)
+	}
+	if validator.seen.RoleARN != "" {
+		t.Fatalf("expected unreadable external id envelope to block validation, validator saw %+v", validator.seen)
+	}
 
 	corrupt, err := store.GetTenancyConnectorSecretEnvelope(ctx, "workspace-a", "project-1", "aws-prod", awsExternalIDSecretName)
 	if err != nil {

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -568,6 +569,7 @@ func TestAWSConnectorStartResumesExistingCloudFormationSetup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("start aws connector: %v", err)
 	}
+	svc.AWSCloudFormationTemplateURL = "https://cdn.identrail.example/connectors/aws/new-template.yaml"
 	second, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
 		WorkspaceID: "workspace-a",
 		ProjectID:   "project-1",
@@ -586,6 +588,9 @@ func TestAWSConnectorStartResumesExistingCloudFormationSetup(t *testing.T) {
 	}
 	if second.LaunchURL != first.LaunchURL || second.RoleName != first.RoleName || second.StackName != first.StackName {
 		t.Fatalf("expected resume to preserve launch parameters\nfirst=%+v\nsecond=%+v", first, second)
+	}
+	if second.TemplateURL != first.TemplateURL || second.Connection.TemplateURL != first.TemplateURL {
+		t.Fatalf("expected resume to preserve persisted template URL, first=%q second=%q connection=%q", first.TemplateURL, second.TemplateURL, second.Connection.TemplateURL)
 	}
 	if second.Connection.DisplayName != "Production AWS" || second.Connection.Region != "us-east-1" {
 		t.Fatalf("expected resume to return persisted connector identity, got %+v", second.Connection)
@@ -611,6 +616,136 @@ func TestAWSConnectorStartResumesExistingCloudFormationSetup(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(plaintext)); got != first.ExternalID {
 		t.Fatalf("expected encrypted external id %q, got %q", first.ExternalID, got)
+	}
+}
+
+func TestAWSConnectorStartSerializesConcurrentExplicitConnectorStarts(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	manager, err := secretstore.NewManager([]secretstore.KeyMaterial{{Version: "test-v1", Key: bytes.Repeat([]byte{7}, 32)}})
+	if err != nil {
+		t.Fatalf("build connector secret manager: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.ConnectorSecretManager = manager
+	svc.AWSCloudFormationTemplateURL = "https://cdn.identrail.example/connectors/aws/identrail-readonly.yaml"
+	svc.AWSAccountID = "999999999999"
+
+	const workers = 16
+	start := make(chan struct{})
+	responses := make(chan AWSConnectorStartResponse, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			response, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+				WorkspaceID: "workspace-a",
+				ProjectID:   "project-1",
+				ConnectorID: "aws-prod",
+				DisplayName: "Production AWS",
+				Region:      "us-east-1",
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			responses <- response
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	close(responses)
+
+	for err := range errs {
+		t.Fatalf("concurrent start returned error: %v", err)
+	}
+	var first AWSConnectorStartResponse
+	for response := range responses {
+		if first.ConnectorID == "" {
+			first = response
+			continue
+		}
+		if response.ExternalID != first.ExternalID || response.LaunchURL != first.LaunchURL || response.TemplateURL != first.TemplateURL {
+			t.Fatalf("expected concurrent starts to return one launch plan\nfirst=%+v\nresponse=%+v", first, response)
+		}
+	}
+	if first.ConnectorID != "aws-prod" || first.ExternalID == "" || first.LaunchURL == "" {
+		t.Fatalf("expected complete first launch response, got %+v", first)
+	}
+}
+
+func TestAWSConnectorStartPersistsRecoveredExternalIDLaunchState(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	manager, err := secretstore.NewManager([]secretstore.KeyMaterial{{Version: "test-v1", Key: bytes.Repeat([]byte{7}, 32)}})
+	if err != nil {
+		t.Fatalf("build connector secret manager: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.ConnectorSecretManager = manager
+	svc.AWSCloudFormationTemplateURL = "https://cdn.identrail.example/connectors/aws/identrail-readonly.yaml"
+	svc.AWSAccountID = "999999999999"
+
+	first, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("start aws connector: %v", err)
+	}
+	if err := store.DeleteTenancyConnectorSecretEnvelope(ctx, "workspace-a", "project-1", "aws-prod", awsExternalIDSecretName); err != nil {
+		t.Fatalf("delete external id envelope: %v", err)
+	}
+
+	recovered, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("recover aws connector external id: %v", err)
+	}
+	if recovered.ExternalID == "" || recovered.ExternalID == first.ExternalID {
+		t.Fatalf("expected regenerated external id after envelope loss, first=%q recovered=%q", first.ExternalID, recovered.ExternalID)
+	}
+	if recovered.LaunchURL == first.LaunchURL {
+		t.Fatalf("expected regenerated launch URL to carry regenerated external id")
+	}
+
+	stored, err := store.GetTenancyConnector(ctx, "workspace-a", "project-1", "aws-prod")
+	if err != nil {
+		t.Fatalf("load recovered connector: %v", err)
+	}
+	if got := awsMetadataString(stored.State.Metadata, "launch_url"); got != recovered.LaunchURL {
+		t.Fatalf("expected recovered launch URL to be persisted, got %q want %q", got, recovered.LaunchURL)
+	}
+	if got := awsMetadataString(stored.State.Metadata, "template_url"); got != recovered.TemplateURL {
+		t.Fatalf("expected recovered template URL to be persisted, got %q want %q", got, recovered.TemplateURL)
+	}
+
+	again, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("resume recovered aws connector: %v", err)
+	}
+	if again.ExternalID != recovered.ExternalID || again.LaunchURL != recovered.LaunchURL {
+		t.Fatalf("expected later resume to keep recovered launch state\nrecovered=%+v\nagain=%+v", recovered, again)
 	}
 }
 

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -706,15 +706,47 @@ func TestAWSConnectorStartPersistsRecoveredExternalIDLaunchState(t *testing.T) {
 		t.Fatalf("delete external id envelope: %v", err)
 	}
 
-	recovered, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
-		WorkspaceID: "workspace-a",
-		ProjectID:   "project-1",
-		ConnectorID: "aws-prod",
-		DisplayName: "Production AWS",
-		Region:      "us-east-1",
-	})
-	if err != nil {
+	const workers = 8
+	start := make(chan struct{})
+	responses := make(chan AWSConnectorStartResponse, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			response, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+				WorkspaceID: "workspace-a",
+				ProjectID:   "project-1",
+				ConnectorID: "aws-prod",
+				DisplayName: "Production AWS",
+				Region:      "us-east-1",
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			responses <- response
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	close(responses)
+	for err := range errs {
 		t.Fatalf("recover aws connector external id: %v", err)
+	}
+
+	var recovered AWSConnectorStartResponse
+	for response := range responses {
+		if recovered.ConnectorID == "" {
+			recovered = response
+			continue
+		}
+		if response.ExternalID != recovered.ExternalID || response.LaunchURL != recovered.LaunchURL {
+			t.Fatalf("expected concurrent recovery to return one launch plan\nrecovered=%+v\nresponse=%+v", recovered, response)
+		}
 	}
 	if recovered.ExternalID == "" || recovered.ExternalID == first.ExternalID {
 		t.Fatalf("expected regenerated external id after envelope loss, first=%q recovered=%q", first.ExternalID, recovered.ExternalID)
@@ -746,6 +778,62 @@ func TestAWSConnectorStartPersistsRecoveredExternalIDLaunchState(t *testing.T) {
 	}
 	if again.ExternalID != recovered.ExternalID || again.LaunchURL != recovered.LaunchURL {
 		t.Fatalf("expected later resume to keep recovered launch state\nrecovered=%+v\nagain=%+v", recovered, again)
+	}
+}
+
+func TestAWSConnectorStartFailsOnUnreadableExternalIDEnvelope(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	manager, err := secretstore.NewManager([]secretstore.KeyMaterial{{Version: "test-v1", Key: bytes.Repeat([]byte{7}, 32)}})
+	if err != nil {
+		t.Fatalf("build connector secret manager: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.ConnectorSecretManager = manager
+	svc.AWSCloudFormationTemplateURL = "https://cdn.identrail.example/connectors/aws/identrail-readonly.yaml"
+	svc.AWSAccountID = "999999999999"
+
+	started, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("start aws connector: %v", err)
+	}
+	secret, err := store.GetTenancyConnectorSecretEnvelope(ctx, "workspace-a", "project-1", "aws-prod", awsExternalIDSecretName)
+	if err != nil {
+		t.Fatalf("load external id envelope: %v", err)
+	}
+	secret.Envelope.Ciphertext[0] ^= 0xff
+	if err := store.UpsertTenancyConnectorSecretEnvelope(ctx, secret); err != nil {
+		t.Fatalf("corrupt external id envelope: %v", err)
+	}
+
+	if _, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+	}); err == nil || !strings.Contains(err.Error(), "decrypt aws connector external id envelope") {
+		t.Fatalf("expected decrypt failure instead of external id rotation, got %v", err)
+	}
+
+	corrupt, err := store.GetTenancyConnectorSecretEnvelope(ctx, "workspace-a", "project-1", "aws-prod", awsExternalIDSecretName)
+	if err != nil {
+		t.Fatalf("reload corrupt external id envelope: %v", err)
+	}
+	corrupt.Envelope.Ciphertext[0] ^= 0xff
+	plaintext, err := manager.Decrypt(corrupt.Envelope, awsExternalIDAAD("tenant-a", "workspace-a", "project-1", "aws-prod"))
+	if err != nil {
+		t.Fatalf("decrypt restored external id envelope: %v", err)
+	}
+	if got := strings.TrimSpace(string(plaintext)); got != started.ExternalID {
+		t.Fatalf("expected failed resume not to rotate external id, got %q want %q", got, started.ExternalID)
 	}
 }
 

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -453,6 +454,9 @@ func TestRouterAWSConnectorCloudFormationFlow(t *testing.T) {
 	if startBody.ConnectorID == "" || startBody.ExternalID == "" || startBody.LaunchURL == "" || len(startBody.PermissionPreview) == 0 {
 		t.Fatalf("expected launch data and permission preview, got %+v", startBody)
 	}
+	if !strings.Contains(startResp.Body.String(), `"external_id"`) {
+		t.Fatalf("expected start response to include one-time external id, got %s", startResp.Body.String())
+	}
 	if startBody.Connection.Status != domain.ConnectorStatusPending || !startBody.Connection.ExternalIDConfigured {
 		t.Fatalf("expected pending connector with external id configured, got %+v", startBody.Connection)
 	}
@@ -470,6 +474,9 @@ func TestRouterAWSConnectorCloudFormationFlow(t *testing.T) {
 	pollResp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/connectors/aws/"+startBody.ConnectorID+"/poll?workspace_id=workspace-a&project_id=project-1", "")
 	if pollResp.Code != http.StatusOK {
 		t.Fatalf("expected connector poll 200, got %d body=%s", pollResp.Code, pollResp.Body.String())
+	}
+	if strings.Contains(pollResp.Body.String(), `"external_id"`) {
+		t.Fatalf("expected poll response to hide external id, got %s", pollResp.Body.String())
 	}
 	var pollBody struct {
 		Connection AWSConnectionStatus `json:"connection"`
@@ -533,6 +540,77 @@ func TestRouterAWSConnectorCloudFormationFlow(t *testing.T) {
 	if validateBody.Connection.ScopeType != AWSConnectorScopeSingleAccount || validateBody.Connection.DeploymentMethod != AWSConnectorDeploymentCloudFormation ||
 		validateBody.Connection.OnboardingStatus != AWSConnectorOnboardingConnected {
 		t.Fatalf("expected validation to preserve setup contract and mark connected, got %+v", validateBody.Connection)
+	}
+}
+
+func TestAWSConnectorStartResumesExistingCloudFormationSetup(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	manager, err := secretstore.NewManager([]secretstore.KeyMaterial{{Version: "test-v1", Key: bytes.Repeat([]byte{7}, 32)}})
+	if err != nil {
+		t.Fatalf("build connector secret manager: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.ConnectorSecretManager = manager
+	svc.AWSCloudFormationTemplateURL = "https://cdn.identrail.example/connectors/aws/identrail-readonly.yaml"
+	svc.AWSAccountID = "999999999999"
+
+	first, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+		RoleName:    "IdentrailReadOnly",
+		StackName:   "identrail-readonly-connector",
+	})
+	if err != nil {
+		t.Fatalf("start aws connector: %v", err)
+	}
+	second, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Different AWS",
+		Region:      "us-west-2",
+		RoleName:    "DifferentRole",
+		StackName:   "different-stack",
+	})
+	if err != nil {
+		t.Fatalf("resume aws connector: %v", err)
+	}
+
+	if second.ExternalID != first.ExternalID {
+		t.Fatalf("expected resume to preserve external id, first=%q second=%q", first.ExternalID, second.ExternalID)
+	}
+	if second.LaunchURL != first.LaunchURL || second.RoleName != first.RoleName || second.StackName != first.StackName {
+		t.Fatalf("expected resume to preserve launch parameters\nfirst=%+v\nsecond=%+v", first, second)
+	}
+	if second.Connection.DisplayName != "Production AWS" || second.Connection.Region != "us-east-1" {
+		t.Fatalf("expected resume to return persisted connector identity, got %+v", second.Connection)
+	}
+	if second.OnboardingStatus != AWSConnectorOnboardingLaunchReady || len(second.NextActions) == 0 || second.SetupSummary == "" {
+		t.Fatalf("expected resumed lifecycle fields, got %+v", second)
+	}
+
+	stored, err := store.GetTenancyConnector(ctx, "workspace-a", "project-1", "aws-prod")
+	if err != nil {
+		t.Fatalf("load stored connector: %v", err)
+	}
+	if _, ok := stored.State.Metadata["external_id"]; ok {
+		t.Fatalf("external id must not be persisted in connector metadata: %+v", stored.State.Metadata)
+	}
+	secret, err := store.GetTenancyConnectorSecretEnvelope(ctx, "workspace-a", "project-1", "aws-prod", awsExternalIDSecretName)
+	if err != nil {
+		t.Fatalf("load external id envelope: %v", err)
+	}
+	plaintext, err := manager.Decrypt(secret.Envelope, awsExternalIDAAD("tenant-a", "workspace-a", "project-1", "aws-prod"))
+	if err != nil {
+		t.Fatalf("decrypt external id envelope: %v", err)
+	}
+	if got := strings.TrimSpace(string(plaintext)); got != first.ExternalID {
+		t.Fatalf("expected encrypted external id %q, got %q", first.ExternalID, got)
 	}
 }
 

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -749,6 +749,80 @@ func TestAWSConnectorStartPersistsRecoveredExternalIDLaunchState(t *testing.T) {
 	}
 }
 
+func TestAWSConnectorStartPersistsRebuiltLaunchMetadataWithExistingExternalID(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	manager, err := secretstore.NewManager([]secretstore.KeyMaterial{{Version: "test-v1", Key: bytes.Repeat([]byte{7}, 32)}})
+	if err != nil {
+		t.Fatalf("build connector secret manager: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.ConnectorSecretManager = manager
+	svc.AWSCloudFormationTemplateURL = "https://cdn.identrail.example/connectors/aws/identrail-readonly.yaml"
+	svc.AWSAccountID = "999999999999"
+
+	first, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("start aws connector: %v", err)
+	}
+	stored, err := store.GetTenancyConnector(ctx, "workspace-a", "project-1", "aws-prod")
+	if err != nil {
+		t.Fatalf("load stored connector: %v", err)
+	}
+	metadata := copyAWSMetadata(stored.State.Metadata)
+	delete(metadata, "launch_url")
+	delete(metadata, "template_url")
+	stored.State.Metadata = metadata
+	if err := store.UpsertTenancyConnector(ctx, stored.Connector, stored.State); err != nil {
+		t.Fatalf("remove launch metadata: %v", err)
+	}
+
+	recovered, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("rebuild launch metadata: %v", err)
+	}
+	if recovered.ExternalID != first.ExternalID {
+		t.Fatalf("expected existing external id to be preserved, first=%q recovered=%q", first.ExternalID, recovered.ExternalID)
+	}
+	if recovered.LaunchURL == "" || recovered.TemplateURL == "" {
+		t.Fatalf("expected rebuilt launch metadata, got %+v", recovered)
+	}
+
+	persisted, err := store.GetTenancyConnector(ctx, "workspace-a", "project-1", "aws-prod")
+	if err != nil {
+		t.Fatalf("load rebuilt connector: %v", err)
+	}
+	if got := awsMetadataString(persisted.State.Metadata, "launch_url"); got != recovered.LaunchURL {
+		t.Fatalf("expected rebuilt launch URL to persist, got %q want %q", got, recovered.LaunchURL)
+	}
+	again, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("resume rebuilt launch metadata: %v", err)
+	}
+	if again.ExternalID != recovered.ExternalID || again.LaunchURL != recovered.LaunchURL {
+		t.Fatalf("expected later resume to keep rebuilt launch metadata\nrecovered=%+v\nagain=%+v", recovered, again)
+	}
+}
+
 func TestRouterAWSConnectorFeatureFlagDisabled(t *testing.T) {
 	r := newAWSConnectionTestRouter(t, &fakeAWSConnectorValidator{})
 

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -522,6 +522,9 @@ func TestRouterAWSConnectorCloudFormationFlow(t *testing.T) {
 	if startBody.Connection.Status != domain.ConnectorStatusPending || !startBody.Connection.ExternalIDConfigured {
 		t.Fatalf("expected pending connector with external id configured, got %+v", startBody.Connection)
 	}
+	if startBody.Connection.LaunchURL != "" {
+		t.Fatalf("expected nested start connection to redact launch URL, got %q", startBody.Connection.LaunchURL)
+	}
 	if startBody.ScopeType != AWSConnectorScopeSingleAccount || startBody.DeploymentMethod != AWSConnectorDeploymentCloudFormation ||
 		startBody.OnboardingStatus != AWSConnectorOnboardingLaunchReady {
 		t.Fatalf("expected single-account cloudformation launch contract, got scope=%q method=%q status=%q", startBody.ScopeType, startBody.DeploymentMethod, startBody.OnboardingStatus)
@@ -539,6 +542,9 @@ func TestRouterAWSConnectorCloudFormationFlow(t *testing.T) {
 	}
 	if strings.Contains(pollResp.Body.String(), `"external_id"`) {
 		t.Fatalf("expected poll response to hide external id, got %s", pollResp.Body.String())
+	}
+	if strings.Contains(pollResp.Body.String(), startBody.ExternalID) || strings.Contains(pollResp.Body.String(), `"launch_url"`) {
+		t.Fatalf("expected poll response to redact launch URL and external id, got %s", pollResp.Body.String())
 	}
 	var pollBody struct {
 		Connection AWSConnectionStatus `json:"connection"`
@@ -602,6 +608,17 @@ func TestRouterAWSConnectorCloudFormationFlow(t *testing.T) {
 	if validateBody.Connection.ScopeType != AWSConnectorScopeSingleAccount || validateBody.Connection.DeploymentMethod != AWSConnectorDeploymentCloudFormation ||
 		validateBody.Connection.OnboardingStatus != AWSConnectorOnboardingConnected {
 		t.Fatalf("expected validation to preserve setup contract and mark connected, got %+v", validateBody.Connection)
+	}
+	if strings.Contains(validateResp.Body.String(), startBody.ExternalID) || strings.Contains(validateResp.Body.String(), `"launch_url"`) {
+		t.Fatalf("expected validate response to redact launch URL and external id, got %s", validateResp.Body.String())
+	}
+
+	validatedPollResp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/connectors/aws/"+startBody.ConnectorID+"/poll?workspace_id=workspace-a&project_id=project-1", "")
+	if validatedPollResp.Code != http.StatusOK {
+		t.Fatalf("expected validated connector poll 200, got %d body=%s", validatedPollResp.Code, validatedPollResp.Body.String())
+	}
+	if strings.Contains(validatedPollResp.Body.String(), startBody.ExternalID) || strings.Contains(validatedPollResp.Body.String(), `"launch_url"`) {
+		t.Fatalf("expected validated poll response to redact launch URL and external id, got %s", validatedPollResp.Body.String())
 	}
 }
 

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -680,6 +680,83 @@ func TestAWSConnectorStartResumesExistingCloudFormationSetup(t *testing.T) {
 	}
 }
 
+func TestAWSConnectorValidatePreservesCloudFormationLaunchMetadata(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	manager, err := secretstore.NewManager([]secretstore.KeyMaterial{{Version: "test-v1", Key: bytes.Repeat([]byte{7}, 32)}})
+	if err != nil {
+		t.Fatalf("build connector secret manager: %v", err)
+	}
+	validator := &fakeAWSConnectorValidator{
+		result: AWSConnectionValidationResult{
+			AccountID:    "123456789012",
+			PrincipalARN: "arn:aws:sts::123456789012:assumed-role/IdentrailCustomRole/identrail-connector-validation",
+			UserID:       "AROATEST:identrail-connector-validation",
+			Region:       "us-east-1",
+			PermissionChecks: []AWSConnectionPermissionCheck{
+				{Name: "sts:AssumeRole", Passed: true, Message: "Role assumption succeeded."},
+			},
+		},
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.AWSConnectorValidator = validator
+	svc.ConnectorSecretManager = manager
+	svc.AWSCloudFormationTemplateURL = "https://cdn.identrail.example/connectors/aws/identrail-readonly-v1.yaml"
+	svc.AWSAccountID = "999999999999"
+
+	started, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+		RoleName:    "IdentrailCustomRole",
+		StackName:   "identrail-custom-stack",
+	})
+	if err != nil {
+		t.Fatalf("start aws connector: %v", err)
+	}
+	if _, err := svc.ValidateAWSConnector(ctx, "aws-prod", AWSConnectorValidateRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		RoleARN:     "arn:aws:iam::123456789012:role/IdentrailCustomRole",
+	}); err != nil {
+		t.Fatalf("validate aws connector: %v", err)
+	}
+	stored, err := store.GetTenancyConnector(ctx, "workspace-a", "project-1", "aws-prod")
+	if err != nil {
+		t.Fatalf("load validated connector: %v", err)
+	}
+	if got := awsMetadataString(stored.State.Metadata, "launch_url"); got != started.LaunchURL {
+		t.Fatalf("expected validation to preserve launch URL, got %q want %q", got, started.LaunchURL)
+	}
+	if got := awsMetadataString(stored.State.Metadata, "template_url"); got != started.TemplateURL {
+		t.Fatalf("expected validation to preserve template URL, got %q want %q", got, started.TemplateURL)
+	}
+	if got := awsMetadataString(stored.State.Metadata, "role_name"); got != started.RoleName {
+		t.Fatalf("expected validation to preserve role name, got %q want %q", got, started.RoleName)
+	}
+	if got := awsMetadataString(stored.State.Metadata, "stack_name"); got != started.StackName {
+		t.Fatalf("expected validation to preserve stack name, got %q want %q", got, started.StackName)
+	}
+
+	svc.AWSCloudFormationTemplateURL = "https://cdn.identrail.example/connectors/aws/identrail-readonly-v2.yaml"
+	resumed, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-west-2",
+	})
+	if err != nil {
+		t.Fatalf("resume validated aws connector: %v", err)
+	}
+	if resumed.LaunchURL != started.LaunchURL || resumed.TemplateURL != started.TemplateURL || resumed.RoleName != started.RoleName || resumed.StackName != started.StackName {
+		t.Fatalf("expected resume after validation to keep original launch plan\nstarted=%+v\nresumed=%+v", started, resumed)
+	}
+}
+
 func TestAWSConnectorStartSerializesConcurrentExplicitConnectorStarts(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
@@ -944,6 +1021,14 @@ func TestAWSConnectorStartPersistsRebuiltLaunchMetadataWithExistingExternalID(t 
 	if err != nil {
 		t.Fatalf("load stored connector: %v", err)
 	}
+	originalSecretVersion := stored.Connector.SecretRefVersion
+	if originalSecretVersion == "" {
+		t.Fatalf("expected initial connector secret version")
+	}
+	if stored.Connector.SecretLastRotatedAt == nil {
+		t.Fatalf("expected initial connector secret rotation time")
+	}
+	originalSecretRotatedAt := *stored.Connector.SecretLastRotatedAt
 	metadata := copyAWSMetadata(stored.State.Metadata)
 	delete(metadata, "launch_url")
 	delete(metadata, "template_url")
@@ -951,6 +1036,14 @@ func TestAWSConnectorStartPersistsRebuiltLaunchMetadataWithExistingExternalID(t 
 	if err := store.UpsertTenancyConnector(ctx, stored.Connector, stored.State); err != nil {
 		t.Fatalf("remove launch metadata: %v", err)
 	}
+	rotatedManager, err := secretstore.NewManager([]secretstore.KeyMaterial{
+		{Version: "test-v1", Key: bytes.Repeat([]byte{7}, 32)},
+		{Version: "test-v2", Key: bytes.Repeat([]byte{8}, 32)},
+	})
+	if err != nil {
+		t.Fatalf("build rotated connector secret manager: %v", err)
+	}
+	svc.ConnectorSecretManager = rotatedManager
 
 	recovered, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
 		WorkspaceID: "workspace-a",
@@ -975,6 +1068,12 @@ func TestAWSConnectorStartPersistsRebuiltLaunchMetadataWithExistingExternalID(t 
 	}
 	if got := awsMetadataString(persisted.State.Metadata, "launch_url"); got != recovered.LaunchURL {
 		t.Fatalf("expected rebuilt launch URL to persist, got %q want %q", got, recovered.LaunchURL)
+	}
+	if persisted.Connector.SecretRefVersion != originalSecretVersion {
+		t.Fatalf("expected metadata-only launch repair to preserve secret version, got %q want %q", persisted.Connector.SecretRefVersion, originalSecretVersion)
+	}
+	if persisted.Connector.SecretLastRotatedAt == nil || !persisted.Connector.SecretLastRotatedAt.Equal(originalSecretRotatedAt) {
+		t.Fatalf("expected metadata-only launch repair to preserve secret rotation time, got %v want %v", persisted.Connector.SecretLastRotatedAt, originalSecretRotatedAt)
 	}
 	again, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
 		WorkspaceID: "workspace-a",

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -757,6 +757,97 @@ func TestAWSConnectorValidatePreservesCloudFormationLaunchMetadata(t *testing.T)
 	}
 }
 
+func TestAWSConnectorValidateDropsLaunchMetadataWhenExternalIDChanges(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	manager, err := secretstore.NewManager([]secretstore.KeyMaterial{{Version: "test-v1", Key: bytes.Repeat([]byte{7}, 32)}})
+	if err != nil {
+		t.Fatalf("build connector secret manager: %v", err)
+	}
+	validator := &fakeAWSConnectorValidator{
+		result: AWSConnectionValidationResult{
+			AccountID:    "123456789012",
+			PrincipalARN: "arn:aws:sts::123456789012:assumed-role/IdentrailCustomRole/identrail-connector-validation",
+			UserID:       "AROATEST:identrail-connector-validation",
+			Region:       "us-east-1",
+			PermissionChecks: []AWSConnectionPermissionCheck{
+				{Name: "sts:AssumeRole", Passed: true, Message: "Role assumption succeeded."},
+			},
+		},
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.AWSConnectorValidator = validator
+	svc.ConnectorSecretManager = manager
+	svc.AWSCloudFormationTemplateURL = "https://cdn.identrail.example/connectors/aws/identrail-readonly-v1.yaml"
+	svc.AWSAccountID = "999999999999"
+
+	started, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+		RoleName:    "IdentrailCustomRole",
+		StackName:   "identrail-custom-stack",
+	})
+	if err != nil {
+		t.Fatalf("start aws connector: %v", err)
+	}
+	newExternalID := "operator-supplied-external-id"
+	if strings.Contains(started.LaunchURL, newExternalID) {
+		t.Fatalf("test setup expected original launch URL to use a different external id: %s", started.LaunchURL)
+	}
+	if _, err := svc.ValidateAWSConnector(ctx, "aws-prod", AWSConnectorValidateRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		RoleARN:     "arn:aws:iam::123456789012:role/IdentrailCustomRole",
+		ExternalID:  newExternalID,
+	}); err != nil {
+		t.Fatalf("validate aws connector: %v", err)
+	}
+	if validator.seen.ExternalID != newExternalID {
+		t.Fatalf("expected validator to receive updated external id %q, got %q", newExternalID, validator.seen.ExternalID)
+	}
+	stored, err := store.GetTenancyConnector(ctx, "workspace-a", "project-1", "aws-prod")
+	if err != nil {
+		t.Fatalf("load validated connector: %v", err)
+	}
+	for _, key := range []string{"launch_url", "template_url", "role_name", "stack_name"} {
+		if got := awsMetadataString(stored.State.Metadata, key); got != "" {
+			t.Fatalf("expected validation to drop stale %s, got %q", key, got)
+		}
+	}
+	secret, err := store.GetTenancyConnectorSecretEnvelope(ctx, "workspace-a", "project-1", "aws-prod", awsExternalIDSecretName)
+	if err != nil {
+		t.Fatalf("load external id envelope: %v", err)
+	}
+	plaintext, err := manager.Decrypt(secret.Envelope, awsExternalIDAAD("tenant-a", "workspace-a", "project-1", "aws-prod"))
+	if err != nil {
+		t.Fatalf("decrypt external id envelope: %v", err)
+	}
+	if got := strings.TrimSpace(string(plaintext)); got != newExternalID {
+		t.Fatalf("expected encrypted external id %q, got %q", newExternalID, got)
+	}
+
+	resumed, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("resume validated aws connector: %v", err)
+	}
+	if !strings.Contains(resumed.LaunchURL, newExternalID) {
+		t.Fatalf("expected rebuilt launch URL to contain updated external id %q, got %q", newExternalID, resumed.LaunchURL)
+	}
+	if strings.Contains(resumed.LaunchURL, started.ExternalID) {
+		t.Fatalf("expected rebuilt launch URL to drop original external id %q, got %q", started.ExternalID, resumed.LaunchURL)
+	}
+}
+
 func TestAWSConnectorStartSerializesConcurrentExplicitConnectorStarts(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -811,9 +811,15 @@ func TestAWSConnectorValidateDropsLaunchMetadataWhenExternalIDChanges(t *testing
 	if err != nil {
 		t.Fatalf("start aws connector: %v", err)
 	}
-	newExternalID := "operator-supplied-external-id"
-	if strings.Contains(started.LaunchURL, newExternalID) {
-		t.Fatalf("test setup expected original launch URL to use a different external id: %s", started.LaunchURL)
+	if len(started.ExternalID) < 12 {
+		t.Fatalf("test setup expected generated external id to be long enough, got %q", started.ExternalID)
+	}
+	newExternalID := started.ExternalID[:12]
+	if !strings.Contains(started.LaunchURL, newExternalID) {
+		t.Fatalf("test setup expected original launch URL to contain the new substring external id: %s", started.LaunchURL)
+	}
+	if awsCloudFormationLaunchURLExternalID(started.LaunchURL) != started.ExternalID {
+		t.Fatalf("test setup expected original launch URL external id %q, got %q", started.ExternalID, awsCloudFormationLaunchURLExternalID(started.LaunchURL))
 	}
 	if _, err := svc.ValidateAWSConnector(ctx, "aws-prod", AWSConnectorValidateRequest{
 		WorkspaceID: "workspace-a",

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -223,6 +223,67 @@ func TestGetAWSConnectionTreatsLegacyRoleMetadataAsManualScope(t *testing.T) {
 	}
 }
 
+func TestAWSConnectorStartRejectsLegacyManualConnectorResume(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	now := time.Date(2026, 7, 12, 15, 0, 0, 0, time.UTC)
+	if err := store.UpsertTenancyConnector(ctx, db.TenancyConnector{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-legacy",
+		Type:        domain.ConnectorTypeAWS,
+		DisplayName: "Legacy AWS",
+		Status:      domain.ConnectorStatusActive,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}, db.TenancyConnectorState{
+		TenantID:     "tenant-a",
+		WorkspaceID:  "workspace-a",
+		ProjectID:    "project-1",
+		ConnectorID:  "aws-legacy",
+		HealthStatus: "healthy",
+		Metadata: map[string]any{
+			"role_arn":    "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+			"account_id":  "123456789012",
+			"region":      "us-west-2",
+			"external_id": "tenant-external-id",
+		},
+		ObservedAt: now,
+		UpdatedAt:  now,
+	}); err != nil {
+		t.Fatalf("seed legacy connector: %v", err)
+	}
+
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.AWSCloudFormationTemplateURL = "https://cdn.identrail.example/connectors/aws/identrail-readonly.yaml"
+	svc.AWSAccountID = "999999999999"
+	if _, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-legacy",
+		DisplayName: "Production AWS",
+		Region:      "us-east-1",
+	}); !errors.Is(err, ErrInvalidAWSConnectionRequest) {
+		t.Fatalf("expected legacy manual connector resume to be rejected, got %v", err)
+	}
+
+	stored, err := store.GetTenancyConnector(ctx, "workspace-a", "project-1", "aws-legacy")
+	if err != nil {
+		t.Fatalf("load legacy connector: %v", err)
+	}
+	if stored.Connector.SecretProvider != "" || stored.Connector.SecretRefID != "" {
+		t.Fatalf("expected rejected resume not to add secret refs, got %+v", stored.Connector)
+	}
+	if stored.State.Metadata["launch_url"] != nil || stored.State.Metadata["template_url"] != nil {
+		t.Fatalf("expected rejected resume not to add launch metadata, got %+v", stored.State.Metadata)
+	}
+	if _, err := store.GetTenancyConnectorSecretEnvelope(ctx, "workspace-a", "project-1", "aws-legacy", awsExternalIDSecretName); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("expected rejected resume not to persist external id envelope, got %v", err)
+	}
+}
+
 func TestAWSConnectionClearsPersistedExternalID(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -1496,6 +1496,68 @@ func awsPlatformBaselineKey(tenantID string, workspaceID string, projectID strin
 	return tenancyCompositeKey(strings.TrimSpace(tenantID), strings.TrimSpace(workspaceID), strings.TrimSpace(projectID), strings.TrimSpace(connectorID))
 }
 
+// CreateTenancyConnectorWithSecretEnvelopeIfAbsent creates a connector, state,
+// and secret envelope atomically, or returns the existing connector unchanged.
+func (m *MemoryStore) CreateTenancyConnectorWithSecretEnvelopeIfAbsent(ctx context.Context, connector TenancyConnector, state TenancyConnectorState, envelope TenancyConnectorSecretEnvelope) (TenancyConnectorWithState, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+	connector.TenantID = scope.TenantID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, connector.WorkspaceID)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+	connector.WorkspaceID = resolvedWorkspaceID
+	state.TenantID = scope.TenantID
+	state.WorkspaceID = resolvedWorkspaceID
+	state.ProjectID = connector.ProjectID
+	state.ConnectorID = connector.ConnectorID
+	envelope.TenantID = scope.TenantID
+	envelope.WorkspaceID = resolvedWorkspaceID
+	envelope.ProjectID = connector.ProjectID
+	envelope.ConnectorID = connector.ConnectorID
+
+	normalizedConnector, err := NormalizeTenancyConnectorForWrite(connector)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+	normalizedState, err := NormalizeTenancyConnectorStateForWrite(state)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+	normalizedEnvelope, err := NormalizeTenancyConnectorSecretEnvelopeForWrite(envelope)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+
+	key := tenancyConnectorKey(normalizedConnector.TenantID, normalizedConnector.WorkspaceID, normalizedConnector.ProjectID, normalizedConnector.ConnectorID)
+	if existing, exists := m.connectors[key]; exists {
+		existingState := m.connStates[key]
+		existingState.Metadata = cloneMetadataMap(existingState.Metadata)
+		return TenancyConnectorWithState{Connector: existing, State: existingState}, false, nil
+	}
+	if _, exists := m.projects[tenancyProjectKey(normalizedConnector.TenantID, normalizedConnector.WorkspaceID, normalizedConnector.ProjectID)]; !exists {
+		return TenancyConnectorWithState{}, false, ErrNotFound
+	}
+
+	secretKey := tenancyConnectorSecretKey(
+		normalizedEnvelope.TenantID,
+		normalizedEnvelope.WorkspaceID,
+		normalizedEnvelope.ProjectID,
+		normalizedEnvelope.ConnectorID,
+		normalizedEnvelope.SecretName,
+	)
+	m.connectors[key] = normalizedConnector
+	m.connStates[key] = normalizedState
+	m.connSecrets[secretKey] = normalizedEnvelope
+	normalizedState.Metadata = cloneMetadataMap(normalizedState.Metadata)
+	return TenancyConnectorWithState{Connector: normalizedConnector, State: normalizedState}, true, nil
+}
+
 // UpsertTenancyConnector persists one connector and its latest state atomically.
 func (m *MemoryStore) UpsertTenancyConnector(ctx context.Context, connector TenancyConnector, state TenancyConnectorState) error {
 	m.mu.Lock()

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -1948,6 +1948,51 @@ func cloneAWSPlatformBaselineResult(result AWSPlatformBaselineResult) AWSPlatfor
 	return cloned
 }
 
+// CreateTenancyConnectorSecretEnvelopeIfAbsent creates a secret envelope or
+// returns the existing envelope unchanged when the scoped secret key exists.
+func (m *MemoryStore) CreateTenancyConnectorSecretEnvelopeIfAbsent(ctx context.Context, envelope TenancyConnectorSecretEnvelope) (TenancyConnectorSecretEnvelope, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyConnectorSecretEnvelope{}, false, err
+	}
+	envelope.TenantID = scope.TenantID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, envelope.WorkspaceID)
+	if err != nil {
+		return TenancyConnectorSecretEnvelope{}, false, err
+	}
+	envelope.WorkspaceID = resolvedWorkspaceID
+	normalized, err := NormalizeTenancyConnectorSecretEnvelopeForWrite(envelope)
+	if err != nil {
+		return TenancyConnectorSecretEnvelope{}, false, err
+	}
+	connectorKey := tenancyConnectorKey(
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.ProjectID,
+		normalized.ConnectorID,
+	)
+	if _, exists := m.connectors[connectorKey]; !exists {
+		return TenancyConnectorSecretEnvelope{}, false, ErrNotFound
+	}
+	secretKey := tenancyConnectorSecretKey(
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.ProjectID,
+		normalized.ConnectorID,
+		normalized.SecretName,
+	)
+	if existing, exists := m.connSecrets[secretKey]; exists {
+		existing.Envelope.Nonce = append([]byte(nil), existing.Envelope.Nonce...)
+		existing.Envelope.Ciphertext = append([]byte(nil), existing.Envelope.Ciphertext...)
+		return existing, false, nil
+	}
+	m.connSecrets[secretKey] = normalized
+	return normalized, true, nil
+}
+
 // UpsertTenancyConnectorSecretEnvelope persists one encrypted connector secret envelope.
 func (m *MemoryStore) UpsertTenancyConnectorSecretEnvelope(ctx context.Context, envelope TenancyConnectorSecretEnvelope) error {
 	m.mu.Lock()

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -1822,6 +1822,158 @@ func (p *PostgresStore) DeleteTenancyScanPolicy(ctx context.Context, workspaceID
 	return nil
 }
 
+// CreateTenancyConnectorWithSecretEnvelopeIfAbsent creates a connector, state,
+// and secret envelope in one transaction, or returns the existing connector
+// unchanged when the scoped connector key already exists.
+func (p *PostgresStore) CreateTenancyConnectorWithSecretEnvelopeIfAbsent(ctx context.Context, connector TenancyConnector, state TenancyConnectorState, envelope TenancyConnectorSecretEnvelope) (TenancyConnectorWithState, bool, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+	connector.TenantID = scope.TenantID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, connector.WorkspaceID)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+	connector.WorkspaceID = resolvedWorkspaceID
+	state.TenantID = scope.TenantID
+	state.WorkspaceID = resolvedWorkspaceID
+	state.ProjectID = connector.ProjectID
+	state.ConnectorID = connector.ConnectorID
+	envelope.TenantID = scope.TenantID
+	envelope.WorkspaceID = resolvedWorkspaceID
+	envelope.ProjectID = connector.ProjectID
+	envelope.ConnectorID = connector.ConnectorID
+
+	normalizedConnector, err := NormalizeTenancyConnectorForWrite(connector)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+	normalizedState, err := NormalizeTenancyConnectorStateForWrite(state)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+	normalizedEnvelope, err := NormalizeTenancyConnectorSecretEnvelopeForWrite(envelope)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+	metadataPayload, err := json.Marshal(normalizedState.Metadata)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, fmt.Errorf("marshal connector state metadata: %w", err)
+	}
+
+	tx, err := p.beginTx(ctx)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+	defer tx.Rollback()
+
+	result, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO tenancy_connectors (
+		     tenant_id, workspace_id, project_id, connector_id, type, display_name, status,
+		     secret_provider, secret_ref_id, secret_ref_version, secret_last_rotated_at,
+		     config_checksum, last_sync_at, created_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), $11, NULLIF($12, ''), $13, $14, $15)
+		 ON CONFLICT (tenant_id, workspace_id, project_id, connector_id) DO NOTHING`,
+		normalizedConnector.TenantID,
+		normalizedConnector.WorkspaceID,
+		normalizedConnector.ProjectID,
+		normalizedConnector.ConnectorID,
+		string(normalizedConnector.Type),
+		normalizedConnector.DisplayName,
+		string(normalizedConnector.Status),
+		normalizedConnector.SecretProvider,
+		normalizedConnector.SecretRefID,
+		normalizedConnector.SecretRefVersion,
+		normalizedConnector.SecretLastRotatedAt,
+		normalizedConnector.ConfigChecksum,
+		normalizedConnector.LastSyncAt,
+		normalizedConnector.CreatedAt,
+		normalizedConnector.UpdatedAt,
+	)
+	if isTenancyFKViolation(err) {
+		return TenancyConnectorWithState{}, false, ErrNotFound
+	}
+	if err != nil {
+		return TenancyConnectorWithState{}, false, fmt.Errorf("create tenancy connector if absent: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return TenancyConnectorWithState{}, false, err
+	}
+	if affected == 0 {
+		if err := tx.Commit(); err != nil {
+			return TenancyConnectorWithState{}, false, fmt.Errorf("commit skipped tenancy connector create: %w", err)
+		}
+		existing, err := p.GetTenancyConnector(ctx, normalizedConnector.WorkspaceID, normalizedConnector.ProjectID, normalizedConnector.ConnectorID)
+		return existing, false, err
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO tenancy_connector_states (
+		     tenant_id, workspace_id, project_id, connector_id, health_status, sync_cursor,
+		     last_successful_sync_at, last_error_code, last_error_message, metadata, observed_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, NULLIF($6, ''), $7, NULLIF($8, ''), NULLIF($9, ''), $10::jsonb, $11, $12)`,
+		normalizedState.TenantID,
+		normalizedState.WorkspaceID,
+		normalizedState.ProjectID,
+		normalizedState.ConnectorID,
+		normalizedState.HealthStatus,
+		normalizedState.SyncCursor,
+		normalizedState.LastSuccessfulSyncAt,
+		normalizedState.LastErrorCode,
+		normalizedState.LastErrorMessage,
+		metadataPayload,
+		normalizedState.ObservedAt,
+		normalizedState.UpdatedAt,
+	)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, fmt.Errorf("create tenancy connector state if absent: %w", err)
+	}
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO tenancy_connector_secret_envelopes (
+		     tenant_id, workspace_id, project_id, connector_id, secret_name, envelope_version,
+		     algorithm, key_version, nonce, ciphertext, secret_ref_id, rotated_at, rotation_due_at, created_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NULLIF($11, ''), $12, $13, $14, $15)`,
+		normalizedEnvelope.TenantID,
+		normalizedEnvelope.WorkspaceID,
+		normalizedEnvelope.ProjectID,
+		normalizedEnvelope.ConnectorID,
+		normalizedEnvelope.SecretName,
+		normalizedEnvelope.EnvelopeVersion,
+		normalizedEnvelope.Envelope.Algorithm,
+		normalizedEnvelope.Envelope.KeyVersion,
+		normalizedEnvelope.Envelope.Nonce,
+		normalizedEnvelope.Envelope.Ciphertext,
+		normalizedEnvelope.SecretRefID,
+		normalizedEnvelope.RotatedAt,
+		normalizedEnvelope.RotationDueAt,
+		normalizedEnvelope.CreatedAt,
+		normalizedEnvelope.UpdatedAt,
+	)
+	if err != nil {
+		return TenancyConnectorWithState{}, false, fmt.Errorf("create tenancy connector secret envelope if absent: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return TenancyConnectorWithState{}, false, fmt.Errorf("commit tenancy connector create if absent: %w", err)
+	}
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "tenancy.connector.create_if_absent",
+		TenantID:     normalizedConnector.TenantID,
+		WorkspaceID:  normalizedConnector.WorkspaceID,
+		ResourceType: "tenancy_connector",
+		ResourceID:   normalizedConnector.ConnectorID,
+		Outcome:      "success",
+	})
+	return TenancyConnectorWithState{Connector: normalizedConnector, State: normalizedState}, true, nil
+}
+
 // UpsertTenancyConnector persists one connector and its latest state atomically.
 func (p *PostgresStore) UpsertTenancyConnector(ctx context.Context, connector TenancyConnector, state TenancyConnectorState) error {
 	scope, err := RequireScope(ctx)

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -2805,6 +2805,65 @@ func scanTenancyConnectorRows(rows rowsScanner) ([]TenancyConnectorWithState, er
 	return results, rows.Err()
 }
 
+// CreateTenancyConnectorSecretEnvelopeIfAbsent creates an encrypted connector
+// secret envelope or returns the existing envelope when the scoped secret key
+// already exists.
+func (p *PostgresStore) CreateTenancyConnectorSecretEnvelopeIfAbsent(ctx context.Context, envelope TenancyConnectorSecretEnvelope) (TenancyConnectorSecretEnvelope, bool, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyConnectorSecretEnvelope{}, false, err
+	}
+	envelope.TenantID = scope.TenantID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, envelope.WorkspaceID)
+	if err != nil {
+		return TenancyConnectorSecretEnvelope{}, false, err
+	}
+	envelope.WorkspaceID = resolvedWorkspaceID
+	normalized, err := NormalizeTenancyConnectorSecretEnvelopeForWrite(envelope)
+	if err != nil {
+		return TenancyConnectorSecretEnvelope{}, false, err
+	}
+	result, err := p.execContext(
+		ctx,
+		`INSERT INTO tenancy_connector_secret_envelopes (
+		     tenant_id, workspace_id, project_id, connector_id, secret_name, envelope_version,
+		     algorithm, key_version, nonce, ciphertext, secret_ref_id, rotated_at, rotation_due_at, created_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NULLIF($11, ''), $12, $13, $14, $15)
+		 ON CONFLICT (tenant_id, workspace_id, project_id, connector_id, secret_name) DO NOTHING`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.ProjectID,
+		normalized.ConnectorID,
+		normalized.SecretName,
+		normalized.EnvelopeVersion,
+		normalized.Envelope.Algorithm,
+		normalized.Envelope.KeyVersion,
+		normalized.Envelope.Nonce,
+		normalized.Envelope.Ciphertext,
+		normalized.SecretRefID,
+		normalized.RotatedAt,
+		normalized.RotationDueAt,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	if isTenancyFKViolation(err) {
+		return TenancyConnectorSecretEnvelope{}, false, ErrNotFound
+	}
+	if err != nil {
+		return TenancyConnectorSecretEnvelope{}, false, fmt.Errorf("create connector secret envelope if absent: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return TenancyConnectorSecretEnvelope{}, false, err
+	}
+	if affected == 0 {
+		existing, err := p.GetTenancyConnectorSecretEnvelope(ctx, normalized.WorkspaceID, normalized.ProjectID, normalized.ConnectorID, normalized.SecretName)
+		return existing, false, err
+	}
+	return normalized, true, nil
+}
+
 // UpsertTenancyConnectorSecretEnvelope persists one encrypted connector secret envelope.
 func (p *PostgresStore) UpsertTenancyConnectorSecretEnvelope(ctx context.Context, envelope TenancyConnectorSecretEnvelope) error {
 	scope, err := RequireScope(ctx)

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -169,6 +169,189 @@ func TestPostgresStoreUpsertAndGetTenancyConnector(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreCreateTenancyConnectorWithSecretEnvelopeIfAbsentCreatesAtomically(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+
+	store := NewPostgresStoreWithDB(rawDB)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	connector, state, envelope := postgresAWSConnectorCreateFixture()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tenancy_connectors").
+		WithArgs("tenant-a", "workspace-a", "project-1", "aws-prod", "aws", "Production AWS", "pending", "secret-envelope", "secret-ref", "test-v1", sqlmock.AnyArg(), "", nil, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO tenancy_connector_states").
+		WithArgs("tenant-a", "workspace-a", "project-1", "aws-prod", "unknown", "", nil, "", "", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO tenancy_connector_secret_envelopes").
+		WithArgs("tenant-a", "workspace-a", "project-1", "aws-prod", "external_id", 1, secretstore.AlgorithmAES256GCM, "test-v1", []byte("123456789012"), []byte("ciphertext"), "secret-ref", sqlmock.AnyArg(), nil, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	got, created, err := store.CreateTenancyConnectorWithSecretEnvelopeIfAbsent(ctx, connector, state, envelope)
+	if err != nil {
+		t.Fatalf("create connector with envelope: %v", err)
+	}
+	if !created || got.Connector.ConnectorID != "aws-prod" || got.State.HealthStatus != "unknown" {
+		t.Fatalf("expected created connector with state, created=%v got=%+v", created, got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreCreateTenancyConnectorWithSecretEnvelopeIfAbsentReturnsExistingOnConflict(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+
+	store := NewPostgresStoreWithDB(rawDB)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	connector, state, envelope := postgresAWSConnectorCreateFixture()
+	now := connector.CreatedAt
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tenancy_connectors").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+	rows := sqlmock.NewRows([]string{
+		"tenant_id", "workspace_id", "project_id", "connector_id", "type", "display_name", "status",
+		"secret_provider", "secret_ref_id", "secret_ref_version", "secret_last_rotated_at",
+		"config_checksum", "last_sync_at", "created_at", "updated_at", "health_status", "sync_cursor",
+		"last_successful_sync_at", "last_error_code", "last_error_message", "metadata", "observed_at", "state_updated_at",
+	}).AddRow(
+		"tenant-a", "workspace-a", "project-1", "aws-prod", "aws", "Existing AWS", "pending",
+		"secret-envelope", "existing-secret-ref", "test-v1", now, nil, nil, now, now, "unknown", nil, nil, nil, nil,
+		[]byte(`{"launch_url":"https://console.aws.amazon.com/cloudformation/home"}`),
+		now, now,
+	)
+	mock.ExpectQuery(`(?s)SELECT.*FROM tenancy_connectors.*c\.connector_id = \$4.*LIMIT \$5`).
+		WithArgs("tenant-a", "workspace-a", "project-1", "aws-prod", 1).
+		WillReturnRows(rows)
+
+	got, created, err := store.CreateTenancyConnectorWithSecretEnvelopeIfAbsent(ctx, connector, state, envelope)
+	if err != nil {
+		t.Fatalf("load existing connector after conflict: %v", err)
+	}
+	if created || got.Connector.DisplayName != "Existing AWS" || got.Connector.SecretRefID != "existing-secret-ref" {
+		t.Fatalf("expected existing connector on conflict, created=%v got=%+v", created, got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreCreateTenancyConnectorWithSecretEnvelopeIfAbsentRollsBackStateFailure(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+
+	store := NewPostgresStoreWithDB(rawDB)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	connector, state, envelope := postgresAWSConnectorCreateFixture()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tenancy_connectors").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO tenancy_connector_states").
+		WillReturnError(errors.New("state insert failed"))
+	mock.ExpectRollback()
+
+	if _, _, err := store.CreateTenancyConnectorWithSecretEnvelopeIfAbsent(ctx, connector, state, envelope); err == nil || !strings.Contains(err.Error(), "create tenancy connector state if absent") {
+		t.Fatalf("expected state insert failure, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreCreateTenancyConnectorWithSecretEnvelopeIfAbsentRollsBackEnvelopeFailure(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+
+	store := NewPostgresStoreWithDB(rawDB)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	connector, state, envelope := postgresAWSConnectorCreateFixture()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO tenancy_connectors").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO tenancy_connector_states").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO tenancy_connector_secret_envelopes").
+		WillReturnError(errors.New("envelope insert failed"))
+	mock.ExpectRollback()
+
+	if _, _, err := store.CreateTenancyConnectorWithSecretEnvelopeIfAbsent(ctx, connector, state, envelope); err == nil || !strings.Contains(err.Error(), "create tenancy connector secret envelope if absent") {
+		t.Fatalf("expected envelope insert failure, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func postgresAWSConnectorCreateFixture() (TenancyConnector, TenancyConnectorState, TenancyConnectorSecretEnvelope) {
+	now := time.Date(2026, 7, 13, 9, 0, 0, 0, time.UTC)
+	connector := TenancyConnector{
+		TenantID:            "tenant-a",
+		WorkspaceID:         "workspace-a",
+		ProjectID:           "project-1",
+		ConnectorID:         "aws-prod",
+		Type:                domain.ConnectorTypeAWS,
+		DisplayName:         "Production AWS",
+		Status:              domain.ConnectorStatusPending,
+		SecretProvider:      "secret-envelope",
+		SecretRefID:         "secret-ref",
+		SecretRefVersion:    "test-v1",
+		SecretLastRotatedAt: &now,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	state := TenancyConnectorState{
+		TenantID:     "tenant-a",
+		WorkspaceID:  "workspace-a",
+		ProjectID:    "project-1",
+		ConnectorID:  "aws-prod",
+		HealthStatus: "unknown",
+		Metadata: map[string]any{
+			"launch_url": "https://console.aws.amazon.com/cloudformation/home",
+		},
+		ObservedAt: now,
+		UpdatedAt:  now,
+	}
+	envelope := TenancyConnectorSecretEnvelope{
+		TenantID:        "tenant-a",
+		WorkspaceID:     "workspace-a",
+		ProjectID:       "project-1",
+		ConnectorID:     "aws-prod",
+		SecretName:      "external_id",
+		EnvelopeVersion: 1,
+		Envelope: secretstore.Envelope{
+			Version:    1,
+			Algorithm:  secretstore.AlgorithmAES256GCM,
+			KeyVersion: "test-v1",
+			Nonce:      []byte("123456789012"),
+			Ciphertext: []byte("ciphertext"),
+		},
+		SecretRefID: "secret-ref",
+		RotatedAt:   now,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	return connector, state, envelope
+}
+
 func TestPostgresStoreListTenancyConnectors(t *testing.T) {
 	rawDB, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -3160,6 +3160,7 @@ type Store interface {
 	ListScheduledTenancyScanPolicies(ctx context.Context, limit int, offset int) ([]TenancyScanPolicy, error)
 	ClaimTenancyScanPolicySchedule(ctx context.Context, workspaceID string, projectID string, policyID string, scheduledAt time.Time, now time.Time) (bool, error)
 	DeleteTenancyScanPolicy(ctx context.Context, workspaceID string, projectID string, policyID string) error
+	CreateTenancyConnectorSecretEnvelopeIfAbsent(ctx context.Context, envelope TenancyConnectorSecretEnvelope) (TenancyConnectorSecretEnvelope, bool, error)
 	UpsertTenancyConnectorSecretEnvelope(ctx context.Context, envelope TenancyConnectorSecretEnvelope) error
 	GetTenancyConnectorSecretEnvelope(ctx context.Context, workspaceID string, projectID string, connectorID string, secretName string) (TenancyConnectorSecretEnvelope, error)
 	DeleteTenancyConnectorSecretEnvelope(ctx context.Context, workspaceID string, projectID string, connectorID string, secretName string) error

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -3144,6 +3144,7 @@ type Store interface {
 	GetProject(ctx context.Context, workspaceID string, projectID string) (TenancyProject, error)
 	ListProjects(ctx context.Context, workspaceID string, includeArchived bool, limit int) ([]TenancyProject, error)
 	DeleteProject(ctx context.Context, workspaceID string, projectID string) error
+	CreateTenancyConnectorWithSecretEnvelopeIfAbsent(ctx context.Context, connector TenancyConnector, state TenancyConnectorState, envelope TenancyConnectorSecretEnvelope) (TenancyConnectorWithState, bool, error)
 	UpsertTenancyConnector(ctx context.Context, connector TenancyConnector, state TenancyConnectorState) error
 	GetTenancyConnector(ctx context.Context, workspaceID string, projectID string, connectorID string) (TenancyConnectorWithState, error)
 	ListTenancyConnectors(ctx context.Context, workspaceID string, projectID string, connectorType domain.ConnectorType, limit int) ([]TenancyConnectorWithState, error)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -840,6 +840,82 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('uses the AWS connector start, poll, and validate paths', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ connector_id: 'aws-prod', external_id: 'external-prod', launch_url: 'https://console.aws.amazon.com/cloudformation' })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ connection: { provider: 'aws', connector_id: 'aws-prod', onboarding_status: 'launch_ready' } })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ connection: { provider: 'aws', connector_id: 'aws-prod', onboarding_status: 'connected' } })
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const auth = {
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace/a',
+      bearerToken: 'token-a'
+    };
+
+    await apiClient.startAWSConnector(
+      {
+        workspace_id: 'workspace/a',
+        project_id: 'project 1',
+        connector_id: 'aws-prod',
+        display_name: 'Production AWS',
+        region: 'us-east-1'
+      },
+      auth
+    );
+    await apiClient.pollAWSConnector('aws/prod', 'workspace/a', 'project 1', auth);
+    await apiClient.validateAWSConnector(
+      'aws/prod',
+      {
+        workspace_id: 'workspace/a',
+        project_id: 'project 1',
+        role_arn: 'arn:aws:iam::123456789012:role/IdentrailReadOnly'
+      },
+      auth
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [startURL, startOptions] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(startURL).toContain('/v1/connectors/aws');
+    expect(startOptions.method).toBe('POST');
+    expect(startOptions.body).toBe(
+      JSON.stringify({
+        workspace_id: 'workspace/a',
+        project_id: 'project 1',
+        connector_id: 'aws-prod',
+        display_name: 'Production AWS',
+        region: 'us-east-1'
+      })
+    );
+
+    const [pollURL, pollOptions] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(pollURL).toContain('/v1/connectors/aws/aws%2Fprod/poll');
+    expect(pollURL).toContain('workspace_id=workspace%2Fa');
+    expect(pollURL).toContain('project_id=project+1');
+    expect(pollOptions.method).toBeUndefined();
+
+    const [validateURL, validateOptions] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(validateURL).toContain('/v1/connectors/aws/aws%2Fprod/validate');
+    expect(validateOptions.method).toBe('POST');
+    expect(validateOptions.body).toBe(
+      JSON.stringify({
+        workspace_id: 'workspace/a',
+        project_id: 'project 1',
+        role_arn: 'arn:aws:iam::123456789012:role/IdentrailReadOnly'
+      })
+    );
+  });
+
   it('gets and verifies AWS project baseline gate with scoped headers', async () => {
     const fetchMock = vi
       .fn()


### PR DESCRIPTION
## Summary

Closes #1749.

Implements the single-account AWS CloudFormation one-click backend behavior on top of the scope contract from #1748.

## Why

AWS onboarding retries must be safe. Before this change, posting the same connector ID could create a fresh External ID and rewrite launch parameters, which risks drifting Identrail state away from the CloudFormation trust policy the operator is installing in AWS.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

This PR:

- Makes `POST /v1/connectors/aws` resume an existing single-account CloudFormation connector when the same `connector_id` is supplied.
- Preserves the encrypted External ID and persisted launch parameters during retries.
- Keeps lifecycle fields, setup summary, next actions, permission preview, and policy tier metadata available in the start/resume response.
- Keeps poll/status responses free of serialized External ID values.
- Validates connector ID/display fields through the domain connector contract before creating a new start record.
- Adds API and web client regression coverage for start/resume, poll secrecy, and start/poll/validate request paths.
- Updates AWS connector docs, source onboarding docs, and the changelog.

## Validation

```bash
go test ./internal/api -run 'TestRouterAWSConnector|TestAWSConnector(StartResumes|ServiceErrorPaths)|TestNormalizeAWSConnectorSetupContract'
go test ./internal/api
npm run test:ci --prefix web -- src/api/client.test.ts
```

All checks passed locally.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: none
- Areas where used: none
- Human verification performed: local API and web client tests listed above

## Related Issues

Closes #1749

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements single-account AWS CloudFormation one-click onboarding with atomic, datastore-backed create-or-resume and stricter redaction. Repeating `POST /v1/connectors/aws` with the same `connector_id` resumes setup, preserves the encrypted External ID and launch parameters, serializes External ID recovery, rebuilds/persists launch metadata, and redacts the External ID and launch URL from public responses (closes #1749).

- **New Features**
  - Atomic create-or-resume: create connector, state, and secret envelope together; concurrent starts converge to one launch plan; secret-envelope recovery is serialized.
  - Resume and preservation: repeat start returns the same External ID; preserve template URL, role/stack names, region, and policy hash; rebuild missing or mismatched launch metadata and persist; start/resume responses include lifecycle, setup summary, next actions, permission preview, and policy tiers.
  - Redaction and secrets: store the External ID only in an encrypted envelope; decryption failures fail start/validate without rotation; poll/status/validate/get redact the External ID and launch URL, and the nested `connection` in start/resume also redacts the launch URL.

- **Bug Fixes**
  - Reject legacy manual AWS connector resume; do not persist secrets or launch metadata in that path.
  - Drop stale launch metadata when the External ID changes during validate; clear old launch data so the next start rebuilds it with the new External ID.

<sup>Written for commit b7073a8ef70bf53bb113981d3e9843251379ddba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

