### PR TITLE
Replace AWS connect form with scope-first wizard

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -303,7 +303,27 @@ jobs:
           npm install --global "vercel@${VERCEL_CLI_VERSION}"
           vercel --version
 
-      - name: Deploy to Vercel
+      - name: Pull Vercel production settings
+        if: steps.deploy-gate.outputs.can_deploy == 'true' && steps.verify-token.outputs.token_verified == 'true'
+        env:
+          VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          vercel pull --yes --environment=production
+
+      - name: Build Vercel production artifact
+        if: steps.deploy-gate.outputs.can_deploy == 'true' && steps.verify-token.outputs.token_verified == 'true'
+        env:
+          VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          vercel build --prod
+
+      - name: Deploy prebuilt artifact to Vercel
         id: deploy
         if: steps.deploy-gate.outputs.can_deploy == 'true' && steps.verify-token.outputs.token_verified == 'true'
         env:
@@ -312,7 +332,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           set -euo pipefail
-          deploy_output="$(vercel --cwd web deploy --prod --force --yes)"
+          deploy_output="$(vercel deploy --prebuilt --prod --yes)"
           printf '%s\n' "$deploy_output"
 
           deployment_url="$(printf '%s\n' "$deploy_output" | awk '/^https:\/\// { url=$0 } END { print url }')"

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -311,6 +311,8 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           set -euo pipefail
+          # The linked Vercel project already sets web/ as its root directory.
+          # Running the CLI with --cwd web makes Vercel resolve web/web.
           vercel pull --yes --environment=production
 
       - name: Build Vercel production artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## Unreleased
+- Replace the first-run **Connect AWS** screen with a scope-first single-account
+  setup wizard (#1750). Operators now choose the supported account scope, enter
+  a display name and setup region, launch the CloudFormation stack through a
+  clear `Connect AWS account` action, and only see the stack role ARN field
+  during post-launch validation or existing connector recovery. The page keeps
+  baseline and diagnostics out of the first-run state, preserves connected and
+  degraded operational panels, and keeps environment switching/stale async
+  guards around connector drafts.
 - Implement the **single-account AWS CloudFormation one-click backend** (#1749).
   `POST /v1/connectors/aws` now safely resumes an existing setup when the same
   connector ID is supplied, preserving the encrypted External ID, launch URL,

--- a/docs/auth/aws-connector.md
+++ b/docs/auth/aws-connector.md
@@ -30,11 +30,30 @@ When a persistent database is configured and AWS connector setup is enabled, `ID
 
 ## Flow
 
-1. The UI calls `POST /v1/connectors/aws` with `workspace_id`, `project_id`, and optional connector display fields.
-2. The API normalizes the single-account CloudFormation setup, generates a 32-byte External ID, stores it encrypted, creates a pending AWS connector, and returns an AWS CloudFormation launch URL.
-3. The user launches the stack in AWS. The stack creates an `IdentrailReadOnly` role with a trust policy requiring the External ID.
-4. The user pastes the created role ARN back into Identrail.
-5. The API uses the stored External ID, assumes the role with STS, verifies caller identity, checks scanner-critical IAM read access, and marks the connector active or degraded.
+The app presents AWS setup as a scope-first wizard. The only executable scope
+today is **Single AWS account**. Organization, selected OU/account, and existing
+manual-role setup are visible as planned paths so operators understand the
+roadmap without seeing raw credential fields on the first screen.
+
+1. The operator chooses **Single AWS account**, adds a display name, and picks
+   the home region used for setup.
+2. The UI calls `POST /v1/connectors/aws` with `workspace_id`, `project_id`,
+   display name, region, and the CloudFormation defaults.
+3. The API normalizes the single-account CloudFormation setup, generates a
+   32-byte External ID, stores it encrypted, creates a pending AWS connector,
+   and returns an AWS CloudFormation launch URL.
+4. The operator opens the AWS stack. The stack creates an `IdentrailReadOnly`
+   role with a trust policy requiring the generated External ID.
+5. After the stack finishes, the operator refreshes connector status and pastes
+   the created role ARN from the stack output into Identrail.
+6. The API uses the stored External ID, assumes the role with STS, verifies
+   caller identity, checks scanner-critical IAM read access, and marks the
+   connector active or degraded.
+
+The first-run UI intentionally does not ask for External ID, session name, or a
+raw role ARN. The role ARN appears only after a connector launch or existing
+connection is present, because it belongs to the post-CloudFormation validation
+step.
 
 If the app calls `POST /v1/connectors/aws` again with the same `connector_id`, the API resumes the existing setup instead of rotating the External ID or changing the launch parameters. This keeps the AWS trust policy, CloudFormation stack parameters, and Identrail connector record aligned while a user retries or returns to setup. Poll and status responses expose lifecycle fields, setup summary, launch URL, template URL, policy hash, diagnostics, and next actions, but they do not serialize the External ID.
 

--- a/docs/source-onboarding.md
+++ b/docs/source-onboarding.md
@@ -26,7 +26,14 @@ The action uses the tenant/workspace scope headers from the product session, sho
 
 ## AWS
 
-AWS onboarding now follows the CloudFormation connector flow:
+AWS onboarding uses a scope-first app wizard. The first supported path is
+**Single AWS account**: the operator names the account, chooses a setup region,
+launches the CloudFormation stack from Identrail, then validates the role AWS
+created after the stack finishes. Organization-wide setup, selected OUs/accounts,
+and existing manual-role setup are shown as planned paths, not editable raw
+forms.
+
+The wizard follows the CloudFormation connector flow:
 
 ```text
 POST /v1/connectors/aws
@@ -41,6 +48,10 @@ POST /v1/connectors/aws/{connector_id}/refresh-policy
 `POST /v1/connectors/aws/{connector_id}/refresh-policy` regenerates the read-only policy preview and capability matrix for the same connector.
 
 Current product behavior remains IAM-focused and read-only. CloudFormation creates a role with scanner-only permissions and does not execute cloud-side mutation or remediation.
+
+The default screen does not ask for External ID or a role ARN. Identrail
+generates and stores the External ID server-side, and the role ARN field appears
+only during the post-launch validation step or for an existing connector.
 
 Keep in mind the older project-scoped route remains for compatibility only:
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -28,7 +28,7 @@
         "@vitest/coverage-v8": "^4.1.10",
         "jsdom": "^29.1.1",
         "tsx": "^4.23.1",
-        "typescript": "^7.0.2",
+        "typescript": "^6.0.3",
         "vite": "^8.1.4",
         "vitest": "^4.1.2"
       }
@@ -1250,9 +1250,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1270,9 +1267,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1290,9 +1284,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1310,9 +1301,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,9 +1318,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1350,9 +1335,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1731,346 +1713,6 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@typescript/typescript-aix-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-loong64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-mips64el": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-riscv64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-s390x": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-sunos-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -6614,38 +6256,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc"
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {

--- a/web/package.json
+++ b/web/package.json
@@ -34,7 +34,7 @@
     "@vitest/coverage-v8": "^4.1.10",
     "jsdom": "^29.1.1",
     "tsx": "^4.23.1",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vite": "^8.1.4",
     "vitest": "^4.1.2"
   },

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1827,7 +1827,7 @@ describe('App', () => {
 
     expect(await screen.findByRole('heading', { level: 2, name: /Connect AWS/i })).toBeInTheDocument();
     expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/aws/connect');
-    expect(await screen.findByRole('heading', { level: 3, name: /AWS read-only connector/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose what Identrail should cover/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /AWS overview/i })).toHaveAttribute('href', '/app/tenant-a/workspace-a/aws?environment=project-1');
     expect(screen.queryByLabelText('AWS source')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Source types')).not.toBeInTheDocument();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8192,6 +8192,94 @@ describe('Domain-first app routes', () => {
     );
   });
 
+  it('starts AWS connect with the single-account wizard instead of the raw role form', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-connector-1',
+        onboarding_status: 'launch_ready',
+        launch_url: 'https://console.aws.amazon.com/cloudformation'
+      },
+      connector_id: 'aws-connector-1',
+      external_id: 'external-id-hidden-from-default-screen',
+      launch_url: 'https://console.aws.amazon.com/cloudformation',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      policy_hash: 'sha256:example',
+      scope_type: 'single_account',
+      deployment_method: 'cloudformation',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: [],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: false,
+      setup_summary: 'Single AWS account read-only setup through CloudFormation.',
+      next_actions: ['launch_stack', 'validate_role', 'refresh_status'],
+      permission_preview: [
+        { service: 'IAM', actions: ['iam:GetRole'], resources: ['*'], reason: 'Inspect role metadata.' }
+      ],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose what Identrail should cover/i })).toBeInTheDocument();
+    expect(screen.getByRole('list', { name: 'AWS setup scope options' })).toHaveTextContent('Single account');
+    expect(screen.getByText('All accounts')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Stack role ARN')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Production AWS' } });
+    fireEvent.change(screen.getByLabelText('Home region'), { target: { value: 'us-west-2' } });
+    fireEvent.click(screen.getByRole('button', { name: /Connect AWS account/i }));
+
+    await waitFor(() =>
+      expect(api.apiClient.startAWSConnector).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          display_name: 'Production AWS',
+          region: 'us-west-2'
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(await screen.findByRole('link', { name: /Open AWS stack/i })).toHaveAttribute(
+      'href',
+      'https://console.aws.amazon.com/cloudformation'
+    );
+    expect(screen.getByLabelText('Stack role ARN')).toHaveValue('');
+  });
+
   it('renders the Kubernetes Control Center with connected cluster coverage', async () => {
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
     mockBackendFeatures({ github: true, kubernetes: true });
@@ -8762,15 +8850,15 @@ describe('Domain-first app routes', () => {
       });
     });
 
-    expect(await screen.findByRole('heading', { level: 3, name: /AWS read-only connector/i })).toBeInTheDocument();
-    expect(screen.getByLabelText('Role ARN')).toHaveValue('');
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose what Identrail should cover/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Stack role ARN')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Display name')).toHaveValue('');
-    expect(screen.getByLabelText('Region')).toHaveValue('us-east-1');
+    expect(screen.getByLabelText('Home region')).toHaveValue('us-east-1');
 
     await act(async () => {
       productionStatus.resolve({ connection: connectedAWS });
     });
-    expect(screen.getByLabelText('Role ARN')).toHaveValue('');
+    expect(screen.queryByLabelText('Stack role ARN')).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue('Production AWS')).not.toBeInTheDocument();
   });
 
@@ -8817,7 +8905,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    const launchButton = await screen.findByRole('button', { name: /Launch stack/i });
+    const launchButton = await screen.findByRole('button', { name: /Connect AWS account/i });
     fireEvent.click(launchButton);
     await waitFor(() =>
       expect(api.apiClient.startAWSConnector).toHaveBeenCalledWith(
@@ -8855,7 +8943,7 @@ describe('Domain-first app routes', () => {
     });
 
     expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('staging');
-    expect(screen.getByLabelText('External ID')).toHaveValue('');
+    expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
     expect(screen.queryByText(/AWS CloudFormation launch is ready/i)).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Preview permissions/i })).not.toBeInTheDocument();
   });
@@ -8905,8 +8993,8 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 3, name: /AWS read-only connector/i })).toBeInTheDocument();
-    const refreshButton = within(screen.getByLabelText('AWS connector setup')).getByRole('button', {
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose what Identrail should cover/i })).toBeInTheDocument();
+    const refreshButton = within(screen.getByLabelText('AWS account setup')).getByRole('button', {
       name: /Refresh status/i
     });
     fireEvent.click(refreshButton);
@@ -8976,7 +9064,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    const submitButton = await screen.findByRole('button', { name: /Validate and save AWS/i });
+    const submitButton = await screen.findByRole('button', { name: /Validate connection/i });
     fireEvent.click(submitButton);
     await waitFor(() =>
       expect(api.apiClient.validateAWSConnector).toHaveBeenCalledWith(
@@ -9041,7 +9129,7 @@ describe('Domain-first app routes', () => {
     );
 
     expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('older-production');
-    expect(await screen.findByRole('heading', { level: 3, name: /AWS read-only connector/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose what Identrail should cover/i })).toBeInTheDocument();
     // The connected-state primary CTA is the AWS overview link.
     expect(screen.getByRole('link', { name: /AWS overview/i })).toHaveAttribute(
       'href',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8259,7 +8259,7 @@ describe('Domain-first app routes', () => {
     expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Production AWS' } });
-    fireEvent.change(screen.getByLabelText('Home region'), { target: { value: 'us-west-2' } });
+    fireEvent.change(screen.getByLabelText('Home region'), { target: { value: 'ap-south-1' } });
     fireEvent.click(screen.getByRole('button', { name: /Connect AWS account/i }));
 
     await waitFor(() =>
@@ -8268,7 +8268,7 @@ describe('Domain-first app routes', () => {
           workspace_id: 'workspace-a',
           project_id: 'production',
           display_name: 'Production AWS',
-          region: 'us-west-2'
+          region: 'ap-south-1'
         }),
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
@@ -8278,6 +8278,68 @@ describe('Domain-first app routes', () => {
       'https://console.aws.amazon.com/cloudformation'
     );
     expect(screen.getByLabelText('Stack role ARN')).toHaveValue('');
+  });
+
+  it('keeps the AWS manual role fallback usable when connector setup is feature-off', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: false, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    vi.spyOn(api.apiClient, 'upsertAWSProjectConnection').mockResolvedValue({
+      connection: { ...connectedAWS, region: 'eu-west-2', role_arn: 'arn:aws:iam::123456789012:role/IdentrailReadOnly' }
+    });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector');
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 4, name: /Validate an existing role/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Connect AWS account/i })).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Production AWS' } });
+    fireEvent.change(screen.getByLabelText('Home region'), { target: { value: 'eu-west-2' } });
+    fireEvent.change(screen.getByLabelText('Role ARN'), {
+      target: { value: 'arn:aws:iam::123456789012:role/IdentrailReadOnly' }
+    });
+    fireEvent.change(screen.getByLabelText('External ID'), { target: { value: 'external-guard' } });
+    fireEvent.click(screen.getByRole('button', { name: /Validate and save AWS/i }));
+
+    await waitFor(() =>
+      expect(api.apiClient.upsertAWSProjectConnection).toHaveBeenCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({
+          role_arn: 'arn:aws:iam::123456789012:role/IdentrailReadOnly',
+          external_id: 'external-guard',
+          region: 'eu-west-2',
+          display_name: 'Production AWS'
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(startAWSConnector).not.toHaveBeenCalled();
+    expect(await screen.findByText('AWS connector is active.')).toBeInTheDocument();
   });
 
   it('renders the Kubernetes Control Center with connected cluster coverage', async () => {
@@ -9017,6 +9079,68 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('staging');
     expect(screen.queryByText('AWS connector is active.')).not.toBeInTheDocument();
     expect(screen.queryByText('Production poll AWS')).not.toBeInTheDocument();
+  });
+
+  it('syncs the AWS role ARN returned by polling into the validation step', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-connector-1',
+        onboarding_status: 'waiting_for_aws'
+      }
+    });
+    vi.spyOn(api.apiClient, 'pollAWSConnector').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        role_arn: 'arn:aws:iam::123456789012:role/IdentrailReadOnly',
+        onboarding_status: 'connected'
+      }
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const roleInput = await screen.findByLabelText('Stack role ARN');
+    expect(roleInput).toHaveValue('');
+    expect(screen.getByRole('button', { name: /Validate connection/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Refresh status/i }));
+
+    await waitFor(() =>
+      expect(api.apiClient.pollAWSConnector).toHaveBeenCalledWith(
+        'aws-connector-1',
+        'workspace-a',
+        'production',
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(await screen.findByDisplayValue('arn:aws:iam::123456789012:role/IdentrailReadOnly')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Validate connection/i })).toBeEnabled();
   });
 
   it('ignores stale AWS validation responses after switching environments', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20580,6 +20580,9 @@ export function ProductAWSConnectPage() {
   const baselineTone = awsBaselineTone(baseline, baselineLoading || environmentScope.loading);
   const canSubmit = !submitting && !loadingConnection && Boolean(selectedEnvironmentID);
   const activeConnectorID = awsCloudFormationStart?.connector_id ?? connection?.connector_id ?? '';
+  const showOperationalPanels = Boolean(connection?.connected || connection?.status === 'degraded' || connection?.health_status === 'error');
+  const canValidateRole = Boolean(normalizeValue(awsForm.roleARN));
+  const selectedAWSRegion = normalizeValue(awsForm.region) || 'us-east-1';
 
   const handleAWSCloudFormationStart = async () => {
     if (!selectedEnvironmentID) {
@@ -20810,57 +20813,109 @@ export function ProductAWSConnectPage() {
 
       {selectedEnvironmentID ? (
         <div className="idt-aws-connect-layout">
-          <section className="idt-source-config idt-aws-connect-panel" aria-label="AWS connector setup">
-            <div className="idt-source-config-header">
+          <section className="idt-source-config idt-aws-connect-panel idt-aws-scope-wizard" aria-label="AWS account setup">
+            <div className="idt-source-config-header idt-aws-wizard-header">
               <div className="idt-source-config-title">
                 <SourceLogoMark provider="aws" className="is-hero" />
                 <div>
-                  <h3>AWS read-only connector</h3>
-                  <p>Launch the role stack or paste an existing role ARN.</p>
+                  <h3>Choose what Identrail should cover</h3>
+                  <p>Start with one account. Organization rollout comes next.</p>
                 </div>
               </div>
               <DomainStatusBadge variant={awsStatusVariant(connection)} detail={connection?.health_status ?? 'unknown'} />
             </div>
 
-            <dl className="idt-source-meta">
-              <div>
-                <dt>Required access</dt>
-                <dd>Read-only IAM role ARN</dd>
+            <div className="idt-aws-scope-options" role="list" aria-label="AWS setup scope options">
+              <div className="idt-aws-scope-option is-planned" role="listitem" aria-disabled="true">
+                <span>AWS Organization</span>
+                <strong>All accounts</strong>
+                <small>Recommended · coming soon</small>
               </div>
-              <div>
-                <dt>Health</dt>
-                <dd>{connectionHealth(connection ?? undefined)}</dd>
+              <div className="idt-aws-scope-option is-selected" role="listitem" aria-current="true">
+                <span>Single account</span>
+                <strong>This AWS account</strong>
+                <small>Available now</small>
               </div>
-              <div>
-                <dt>Last validation</dt>
-                <dd>{formatConnectionTime(connection?.last_validated_at ?? connection?.updated_at)}</dd>
+              <div className="idt-aws-scope-option is-planned" role="listitem" aria-disabled="true">
+                <span>Selected scope</span>
+                <strong>OUs or accounts</strong>
+                <small>Planned</small>
               </div>
-            </dl>
+              <div className="idt-aws-scope-option is-planned" role="listitem" aria-disabled="true">
+                <span>Advanced</span>
+                <strong>Existing IAM role</strong>
+                <small>Next issue</small>
+              </div>
+            </div>
 
             <form className="idt-app-form idt-aws-connect-form" onSubmit={handleAWSSubmit}>
-              {FEATURE_CONNECTOR_AWS ? (
-                <article className="idt-source-install-card idt-aws-launch-card">
-                  <div>
-                    <h4>Launch read-only stack</h4>
-                    <p>
-                      {awsCloudFormationStart
-                        ? 'Stack launch generated with external ID and permission preview.'
-                        : 'Generate the IAM role, trust policy, and read-only permissions for this environment.'}
-                    </p>
+              <div className="idt-aws-wizard-step">
+                <div className="idt-aws-step-index" aria-hidden="true">1</div>
+                <div className="idt-aws-step-body">
+                  <div className="idt-aws-step-heading">
+                    <div>
+                      <h4>Name the account</h4>
+                      <p>This label is only used inside Identrail.</p>
+                    </div>
+                    <span>{selectedAWSRegion}</span>
+                  </div>
+                  <div className="idt-source-inline-fields">
+                    <label>
+                      Display name
+                      <input
+                        value={awsForm.displayName}
+                        onChange={(event) => setAWSForm((current) => ({ ...current, displayName: event.target.value }))}
+                        placeholder="Production AWS"
+                      />
+                    </label>
+                    <label>
+                      Home region
+                      <select
+                        value={awsForm.region}
+                        onChange={(event) => setAWSForm((current) => ({ ...current, region: event.target.value }))}
+                      >
+                        <option value="us-east-1">us-east-1</option>
+                        <option value="us-east-2">us-east-2</option>
+                        <option value="us-west-1">us-west-1</option>
+                        <option value="us-west-2">us-west-2</option>
+                        <option value="eu-west-1">eu-west-1</option>
+                        <option value="eu-central-1">eu-central-1</option>
+                        <option value="ap-southeast-1">ap-southeast-1</option>
+                        <option value="ap-northeast-1">ap-northeast-1</option>
+                      </select>
+                    </label>
+                  </div>
+                </div>
+              </div>
+
+              <div className="idt-aws-wizard-step">
+                <div className="idt-aws-step-index" aria-hidden="true">2</div>
+                <div className="idt-aws-step-body">
+                  <div className="idt-aws-step-heading">
+                    <div>
+                      <h4>Grant read-only access</h4>
+                      <p>Identrail creates a CloudFormation launch with a unique trust guard for this environment.</p>
+                    </div>
+                    {awsCloudFormationStart ? <span>Launch ready</span> : <span>Read-only</span>}
+                  </div>
+                  <div className="idt-aws-permission-summary" aria-label="AWS permission summary">
+                    <span>IAM, STS, CloudTrail, Access Analyzer, compute, storage, secrets, and service metadata</span>
+                    <span>No remediation or write access in this connector</span>
+                    <span>External ID is generated and stored by Identrail</span>
                   </div>
                   <div className="idt-source-actions">
                     <button
-                      className="idt-btn idt-btn-dark"
+                      className="idt-btn idt-btn-primary"
                       type="button"
                       onClick={handleAWSCloudFormationStart}
-                      disabled={!canSubmit}
+                      disabled={!canSubmit || !FEATURE_CONNECTOR_AWS}
                     >
-                      {submitting ? 'Preparing...' : 'Launch stack'}
+                      {submitting ? 'Preparing...' : 'Connect AWS account'}
                     </button>
                     {awsCloudFormationStart ? (
                       <a className="idt-btn idt-btn-dark" href={awsCloudFormationStart.launch_url} target="_blank" rel="noreferrer">
                         <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
-                        <span>Open stack</span>
+                        <span>Open AWS stack</span>
                       </a>
                     ) : null}
                     {awsPermissionPreview.length > 0 ? (
@@ -20868,134 +20923,111 @@ export function ProductAWSConnectPage() {
                         Preview permissions
                       </button>
                     ) : null}
-                    {activeConnectorID ? (
-                      <button className="idt-btn idt-btn-ghost" type="button" onClick={handleAWSPoll} disabled={submitting}>
-                        {submitting ? 'Refreshing...' : 'Refresh status'}
-                      </button>
-                    ) : null}
                   </div>
-                </article>
-              ) : (
-                <article className="idt-source-install-card idt-aws-launch-card">
-                  <div>
-                    <h4>CloudFormation launch unavailable</h4>
-                    <p>This build still supports direct role ARN validation and save.</p>
-                  </div>
-                </article>
-              )}
+                </div>
+              </div>
 
-              <label>
-                Role ARN
-                <input
-                  value={awsForm.roleARN}
-                  onChange={(event) => setAWSForm((current) => ({ ...current, roleARN: event.target.value }))}
-                  placeholder="arn:aws:iam::123456789012:role/IdentrailReadOnly"
-                  required
-                />
-              </label>
-              <div className="idt-source-inline-fields">
-                <label>
-                  External ID
-                  <input
-                    value={awsForm.externalID}
-                    onChange={(event) => setAWSForm((current) => ({ ...current, externalID: event.target.value }))}
-                    placeholder="optional trust-policy guard"
-                  />
-                </label>
-                <label>
-                  Region
-                  <input
-                    value={awsForm.region}
-                    onChange={(event) => setAWSForm((current) => ({ ...current, region: event.target.value }))}
-                    placeholder="us-east-1"
-                  />
-                </label>
-              </div>
-              <div className="idt-source-inline-fields">
-                {FEATURE_CONNECTOR_AWS ? (
-                  <>
+              {(awsCloudFormationStart || connection?.connector_id || connection?.role_arn) ? (
+                <div className="idt-aws-wizard-step">
+                  <div className="idt-aws-step-index" aria-hidden="true">3</div>
+                  <div className="idt-aws-step-body">
+                    <div className="idt-aws-step-heading">
+                      <div>
+                        <h4>Verify the connection</h4>
+                        <p>After the AWS stack finishes, refresh status or validate the role AWS created.</p>
+                      </div>
+                      <span>{connectionHealth(connection ?? undefined)}</span>
+                    </div>
                     <label>
-                      Role name
+                      Stack role ARN
                       <input
-                        value={awsForm.roleName}
-                        onChange={(event) => setAWSForm((current) => ({ ...current, roleName: event.target.value }))}
-                        placeholder="IdentrailReadOnly"
+                        value={awsForm.roleARN}
+                        onChange={(event) => setAWSForm((current) => ({ ...current, roleARN: event.target.value }))}
+                        placeholder="arn:aws:iam::123456789012:role/IdentrailReadOnly"
+                        required={canValidateRole}
                       />
                     </label>
-                    <label>
-                      Stack name
-                      <input
-                        value={awsForm.stackName}
-                        onChange={(event) => setAWSForm((current) => ({ ...current, stackName: event.target.value }))}
-                        placeholder="identrail-readonly-connector"
-                      />
-                    </label>
-                  </>
-                ) : null}
-                <label>
-                  Display name
-                  <input
-                    value={awsForm.displayName}
-                    onChange={(event) => setAWSForm((current) => ({ ...current, displayName: event.target.value }))}
-                    placeholder="Production AWS"
-                  />
-                </label>
-                <label>
-                  Session name
-                  <input
-                    value={awsForm.sessionName}
-                    onChange={(event) => setAWSForm((current) => ({ ...current, sessionName: event.target.value }))}
-                    placeholder="identrail-connector-validation"
-                  />
-                </label>
-              </div>
-              <button className="idt-btn idt-btn-primary" type="submit" disabled={!canSubmit}>
-                {submitting ? 'Validating...' : 'Validate and save AWS'}
-              </button>
+                    <div className="idt-source-actions">
+                      {activeConnectorID ? (
+                        <button className="idt-btn idt-btn-secondary" type="button" onClick={handleAWSPoll} disabled={submitting}>
+                          {submitting ? 'Refreshing...' : 'Refresh status'}
+                        </button>
+                      ) : null}
+                      <button className="idt-btn idt-btn-primary" type="submit" disabled={!canSubmit || !canValidateRole}>
+                        {submitting ? 'Validating...' : 'Validate connection'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
             </form>
           </section>
 
           <div className="idt-aws-connect-side">
-            <DomainStatusPanel
-              eyebrow="Validation"
-              title="Permission health and diagnostics"
-              status={awsDiagnosticSummary(connection)}
-              tone={statusTone === 'danger' ? 'danger' : statusTone}
-              actions={[{ label: 'Refresh status', onClick: () => void refreshConnection('manual'), disabled: refreshingConnection }]}
-            >
-              <div className="idt-source-diagnostics" aria-label="AWS permission diagnostics">
-                <AWSConnectionDiagnostics connection={connection} emptyLabel="Validate the role to populate permission checks." />
-              </div>
-            </DomainStatusPanel>
-
-            <DomainStatusPanel
-              eyebrow="Baseline gate"
-              title="Platform readiness"
-              status={awsBaselineLabel(baseline)}
-              tone={baselineTone}
-              actions={[
-                { label: 'Run baseline', onClick: () => void verifyBaseline(), disabled: baselineLoading || !selectedEnvironmentID },
-                { label: 'Refresh gate', onClick: () => void refreshBaseline(), variant: 'ghost', disabled: baselineLoading || !selectedEnvironmentID }
-              ]}
-            >
-              <dl className="idt-domain-route-facts">
+            <section className="idt-source-config idt-aws-connect-summary" aria-label="AWS setup summary">
+              <p className="idt-app-kicker">Setup</p>
+              <h3>{connectedNow ? 'AWS is connected' : awsCloudFormationStart ? 'Finish in AWS' : 'Ready when you are'}</h3>
+              <dl className="idt-source-meta">
                 <div>
-                  <dt>Verified</dt>
-                  <dd>{formatConnectionTime(baseline?.verified_at)}</dd>
+                  <dt>Scope</dt>
+                  <dd>Single account</dd>
                 </div>
                 <div>
-                  <dt>Confidence</dt>
-                  <dd>{baseline ? formatConfidenceScore(baseline.confidence) : 'N/A'}</dd>
+                  <dt>Health</dt>
+                  <dd>{connectionHealth(connection ?? undefined)}</dd>
                 </div>
                 <div>
-                  <dt>Account / region</dt>
-                  <dd>{awsBaselineAccountRegionLabel(baseline)}</dd>
+                  <dt>Last validation</dt>
+                  <dd>{formatConnectionTime(connection?.last_validated_at ?? connection?.updated_at)}</dd>
                 </div>
               </dl>
-              <div className="idt-source-diagnostics" aria-label="AWS baseline diagnostics">
-                <AWSBaselineGateSummary baseline={baseline} loading={baselineLoading} />
-              </div>
-            </DomainStatusPanel>
+              <p>{connection?.setup_summary ?? 'Connect one AWS account, then Identrail can start building machine identity intelligence for that environment.'}</p>
+            </section>
+
+            {showOperationalPanels ? (
+              <>
+                <DomainStatusPanel
+                  eyebrow="Validation"
+                  title="Permission health"
+                  status={awsDiagnosticSummary(connection)}
+                  tone={statusTone === 'danger' ? 'danger' : statusTone}
+                  actions={[{ label: 'Refresh status', onClick: () => void refreshConnection('manual'), disabled: refreshingConnection }]}
+                >
+                  <div className="idt-source-diagnostics" aria-label="AWS permission diagnostics">
+                    <AWSConnectionDiagnostics connection={connection} emptyLabel="No permission checks yet." />
+                  </div>
+                </DomainStatusPanel>
+
+                <DomainStatusPanel
+                  eyebrow="Baseline gate"
+                  title="Platform readiness"
+                  status={awsBaselineLabel(baseline)}
+                  tone={baselineTone}
+                  actions={[
+                    { label: 'Run baseline', onClick: () => void verifyBaseline(), disabled: baselineLoading || !selectedEnvironmentID },
+                    { label: 'Refresh gate', onClick: () => void refreshBaseline(), variant: 'ghost', disabled: baselineLoading || !selectedEnvironmentID }
+                  ]}
+                >
+                  <dl className="idt-domain-route-facts">
+                    <div>
+                      <dt>Verified</dt>
+                      <dd>{formatConnectionTime(baseline?.verified_at)}</dd>
+                    </div>
+                    <div>
+                      <dt>Confidence</dt>
+                      <dd>{baseline ? formatConfidenceScore(baseline.confidence) : 'N/A'}</dd>
+                    </div>
+                    <div>
+                      <dt>Account / region</dt>
+                      <dd>{awsBaselineAccountRegionLabel(baseline)}</dd>
+                    </div>
+                  </dl>
+                  <div className="idt-source-diagnostics" aria-label="AWS baseline diagnostics">
+                    <AWSBaselineGateSummary baseline={baseline} loading={baselineLoading} />
+                  </div>
+                </DomainStatusPanel>
+              </>
+            ) : null}
 
           </div>
         </div>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -415,6 +415,7 @@ const SOURCE_PROFILES: Record<SourceProvider, SourceProfile> = {
 };
 const GITHUB_REPOSITORY_SPLIT_PATTERN = /[\n,]+/;
 const AWS_ROLE_ARN_PATTERN = /^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role\/[A-Za-z0-9+=,.@_/-]{1,512}$/;
+const AWS_REGION_PATTERN = /^[a-z]{2}(-gov)?-[a-z]+-[0-9]$/;
 const SOURCE_ORDER: SourceProvider[] = [
   ...(FEATURE_CONNECTOR_GITHUB_V2 ? (['github'] as SourceProvider[]) : []),
   'aws',
@@ -20595,6 +20596,12 @@ export function ProductAWSConnectPage() {
     const requestID = ++awsStartRequestRef.current;
     const requestEnvironmentID = selectedEnvironmentID;
     const requestScopeKey = scopeKeyRef.current;
+    const region = normalizeValue(awsForm.region) || 'us-east-1';
+    if (!AWS_REGION_PATTERN.test(region)) {
+      setSubmitting(false);
+      setErrorMessage('Enter a valid AWS region, for example us-east-1.');
+      return;
+    }
     const isStale = () =>
       requestID !== awsStartRequestRef.current ||
       selectedEnvironmentIDRef.current !== requestEnvironmentID ||
@@ -20605,7 +20612,7 @@ export function ProductAWSConnectPage() {
           workspace_id: scope.workspaceID,
           project_id: requestEnvironmentID,
           display_name: normalizeValue(awsForm.displayName) || undefined,
-          region: normalizeValue(awsForm.region) || 'us-east-1',
+          region,
           role_name: normalizeValue(awsForm.roleName) || undefined,
           stack_name: normalizeValue(awsForm.stackName) || undefined
         },
@@ -20617,7 +20624,13 @@ export function ProductAWSConnectPage() {
       setAWSCloudFormationStart(response);
       setAWSPermissionPreview(response.permission_preview);
       setAWSPermissionTiers(response.permission_tiers ?? []);
-      setAWSForm((current) => ({ ...current, externalID: response.external_id }));
+      setAWSForm((current) => ({
+        ...current,
+        externalID: response.external_id,
+        roleARN: response.connection.role_arn ?? current.roleARN,
+        region: response.connection.region ?? current.region,
+        displayName: response.connection.display_name ?? current.displayName
+      }));
       setConnection(response.connection);
       setSuccessMessage('AWS CloudFormation launch is ready. Open the stack, then refresh status or validate the role.');
       if (typeof window !== 'undefined' && !/jsdom/i.test(window.navigator.userAgent)) {
@@ -20661,6 +20674,12 @@ export function ProductAWSConnectPage() {
         return;
       }
       setConnection(response.connection);
+      setAWSForm((current) => ({
+        ...current,
+        roleARN: response.connection.role_arn ?? current.roleARN,
+        region: response.connection.region ?? current.region,
+        displayName: response.connection.display_name ?? current.displayName
+      }));
       setSuccessMessage(response.connection.connected ? 'AWS connector is active.' : 'AWS status refreshed.');
       if (response.connection.connected) {
         void verifyBaseline();
@@ -20699,10 +20718,14 @@ export function ProductAWSConnectPage() {
       if (!AWS_ROLE_ARN_PATTERN.test(roleARN)) {
         throw new Error('Enter a valid IAM role ARN, for example arn:aws:iam::123456789012:role/IdentrailReadOnly.');
       }
+      const region = normalizeValue(awsForm.region) || 'us-east-1';
+      if (!AWS_REGION_PATTERN.test(region)) {
+        throw new Error('Enter a valid AWS region, for example us-east-1.');
+      }
       const payload = {
         role_arn: roleARN,
         external_id: normalizeValue(awsForm.externalID) || undefined,
-        region: normalizeValue(awsForm.region) || 'us-east-1',
+        region,
         display_name: normalizeValue(awsForm.displayName) || undefined,
         session_name: normalizeValue(awsForm.sessionName) || undefined
       };
@@ -20726,6 +20749,12 @@ export function ProductAWSConnectPage() {
         return;
       }
       setConnection(response.connection);
+      setAWSForm((current) => ({
+        ...current,
+        roleARN: response.connection.role_arn ?? current.roleARN,
+        region: response.connection.region ?? current.region,
+        displayName: response.connection.display_name ?? current.displayName
+      }));
       setSuccessMessage(
         response.connection.connected ? 'AWS connector is active.' : 'AWS connector saved with diagnostics to resolve.'
       );
@@ -20870,64 +20899,94 @@ export function ProductAWSConnectPage() {
                     </label>
                     <label>
                       Home region
-                      <select
+                      <input
                         value={awsForm.region}
                         onChange={(event) => setAWSForm((current) => ({ ...current, region: event.target.value }))}
-                      >
-                        <option value="us-east-1">us-east-1</option>
-                        <option value="us-east-2">us-east-2</option>
-                        <option value="us-west-1">us-west-1</option>
-                        <option value="us-west-2">us-west-2</option>
-                        <option value="eu-west-1">eu-west-1</option>
-                        <option value="eu-central-1">eu-central-1</option>
-                        <option value="ap-southeast-1">ap-southeast-1</option>
-                        <option value="ap-northeast-1">ap-northeast-1</option>
-                      </select>
+                        placeholder="us-east-1"
+                        pattern="[a-z]{2}(-gov)?-[a-z]+-[0-9]"
+                      />
                     </label>
                   </div>
                 </div>
               </div>
 
-              <div className="idt-aws-wizard-step">
-                <div className="idt-aws-step-index" aria-hidden="true">2</div>
-                <div className="idt-aws-step-body">
-                  <div className="idt-aws-step-heading">
-                    <div>
-                      <h4>Grant read-only access</h4>
-                      <p>Identrail creates a CloudFormation launch with a unique trust guard for this environment.</p>
+              {FEATURE_CONNECTOR_AWS ? (
+                <div className="idt-aws-wizard-step">
+                  <div className="idt-aws-step-index" aria-hidden="true">2</div>
+                  <div className="idt-aws-step-body">
+                    <div className="idt-aws-step-heading">
+                      <div>
+                        <h4>Grant read-only access</h4>
+                        <p>Identrail creates a CloudFormation launch with a unique trust guard for this environment.</p>
+                      </div>
+                      {awsCloudFormationStart ? <span>Launch ready</span> : <span>Read-only</span>}
                     </div>
-                    {awsCloudFormationStart ? <span>Launch ready</span> : <span>Read-only</span>}
-                  </div>
-                  <div className="idt-aws-permission-summary" aria-label="AWS permission summary">
-                    <span>IAM, STS, CloudTrail, Access Analyzer, compute, storage, secrets, and service metadata</span>
-                    <span>No remediation or write access in this connector</span>
-                    <span>External ID is generated and stored by Identrail</span>
-                  </div>
-                  <div className="idt-source-actions">
-                    <button
-                      className="idt-btn idt-btn-primary"
-                      type="button"
-                      onClick={handleAWSCloudFormationStart}
-                      disabled={!canSubmit || !FEATURE_CONNECTOR_AWS}
-                    >
-                      {submitting ? 'Preparing...' : 'Connect AWS account'}
-                    </button>
-                    {awsCloudFormationStart ? (
-                      <a className="idt-btn idt-btn-dark" href={awsCloudFormationStart.launch_url} target="_blank" rel="noreferrer">
-                        <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
-                        <span>Open AWS stack</span>
-                      </a>
-                    ) : null}
-                    {awsPermissionPreview.length > 0 ? (
-                      <button className="idt-btn idt-btn-ghost" type="button" onClick={() => setAWSPreviewOpen(true)}>
-                        Preview permissions
+                    <div className="idt-aws-permission-summary" aria-label="AWS permission summary">
+                      <span>IAM, STS, CloudTrail, Access Analyzer, compute, storage, secrets, and service metadata</span>
+                      <span>No remediation or write access in this connector</span>
+                      <span>External ID is generated and stored by Identrail</span>
+                    </div>
+                    <div className="idt-source-actions">
+                      <button
+                        className="idt-btn idt-btn-primary"
+                        type="button"
+                        onClick={handleAWSCloudFormationStart}
+                        disabled={!canSubmit}
+                      >
+                        {submitting ? 'Preparing...' : 'Connect AWS account'}
                       </button>
-                    ) : null}
+                      {awsCloudFormationStart ? (
+                        <a className="idt-btn idt-btn-dark" href={awsCloudFormationStart.launch_url} target="_blank" rel="noreferrer">
+                          <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
+                          <span>Open AWS stack</span>
+                        </a>
+                      ) : null}
+                      {awsPermissionPreview.length > 0 ? (
+                        <button className="idt-btn idt-btn-ghost" type="button" onClick={() => setAWSPreviewOpen(true)}>
+                          Preview permissions
+                        </button>
+                      ) : null}
+                    </div>
                   </div>
                 </div>
-              </div>
+              ) : (
+                <div className="idt-aws-wizard-step">
+                  <div className="idt-aws-step-index" aria-hidden="true">2</div>
+                  <div className="idt-aws-step-body">
+                    <div className="idt-aws-step-heading">
+                      <div>
+                        <h4>Validate an existing role</h4>
+                        <p>Use the legacy read-only role path while CloudFormation setup is disabled for this build.</p>
+                      </div>
+                      <span>Manual role</span>
+                    </div>
+                    <label>
+                      Role ARN
+                      <input
+                        value={awsForm.roleARN}
+                        onChange={(event) => setAWSForm((current) => ({ ...current, roleARN: event.target.value }))}
+                        placeholder="arn:aws:iam::123456789012:role/IdentrailReadOnly"
+                        required
+                      />
+                    </label>
+                    <label>
+                      External ID
+                      <input
+                        value={awsForm.externalID}
+                        onChange={(event) => setAWSForm((current) => ({ ...current, externalID: event.target.value }))}
+                        placeholder="optional trust-policy guard"
+                      />
+                    </label>
+                    <div className="idt-source-actions">
+                      <button className="idt-btn idt-btn-primary" type="submit" disabled={!canSubmit || !canValidateRole}>
+                        {submitting ? 'Validating...' : 'Validate and save AWS'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
 
-              {(awsCloudFormationStart || connection?.connector_id || connection?.role_arn) ? (
+              {FEATURE_CONNECTOR_AWS && (awsCloudFormationStart || connection?.connector_id || connection?.role_arn) ? (
                 <div className="idt-aws-wizard-step">
                   <div className="idt-aws-step-index" aria-hidden="true">3</div>
                   <div className="idt-aws-step-body">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -23961,6 +23961,146 @@ html[data-theme='light'] .idt-app-shell-screen select {
   gap: 0.85rem;
 }
 
+.idt-aws-scope-wizard {
+  gap: 1rem;
+}
+
+.idt-aws-wizard-header {
+  align-items: flex-start;
+}
+
+.idt-aws-scope-options {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.idt-aws-scope-option {
+  display: grid;
+  gap: 0.22rem;
+  min-width: 0;
+  min-height: 6.4rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.72rem;
+  background: #050505;
+  color: var(--app-muted);
+  text-align: left;
+}
+
+.idt-aws-scope-option span,
+.idt-aws-step-heading span {
+  color: var(--app-dim);
+  font-size: 0.7rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-aws-scope-option strong {
+  min-width: 0;
+  color: #ffffff;
+  font-size: 0.92rem;
+  line-height: 1.25;
+}
+
+.idt-aws-scope-option small {
+  color: var(--app-muted);
+  font-weight: 800;
+}
+
+.idt-aws-scope-option.is-selected {
+  border-color: rgba(126, 105, 255, 0.74);
+  background: #0d0b18;
+  box-shadow: inset 0 0 0 1px rgba(126, 105, 255, 0.32);
+}
+
+.idt-aws-scope-option.is-planned {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.idt-aws-wizard-step {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr);
+  gap: 0.75rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.86rem;
+  background: #080809;
+}
+
+.idt-aws-step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid rgba(126, 105, 255, 0.5);
+  border-radius: 50%;
+  background: #111022;
+  color: #ffffff;
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.idt-aws-step-body {
+  display: grid;
+  gap: 0.78rem;
+  min-width: 0;
+}
+
+.idt-aws-step-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.idt-aws-step-heading h4,
+.idt-aws-connect-summary h3 {
+  margin: 0;
+  color: #ffffff;
+}
+
+.idt-aws-step-heading p,
+.idt-aws-connect-summary p {
+  margin: 0.18rem 0 0;
+  color: var(--app-muted);
+}
+
+.idt-aws-step-heading > span {
+  flex: 0 0 auto;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 999px;
+  padding: 0.22rem 0.48rem;
+  background: #050505;
+  color: #ffffff;
+}
+
+.idt-aws-permission-summary {
+  display: grid;
+  gap: 0.44rem;
+}
+
+.idt-aws-permission-summary span {
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.58rem 0.65rem;
+  background: #050505;
+  color: var(--app-muted);
+  font-size: 0.84rem;
+  font-weight: 760;
+}
+
+.idt-aws-connect-summary {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.idt-app-console-layout .idt-aws-connect-summary .idt-source-meta {
+  grid-template-columns: 1fr;
+}
+
 .idt-aws-connect-side {
   display: grid;
   gap: 1rem;
@@ -24490,6 +24630,10 @@ html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge
   .idt-domain-header-aside {
     justify-items: start;
   }
+
+  .idt-aws-scope-options {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 720px) {
@@ -24578,6 +24722,21 @@ html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge
 
   .idt-aws-runtime-timeline-summary div:nth-child(n + 3) {
     border-top: 1px solid var(--app-border-soft);
+  }
+
+  .idt-aws-scope-options,
+  .idt-aws-wizard-step,
+  .idt-aws-step-heading {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-aws-step-heading {
+    display: grid;
+  }
+
+  .idt-aws-step-index {
+    width: 1.8rem;
+    height: 1.8rem;
   }
 
 }


### PR DESCRIPTION
Fixes #1750

## Summary
- Replaces the first-run Connect AWS form with a scope-first wizard that makes Single AWS account the only wired path and presents Organization, selected scope, and existing role as planned paths.
- Moves raw AWS role validation out of the default screen; the stack role ARN only appears after a connector launch or existing connector state exists.
- Keeps CloudFormation start, status polling, role validation, connected/degraded diagnostics, and baseline readiness wired through the existing AWS connector APIs.
- Updates docs, changelog, app-route assertions, and regression tests for environment switching and stale async connector responses.

## Validation
- `npm run build --prefix web`
- `npm run test:ci --prefix web`
- Browser route smoke check at `http://127.0.0.1:5173/app/tenant-a/workspace-a/aws/connect?environment=production` reached the app but stopped at session validation because no local API/session was running; route behavior is covered by the App/ProductShell tests above.

## AI-assisted
No

## Tools used
None

## Where used
N/A

## Human verification performed
- Reviewed the AWS connect issue scope and dependency state.
- Verified the implementation through web build and full web CI tests.
- Checked the local route behavior in-browser up to the expected unauthenticated session gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the first‑run Connect AWS form with a scope‑first, single‑account wizard to make setup clearer and reduce errors. Implements the scope‑first AWS connect flow requested in #1750.

- **New Features**
  - Single-account is the only active path. Organization, selected scope, and existing role are shown as planned. Header now reads “Choose what Identrail should cover.”
  - Step 1: add a display name and Home region with client-side region validation. Step 2: “Connect AWS account” creates the CloudFormation launch with a server-generated External ID, permission preview, and an “Open AWS stack” link. Step 3: verify via “Stack role ARN” with “Refresh status” and “Validate connection,” auto‑filling the role ARN from polling when available. Manual-role fallback stays when the connector-setup feature is off (“Validate and save AWS”). First-run hides baseline and diagnostics; connected/degraded states keep operational panels and baseline gates. Reuses existing AWS connector APIs. Updates docs, changelog, tests, and styles.

- **Bug Fixes**
  - Stabilized production deploys by pulling production settings, building, and deploying a prebuilt `vercel` artifact, relying on the project’s root (no `--cwd web`). Refreshed Vercel status checks.
  - Pinned web `typescript` to ^6.0.3 to avoid Vercel build issues.

<sup>Written for commit 27dfe4eb78ff93568622547de8c5c02cbbcb37c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

