### PR TITLE
Add advanced AWS manual role setup

### DIFF
--- a/.github/workflows/harden-runner-audit.yml
+++ b/.github/workflows/harden-runner-audit.yml
@@ -13,11 +13,6 @@ jobs:
   hardened-go-smoke:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920
-        with:
-          egress-policy: audit
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
@@ -25,6 +20,11 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
+
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920
+        with:
+          egress-policy: audit
 
       - name: Run smoke tests
         run: go test ./internal/api ./internal/config

--- a/.github/workflows/harden-runner-audit.yml
+++ b/.github/workflows/harden-runner-audit.yml
@@ -13,6 +13,12 @@ jobs:
   hardened-go-smoke:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920
+        with:
+          egress-policy: audit
+          disable-file-monitoring: true
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
@@ -20,11 +26,6 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
-
-      - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920
-        with:
-          egress-policy: audit
 
       - name: Run smoke tests
         run: go test ./internal/api ./internal/config

--- a/docs/auth/aws-connector.md
+++ b/docs/auth/aws-connector.md
@@ -30,10 +30,10 @@ When a persistent database is configured and AWS connector setup is enabled, `ID
 
 ## Flow
 
-The app presents AWS setup as a scope-first wizard. The only executable scope
-today is **Single AWS account**. Organization, selected OU/account, and existing
-manual-role setup are visible as planned paths so operators understand the
-roadmap without seeing raw credential fields on the first screen.
+The app presents AWS setup as a scope-first wizard. The default executable path
+is **Single AWS account** through CloudFormation. Existing manual-role setup is
+available under **Advanced** for teams that manage IAM through their own change
+process. Organization and selected OU/account setup remain planned paths.
 
 1. The operator chooses **Single AWS account**, adds a display name, and picks
    the home region used for setup.
@@ -56,6 +56,57 @@ connection is present, because it belongs to the post-CloudFormation validation
 step.
 
 If the app calls `POST /v1/connectors/aws` again with the same `connector_id`, the API resumes the existing setup instead of rotating the External ID or changing the launch parameters. This keeps the AWS trust policy, CloudFormation stack parameters, and Identrail connector record aligned while a user retries or returns to setup. Poll and status responses expose lifecycle fields, setup summary, launch URL, template URL, policy hash, diagnostics, and next actions, but they do not serialize the External ID.
+
+## Manual IAM role setup
+
+Manual setup uses the same standard connector API as the CloudFormation path:
+
+```json
+{
+  "workspace_id": "workspace-a",
+  "project_id": "production",
+  "scope_type": "manual_role",
+  "deployment_method": "manual",
+  "display_name": "Production AWS",
+  "region": "us-east-1"
+}
+```
+
+The API creates a pending AWS connector, generates a connector-specific
+External ID, stores it encrypted, and returns that External ID only in the setup
+response. The app uses it to render a copyable trust policy for the operator's
+IAM change process. Status and poll responses report that an External ID is
+configured, but do not return the value.
+
+The customer's role trust policy must allow the Identrail deployment AWS account
+to call `sts:AssumeRole` and must require the generated External ID:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<IDENTRAIL_AWS_ACCOUNT_ID>:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "<GENERATED_EXTERNAL_ID>"
+        }
+      }
+    }
+  ]
+}
+```
+
+After the role exists, the app calls
+`POST /v1/connectors/aws/{connector_id}/validate` with the role ARN, project
+scope, region, and optional session name. If `external_id` is omitted, the API
+loads the External ID from the connector-scoped secret envelope. That fallback is
+deliberate: validation must never silently use a value from another workspace,
+project, or connector.
 
 The read-only policy and rationale live together under `deploy/connectors/aws/policies/`.
 
@@ -91,9 +142,9 @@ selected OUs/accounts must include targets, and malformed AWS account IDs, OU
 IDs, and regions fail validation.
 
 The executable `POST /v1/connectors/aws` setup path currently supports
-`single_account`/`cloudformation` read-only onboarding. Organization,
-selected-OU, selected-account, Terraform, and full manual app flows remain
-reserved for the follow-on implementation issues.
+`single_account`/`cloudformation` and `manual_role`/`manual` read-only
+onboarding. Organization, selected-OU, selected-account, and Terraform flows
+remain reserved for follow-on implementation issues.
 
 ## Account and Region Coverage Registry
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -11490,28 +11490,6 @@ components:
           description: Optional requested capability tiers. Defaults to discovery (read-only).
           items:
             $ref: "#/components/schemas/ConnectorCapability"
-        scope_type:
-          $ref: "#/components/schemas/AWSConnectorScopeType"
-        deployment_method:
-          $ref: "#/components/schemas/AWSConnectorDeploymentMethod"
-        target_regions:
-          type: array
-          items:
-            type: string
-        target_account_ids:
-          type: array
-          items:
-            type: string
-        target_ou_ids:
-          type: array
-          items:
-            type: string
-        excluded_account_ids:
-          type: array
-          items:
-            type: string
-        auto_onboard_new_accounts:
-          type: boolean
     AWSConnectorPollRequest:
       type: object
       properties:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -11490,6 +11490,28 @@ components:
           description: Optional requested capability tiers. Defaults to discovery (read-only).
           items:
             $ref: "#/components/schemas/ConnectorCapability"
+        scope_type:
+          $ref: "#/components/schemas/AWSConnectorScopeType"
+        deployment_method:
+          $ref: "#/components/schemas/AWSConnectorDeploymentMethod"
+        target_regions:
+          type: array
+          items:
+            type: string
+        target_account_ids:
+          type: array
+          items:
+            type: string
+        target_ou_ids:
+          type: array
+          items:
+            type: string
+        excluded_account_ids:
+          type: array
+          items:
+            type: string
+        auto_onboard_new_accounts:
+          type: boolean
     AWSConnectorPollRequest:
       type: object
       properties:
@@ -11513,6 +11535,9 @@ components:
         template_url:
           type: string
           format: uri
+        identrail_account_id:
+          type: string
+          description: AWS account ID that should be trusted by manually managed IAM roles.
         role_name:
           type: string
         stack_name:

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -166,6 +166,7 @@ type AWSConnectorStartResponse struct {
 	ExternalID             string                                  `json:"external_id"`
 	LaunchURL              string                                  `json:"launch_url"`
 	TemplateURL            string                                  `json:"template_url"`
+	IdentrailAccountID     string                                  `json:"identrail_account_id,omitempty"`
 	RoleName               string                                  `json:"role_name"`
 	StackName              string                                  `json:"stack_name"`
 	PolicyHash             string                                  `json:"policy_hash"`
@@ -328,6 +329,9 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 	if err != nil {
 		return AWSConnectorStartResponse{}, err
 	}
+	if setup.ScopeType == AWSConnectorScopeManualRole && setup.DeploymentMethod == AWSConnectorDeploymentManual {
+		return s.startAWSManualConnector(ctx, project, scope, request, setup)
+	}
 	if setup.ScopeType != AWSConnectorScopeSingleAccount || setup.DeploymentMethod != AWSConnectorDeploymentCloudFormation {
 		return AWSConnectorStartResponse{}, ErrInvalidAWSConnectionRequest
 	}
@@ -436,7 +440,127 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 	}
 	status := s.awsConnectionStatusFromStored(ctx, stored)
 	status.ExternalID = externalID
-	return awsConnectorStartResponse(status, externalID, launchURL, templateURL, roleName, stackName, policyHash), nil
+	return awsConnectorStartResponse(status, externalID, launchURL, templateURL, accountID, roleName, stackName, policyHash), nil
+}
+
+func (s *Service) startAWSManualConnector(
+	ctx context.Context,
+	project db.TenancyProject,
+	scope db.Scope,
+	request AWSConnectorStartRequest,
+	setup awsConnectorSetupContract,
+) (AWSConnectorStartResponse, error) {
+	connectorID := strings.TrimSpace(request.ConnectorID)
+	if connectorID == "" {
+		connectorID = "aws-" + uuid.NewString()
+	} else {
+		stored, err := s.Store.GetTenancyConnector(ctx, project.WorkspaceID, project.ProjectID, connectorID)
+		if err == nil {
+			return s.resumeAWSManualConnectorStart(ctx, stored)
+		}
+		if !errors.Is(err, db.ErrNotFound) {
+			return AWSConnectorStartResponse{}, err
+		}
+	}
+	displayName := strings.TrimSpace(request.DisplayName)
+	if displayName == "" {
+		displayName = "AWS account"
+	}
+	if err := validateAWSConnectorStartIdentity(connectorID, displayName); err != nil {
+		return AWSConnectorStartResponse{}, err
+	}
+	externalID, err := generateAWSExternalID()
+	if err != nil {
+		return AWSConnectorStartResponse{}, err
+	}
+	accountID := strings.TrimSpace(s.AWSAccountID)
+	if accountID == "" {
+		return AWSConnectorStartResponse{}, ErrAWSConnectorConfigUnavailable
+	}
+	now := s.Now().UTC()
+	region := firstAWSRegion(setup.TargetRegions)
+	if region == "" {
+		region = "us-east-1"
+	}
+	capabilities, _, err := s.resolveAWSConnectorCapabilities(domain.DefaultConnectorCapabilities())
+	if err != nil {
+		return AWSConnectorStartResponse{}, err
+	}
+	onboardingStatus := AWSConnectorOnboardingDraft
+	metadata := map[string]any{
+		"external_id_configured": true,
+		"region":                 region,
+		"permission_checks":      []AWSConnectionPermissionCheck{},
+		"diagnostics":            []AWSConnectionDiagnostic{},
+		"capabilities":           capabilities,
+		"last_started_at":        now.Format(time.RFC3339Nano),
+	}
+	applyAWSConnectorSetupMetadata(metadata, setup, onboardingStatus)
+	connector := db.TenancyConnector{
+		TenantID:            scope.TenantID,
+		WorkspaceID:         project.WorkspaceID,
+		ProjectID:           project.ProjectID,
+		ConnectorID:         connectorID,
+		Type:                domain.ConnectorTypeAWS,
+		DisplayName:         displayName,
+		Status:              domain.ConnectorStatusPending,
+		SecretProvider:      "secret-envelope",
+		SecretRefID:         awsExternalIDSecretRef(connectorID),
+		SecretRefVersion:    s.connectorSecretManager().ActiveKeyVersion(),
+		SecretLastRotatedAt: &now,
+		UpdatedAt:           now,
+	}
+	state := db.TenancyConnectorState{
+		TenantID:     scope.TenantID,
+		WorkspaceID:  project.WorkspaceID,
+		ProjectID:    project.ProjectID,
+		ConnectorID:  connectorID,
+		HealthStatus: "unknown",
+		Metadata:     metadata,
+		ObservedAt:   now,
+		UpdatedAt:    now,
+	}
+	envelope, err := s.newAWSExternalIDSecretEnvelope(scope.TenantID, project.WorkspaceID, project.ProjectID, connectorID, externalID, now)
+	if err != nil {
+		return AWSConnectorStartResponse{}, err
+	}
+	stored, created, err := s.Store.CreateTenancyConnectorWithSecretEnvelopeIfAbsent(ctx, connector, state, envelope)
+	if err != nil {
+		return AWSConnectorStartResponse{}, fmt.Errorf("create manual aws connector: %w", err)
+	}
+	if !created {
+		return s.resumeAWSManualConnectorStart(ctx, stored)
+	}
+	status := s.awsConnectionStatusFromStored(ctx, stored)
+	status.ExternalID = externalID
+	status.Region = firstNonEmptyAWSValue(status.Region, region)
+	return awsConnectorStartResponse(status, externalID, "", "", accountID, "", "", ""), nil
+}
+
+func (s *Service) resumeAWSManualConnectorStart(ctx context.Context, stored db.TenancyConnectorWithState) (AWSConnectorStartResponse, error) {
+	if stored.Connector.Type != domain.ConnectorTypeAWS {
+		return AWSConnectorStartResponse{}, ErrInvalidAWSConnectionRequest
+	}
+	defaultScope, defaultDeployment := awsMetadataSetupFallback(stored.State.Metadata)
+	setup := awsMetadataSetupContract(stored.State.Metadata, defaultScope, defaultDeployment)
+	if setup.ScopeType != AWSConnectorScopeManualRole || setup.DeploymentMethod != AWSConnectorDeploymentManual {
+		return AWSConnectorStartResponse{}, ErrInvalidAWSConnectionRequest
+	}
+	externalID, externalIDConfigured, err := s.awsExternalIDFromStoredStrict(ctx, stored)
+	if err != nil {
+		return AWSConnectorStartResponse{}, err
+	}
+	if !externalIDConfigured || externalID == "" {
+		return AWSConnectorStartResponse{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := strings.TrimSpace(s.AWSAccountID)
+	if accountID == "" {
+		return AWSConnectorStartResponse{}, ErrAWSConnectorConfigUnavailable
+	}
+	status := s.awsConnectionStatusFromStored(ctx, stored)
+	status.ExternalID = externalID
+	status.ExternalIDConfigured = true
+	return awsConnectorStartResponse(status, externalID, "", "", accountID, "", "", ""), nil
 }
 
 func (s *Service) resumeAWSConnectorStart(
@@ -535,7 +659,7 @@ func (s *Service) resumeAWSConnectorStart(
 	status.LaunchURL = firstNonEmptyAWSValue(launchURL, status.LaunchURL)
 	status.TemplateURL = firstNonEmptyAWSValue(status.TemplateURL, templateURL)
 	status.PolicyHash = firstNonEmptyAWSValue(status.PolicyHash, policyHash)
-	return awsConnectorStartResponse(status, externalID, launchURL, status.TemplateURL, roleName, stackName, policyHash), nil
+	return awsConnectorStartResponse(status, externalID, launchURL, status.TemplateURL, accountID, roleName, stackName, policyHash), nil
 }
 
 func persistRecoveredAWSConnectorLaunchState(
@@ -637,16 +761,18 @@ func preserveAWSConnectorLaunchMetadata(metadata map[string]any, preserved map[s
 
 func publicAWSConnectionStatus(status AWSConnectionStatus) AWSConnectionStatus {
 	status.LaunchURL = ""
+	status.ExternalID = ""
 	return status
 }
 
-func awsConnectorStartResponse(status AWSConnectionStatus, externalID string, launchURL string, templateURL string, roleName string, stackName string, policyHash string) AWSConnectorStartResponse {
+func awsConnectorStartResponse(status AWSConnectionStatus, externalID string, launchURL string, templateURL string, identrailAccountID string, roleName string, stackName string, policyHash string) AWSConnectorStartResponse {
 	return AWSConnectorStartResponse{
 		Connection:             publicAWSConnectionStatus(status),
 		ConnectorID:            status.ConnectorID,
 		ExternalID:             externalID,
 		LaunchURL:              launchURL,
 		TemplateURL:            templateURL,
+		IdentrailAccountID:     identrailAccountID,
 		RoleName:               roleName,
 		StackName:              stackName,
 		PolicyHash:             policyHash,
@@ -1241,6 +1367,9 @@ func awsConnectorNextActions(setup awsConnectorSetupContract, onboardingStatus A
 	}
 	if awsConnectorDeploymentIsStackSet(setup.DeploymentMethod) {
 		return []AWSConnectorNextAction{AWSConnectorNextActionOpenStackSet, AWSConnectorNextActionRefreshStatus}
+	}
+	if setup.ScopeType == AWSConnectorScopeManualRole || setup.DeploymentMethod == AWSConnectorDeploymentManual {
+		return []AWSConnectorNextAction{AWSConnectorNextActionValidateRole, AWSConnectorNextActionRefreshStatus}
 	}
 	return []AWSConnectorNextAction{AWSConnectorNextActionLaunchStack, AWSConnectorNextActionValidateRole, AWSConnectorNextActionRefreshStatus}
 }

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -551,7 +551,11 @@ func (s *Service) resumeAWSManualConnectorStart(ctx context.Context, stored db.T
 		return AWSConnectorStartResponse{}, err
 	}
 	if !externalIDConfigured || externalID == "" {
-		return AWSConnectorStartResponse{}, ErrInvalidAWSConnectionRequest
+		var recoverErr error
+		stored, externalID, recoverErr = s.recoverAWSManualConnectorExternalID(ctx, stored)
+		if recoverErr != nil {
+			return AWSConnectorStartResponse{}, recoverErr
+		}
 	}
 	accountID := strings.TrimSpace(s.AWSAccountID)
 	if accountID == "" {
@@ -561,6 +565,56 @@ func (s *Service) resumeAWSManualConnectorStart(ctx context.Context, stored db.T
 	status.ExternalID = externalID
 	status.ExternalIDConfigured = true
 	return awsConnectorStartResponse(status, externalID, "", "", accountID, "", "", ""), nil
+}
+
+func (s *Service) recoverAWSManualConnectorExternalID(ctx context.Context, stored db.TenancyConnectorWithState) (db.TenancyConnectorWithState, string, error) {
+	externalID, err := generateAWSExternalID()
+	if err != nil {
+		return db.TenancyConnectorWithState{}, "", err
+	}
+	rotatedAt := s.Now().UTC()
+	secret, err := s.newAWSExternalIDSecretEnvelope(
+		stored.Connector.TenantID,
+		stored.Connector.WorkspaceID,
+		stored.Connector.ProjectID,
+		stored.Connector.ConnectorID,
+		externalID,
+		rotatedAt,
+	)
+	if err != nil {
+		return db.TenancyConnectorWithState{}, "", err
+	}
+	secret, created, err := s.Store.CreateTenancyConnectorSecretEnvelopeIfAbsent(
+		db.WithScope(ctx, db.Scope{TenantID: stored.Connector.TenantID, WorkspaceID: stored.Connector.WorkspaceID}),
+		secret,
+	)
+	if err != nil {
+		return db.TenancyConnectorWithState{}, "", fmt.Errorf("recover manual aws connector external id envelope: %w", err)
+	}
+	if !created {
+		recoveredExternalID, err := s.decryptAWSExternalIDEnvelope(stored.Connector, secret)
+		if err != nil {
+			return db.TenancyConnectorWithState{}, "", err
+		}
+		externalID = recoveredExternalID
+	}
+
+	metadata := copyAWSMetadata(stored.State.Metadata)
+	delete(metadata, "external_id")
+	metadata["external_id_configured"] = strings.TrimSpace(externalID) != ""
+	metadata["last_started_at"] = rotatedAt.Format(time.RFC3339Nano)
+	stored.State.Metadata = metadata
+	stored.State.ObservedAt = rotatedAt
+	stored.State.UpdatedAt = rotatedAt
+	stored.Connector.SecretProvider = "secret-envelope"
+	stored.Connector.SecretRefID = awsExternalIDSecretRef(stored.Connector.ConnectorID)
+	stored.Connector.SecretRefVersion = s.connectorSecretManager().ActiveKeyVersion()
+	stored.Connector.SecretLastRotatedAt = &rotatedAt
+	stored.Connector.UpdatedAt = rotatedAt
+	if err := s.Store.UpsertTenancyConnector(ctx, stored.Connector, stored.State); err != nil {
+		return db.TenancyConnectorWithState{}, "", fmt.Errorf("persist recovered manual aws connector external id: %w", err)
+	}
+	return stored, externalID, nil
 }
 
 func (s *Service) resumeAWSConnectorStart(
@@ -761,13 +815,18 @@ func preserveAWSConnectorLaunchMetadata(metadata map[string]any, preserved map[s
 
 func publicAWSConnectionStatus(status AWSConnectionStatus) AWSConnectionStatus {
 	status.LaunchURL = ""
+	return status
+}
+
+func awsConnectorSetupPublicConnectionStatus(status AWSConnectionStatus) AWSConnectionStatus {
+	status = publicAWSConnectionStatus(status)
 	status.ExternalID = ""
 	return status
 }
 
 func awsConnectorStartResponse(status AWSConnectionStatus, externalID string, launchURL string, templateURL string, identrailAccountID string, roleName string, stackName string, policyHash string) AWSConnectorStartResponse {
 	return AWSConnectorStartResponse{
-		Connection:             publicAWSConnectionStatus(status),
+		Connection:             awsConnectorSetupPublicConnectionStatus(status),
 		ConnectorID:            status.ConnectorID,
 		ExternalID:             externalID,
 		LaunchURL:              launchURL,
@@ -845,7 +904,7 @@ func (s *Service) ValidateAWSConnector(ctx context.Context, connectorID string, 
 	if awsConnectorValidateRequestHasSetupOverride(request) {
 		return AWSConnectionStatus{}, ErrInvalidAWSConnectionRequest
 	}
-	return s.UpsertAWSConnection(ctx, project.WorkspaceID, project.ProjectID, AWSConnectionUpsertRequest{
+	status, err := s.UpsertAWSConnection(ctx, project.WorkspaceID, project.ProjectID, AWSConnectionUpsertRequest{
 		ConnectorID:            connectorID,
 		DisplayName:            stored.Connector.DisplayName,
 		RoleARN:                request.RoleARN,
@@ -863,6 +922,10 @@ func (s *Service) ValidateAWSConnector(ctx context.Context, connectorID string, 
 		allowSetupContract:     true,
 		preserveLaunchMetadata: awsConnectorLaunchMetadataForExternalID(stored.State.Metadata, externalID),
 	})
+	if err != nil {
+		return AWSConnectionStatus{}, err
+	}
+	return awsConnectorSetupPublicConnectionStatus(status), nil
 }
 
 func (s *Service) PollAWSConnector(ctx context.Context, connectorID string, request AWSConnectorPollRequest) (AWSConnectionStatus, error) {
@@ -877,7 +940,7 @@ func (s *Service) PollAWSConnector(ctx context.Context, connectorID string, requ
 	if err != nil {
 		return AWSConnectionStatus{}, err
 	}
-	return publicAWSConnectionStatus(s.awsConnectionStatusFromStored(ctx, stored)), nil
+	return awsConnectorSetupPublicConnectionStatus(s.awsConnectionStatusFromStored(ctx, stored)), nil
 }
 
 func (s *Service) AWSConnectorPolicy(ctx context.Context, connectorID string, request AWSConnectorPollRequest) (AWSConnectorPolicyResponse, error) {

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -212,6 +212,74 @@ func TestAWSConnectorManualStartAndValidateUsesStoredExternalID(t *testing.T) {
 	}
 }
 
+func TestAWSConnectorManualStartRecoversMissingExternalIDEnvelope(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	manager, err := secretstore.NewManager([]secretstore.KeyMaterial{{Version: "test-v1", Key: bytes.Repeat([]byte{7}, 32)}})
+	if err != nil {
+		t.Fatalf("build connector secret manager: %v", err)
+	}
+	validator := &fakeAWSConnectorValidator{
+		result: AWSConnectionValidationResult{
+			AccountID:    "123456789012",
+			PrincipalARN: "arn:aws:sts::123456789012:assumed-role/CustomerManagedIdentrail/identrail-connector-validation",
+			UserID:       "AROATEST:identrail-connector-validation",
+			Region:       "us-west-2",
+		},
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.ConnectorSecretManager = manager
+	svc.AWSConnectorValidator = validator
+	svc.AWSAccountID = "999999999999"
+
+	started, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID:      "workspace-a",
+		ProjectID:        "project-1",
+		ConnectorID:      "aws-manual-prod",
+		DisplayName:      "Customer-managed AWS",
+		Region:           "us-west-2",
+		ScopeType:        AWSConnectorScopeManualRole,
+		DeploymentMethod: AWSConnectorDeploymentManual,
+	})
+	if err != nil {
+		t.Fatalf("start manual aws connector: %v", err)
+	}
+	if err := store.DeleteTenancyConnectorSecretEnvelope(ctx, "workspace-a", "project-1", "aws-manual-prod", awsExternalIDSecretName); err != nil {
+		t.Fatalf("delete manual external id envelope: %v", err)
+	}
+
+	recovered, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID:      "workspace-a",
+		ProjectID:        "project-1",
+		ConnectorID:      started.ConnectorID,
+		ScopeType:        AWSConnectorScopeManualRole,
+		DeploymentMethod: AWSConnectorDeploymentManual,
+	})
+	if err != nil {
+		t.Fatalf("recover manual aws connector external id: %v", err)
+	}
+	if recovered.ExternalID == "" || recovered.ExternalID == started.ExternalID || recovered.LaunchURL != "" {
+		t.Fatalf("expected regenerated manual external id without launch URL, started=%+v recovered=%+v", started, recovered)
+	}
+
+	validated, err := svc.ValidateAWSConnector(ctx, recovered.ConnectorID, AWSConnectorValidateRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		RoleARN:     "arn:aws:iam::123456789012:role/CustomerManagedIdentrail",
+		Region:      "us-west-2",
+	})
+	if err != nil {
+		t.Fatalf("validate recovered manual aws connector: %v", err)
+	}
+	if validated.ExternalID != "" {
+		t.Fatalf("public validate response must not expose recovered external id, got %q", validated.ExternalID)
+	}
+	if validator.seen.ExternalID != recovered.ExternalID {
+		t.Fatalf("expected validation to use recovered external id, got %q want %q", validator.seen.ExternalID, recovered.ExternalID)
+	}
+}
+
 func TestAWSConnectionPersistsAcrossServiceInstances(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -131,6 +131,87 @@ func TestRouterAWSConnectionKeepsLegacyManualScope(t *testing.T) {
 	}
 }
 
+func TestAWSConnectorManualStartAndValidateUsesStoredExternalID(t *testing.T) {
+	validator := &fakeAWSConnectorValidator{
+		result: AWSConnectionValidationResult{
+			AccountID:    "123456789012",
+			PrincipalARN: "arn:aws:sts::123456789012:assumed-role/CustomerManagedIdentrail/identrail-connector-validation",
+			UserID:       "AROATEST:identrail-connector-validation",
+			Region:       "us-west-2",
+			PermissionChecks: []AWSConnectionPermissionCheck{
+				{Name: "sts:AssumeRole", Passed: true, Message: "Role assumption succeeded."},
+				{Name: "iam:ListRoles", Passed: true, Message: "IAM role listing permission is available."},
+			},
+		},
+	}
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	manager, err := secretstore.NewManager([]secretstore.KeyMaterial{{Version: "test-v1", Key: bytes.Repeat([]byte{7}, 32)}})
+	if err != nil {
+		t.Fatalf("build connector secret manager: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.ConnectorSecretManager = manager
+	svc.AWSConnectorValidator = validator
+	svc.AWSAccountID = "999999999999"
+
+	started, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID:      "workspace-a",
+		ProjectID:        "project-1",
+		ConnectorID:      "aws-manual-prod",
+		DisplayName:      "Customer-managed AWS",
+		Region:           "us-west-2",
+		ScopeType:        AWSConnectorScopeManualRole,
+		DeploymentMethod: AWSConnectorDeploymentManual,
+	})
+	if err != nil {
+		t.Fatalf("start manual aws connector: %v", err)
+	}
+	if started.ExternalID == "" || started.LaunchURL != "" || started.TemplateURL != "" || started.IdentrailAccountID != "999999999999" {
+		t.Fatalf("expected manual setup external id without launch metadata, got %+v", started)
+	}
+	if started.ScopeType != AWSConnectorScopeManualRole || started.DeploymentMethod != AWSConnectorDeploymentManual {
+		t.Fatalf("expected manual setup contract, got scope=%q method=%q", started.ScopeType, started.DeploymentMethod)
+	}
+	if !slices.Contains(started.NextActions, AWSConnectorNextActionValidateRole) || slices.Contains(started.NextActions, AWSConnectorNextActionLaunchStack) {
+		t.Fatalf("expected manual setup next actions to validate role without launch stack, got %+v", started.NextActions)
+	}
+
+	validated, err := svc.ValidateAWSConnector(ctx, started.ConnectorID, AWSConnectorValidateRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		RoleARN:     "arn:aws:iam::123456789012:role/CustomerManagedIdentrail",
+		Region:      "us-west-2",
+	})
+	if err != nil {
+		t.Fatalf("validate manual aws connector: %v", err)
+	}
+	if !validated.Connected || validated.ScopeType != AWSConnectorScopeManualRole || validated.DeploymentMethod != AWSConnectorDeploymentManual {
+		t.Fatalf("expected connected manual connector, got %+v", validated)
+	}
+	if validated.ExternalID != "" {
+		t.Fatalf("public validate response must not expose external id, got %q", validated.ExternalID)
+	}
+	if validator.seen.ExternalID != started.ExternalID {
+		t.Fatalf("expected validation to use stored external id, got %q want %q", validator.seen.ExternalID, started.ExternalID)
+	}
+
+	resumed, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID:      "workspace-a",
+		ProjectID:        "project-1",
+		ConnectorID:      started.ConnectorID,
+		ScopeType:        AWSConnectorScopeManualRole,
+		DeploymentMethod: AWSConnectorDeploymentManual,
+	})
+	if err != nil {
+		t.Fatalf("resume manual aws connector: %v", err)
+	}
+	if resumed.ExternalID != started.ExternalID || resumed.LaunchURL != "" {
+		t.Fatalf("expected manual resume to preserve external id without launch URL, got %+v", resumed)
+	}
+}
+
 func TestAWSConnectionPersistsAcrossServiceInstances(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -9652,6 +9652,7 @@ export type AWSConnectorStartResponse = {
   external_id: string;
   launch_url: string;
   template_url: string;
+  identrail_account_id?: string;
   role_name: string;
   stack_name: string;
   policy_hash: string;
@@ -9677,6 +9678,13 @@ export type AWSConnectorValidateRequest = {
   region?: string;
   session_name?: string;
   capabilities?: ConnectorCapability[];
+  scope_type?: AWSConnectorScopeType;
+  deployment_method?: AWSConnectorDeploymentMethod;
+  target_regions?: string[];
+  target_account_ids?: string[];
+  target_ou_ids?: string[];
+  excluded_account_ids?: string[];
+  auto_onboard_new_accounts?: boolean;
 };
 
 export type AWSConnectorPolicyResponse = {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -9678,13 +9678,6 @@ export type AWSConnectorValidateRequest = {
   region?: string;
   session_name?: string;
   capabilities?: ConnectorCapability[];
-  scope_type?: AWSConnectorScopeType;
-  deployment_method?: AWSConnectorDeploymentMethod;
-  target_regions?: string[];
-  target_account_ids?: string[];
-  target_ou_ids?: string[];
-  excluded_account_ids?: string[];
-  auto_onboard_new_accounts?: boolean;
 };
 
 export type AWSConnectorPolicyResponse = {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8277,6 +8277,255 @@ describe('Domain-first app routes', () => {
     expect(screen.getByLabelText('Stack role ARN')).toHaveValue('');
   });
 
+  it('supports advanced manual AWS role setup without making it the default path', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-manual-1',
+        display_name: 'Production AWS',
+        scope_type: 'manual_role',
+        deployment_method: 'manual',
+        onboarding_status: 'draft',
+        setup_summary: 'Existing IAM role setup for one AWS account.',
+        next_actions: ['validate_role', 'refresh_status']
+      },
+      connector_id: 'aws-manual-1',
+      external_id: 'manual-external-id-1234567890',
+      launch_url: '',
+      template_url: '',
+      identrail_account_id: '999999999999',
+      role_name: '',
+      stack_name: '',
+      policy_hash: '',
+      scope_type: 'manual_role',
+      deployment_method: 'manual',
+      onboarding_status: 'draft',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: [],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: false,
+      setup_summary: 'Existing IAM role setup for one AWS account.',
+      next_actions: ['validate_role', 'refresh_status'],
+      permission_preview: [
+        { service: 'IAM', actions: ['iam:GetRole'], resources: ['*'], reason: 'Inspect role metadata.' }
+      ],
+      permission_tiers: []
+    });
+    const validateAWSConnector = vi.spyOn(api.apiClient, 'validateAWSConnector').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-manual-1',
+        deployment_method: 'manual',
+        scope_type: 'manual_role',
+        role_arn: 'arn:aws:iam::123456789012:role/CustomerManagedIdentrail'
+      }
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose what Identrail should cover/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Existing IAM role/i }));
+    expect(screen.getByRole('heading', { level: 4, name: /Use an existing IAM role/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate External ID/i }));
+
+    await waitFor(() =>
+      expect(api.apiClient.startAWSConnector).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          scope_type: 'manual_role',
+          deployment_method: 'manual'
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(await screen.findByLabelText('External ID')).toHaveValue('manual-external-id-1234567890');
+    const trustPolicy = String((screen.getByLabelText('Trust policy') as HTMLTextAreaElement).value);
+    expect(trustPolicy).toContain('arn:aws:iam::999999999999:root');
+    expect(trustPolicy).toContain('manual-external-id-1234567890');
+    expect(screen.getByLabelText('Role ARN')).toHaveValue('');
+
+    fireEvent.change(screen.getByLabelText('Role ARN'), {
+      target: { value: 'arn:aws:iam::123456789012:role/CustomerManagedIdentrail' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Validate role/i }));
+
+    await waitFor(() =>
+      expect(validateAWSConnector).toHaveBeenCalledWith(
+        'aws-manual-1',
+        expect.objectContaining({
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          role_arn: 'arn:aws:iam::123456789012:role/CustomerManagedIdentrail',
+          external_id: 'manual-external-id-1234567890'
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+  });
+
+  it('keeps the advanced AWS manual path selected when initial status resolves late', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    const initialStatus = deferred<{ connection: AWSConnectionStatus }>();
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockReturnValue(initialStatus.promise);
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Existing IAM role/i }));
+    expect(screen.getByRole('heading', { level: 4, name: /Use an existing IAM role/i })).toBeInTheDocument();
+
+    await act(async () => {
+      initialStatus.resolve({ connection: disconnectedAWS });
+    });
+
+    expect(screen.getByRole('heading', { level: 4, name: /Use an existing IAM role/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Generate External ID/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Connect AWS account/i })).not.toBeInTheDocument();
+  });
+
+  it('clears manual AWS setup secrets when switching environments', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging',
+          name: 'Staging',
+          slug: 'staging',
+          description: 'Staging AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-manual-1',
+        scope_type: 'manual_role',
+        deployment_method: 'manual',
+        onboarding_status: 'draft'
+      },
+      connector_id: 'aws-manual-1',
+      external_id: 'manual-external-id-to-clear',
+      launch_url: '',
+      template_url: '',
+      identrail_account_id: '999999999999',
+      role_name: '',
+      stack_name: '',
+      policy_hash: '',
+      scope_type: 'manual_role',
+      deployment_method: 'manual',
+      onboarding_status: 'draft',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: [],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: false,
+      setup_summary: 'Existing IAM role setup for one AWS account.',
+      next_actions: ['validate_role', 'refresh_status'],
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Existing IAM role/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Generate External ID/i }));
+    expect(await screen.findByDisplayValue('manual-external-id-to-clear')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Role ARN'), {
+      target: { value: 'arn:aws:iam::123456789012:role/CustomerManagedIdentrail' }
+    });
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
+
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('staging');
+    expect(screen.queryByDisplayValue('manual-external-id-to-clear')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('arn:aws:iam::123456789012:role/CustomerManagedIdentrail')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
+  });
+
   it('shows a clear AWS connector setup error instead of falling back to manual role fields', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: false, github: true, kubernetes: true });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8288,6 +8288,122 @@ describe('Domain-first app routes', () => {
     expect(screen.getByLabelText('Stack role ARN')).toHaveValue('');
   });
 
+  it('clears prepared CloudFormation state before starting manual AWS setup', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const startAWSConnector = vi
+      .spyOn(api.apiClient, 'startAWSConnector')
+      .mockResolvedValueOnce({
+        connection: {
+          ...disconnectedAWS,
+          connector_id: 'aws-cloudformation-1',
+          deployment_method: 'cloudformation',
+          onboarding_status: 'launch_ready',
+          launch_url: 'https://console.aws.amazon.com/cloudformation'
+        },
+        connector_id: 'aws-cloudformation-1',
+        external_id: 'cloudformation-external-id',
+        launch_url: 'https://console.aws.amazon.com/cloudformation',
+        template_url: 'https://example.com/template.yaml',
+        role_name: 'IdentrailReadOnly',
+        stack_name: 'identrail-readonly-connector',
+        policy_hash: 'sha256:example',
+        scope_type: 'single_account',
+        deployment_method: 'cloudformation',
+        onboarding_status: 'launch_ready',
+        target_regions: ['us-east-1'],
+        target_account_ids: [],
+        target_ou_ids: [],
+        excluded_account_ids: [],
+        auto_onboard_new_accounts: false,
+        setup_summary: 'Single AWS account read-only setup through CloudFormation.',
+        next_actions: ['launch_stack', 'validate_role', 'refresh_status'],
+        permission_preview: [],
+        permission_tiers: []
+      })
+      .mockResolvedValueOnce({
+        connection: {
+          ...disconnectedAWS,
+          connector_id: 'aws-manual-1',
+          deployment_method: 'manual',
+          scope_type: 'manual_role',
+          onboarding_status: 'draft'
+        },
+        connector_id: 'aws-manual-1',
+        external_id: 'manual-external-id-after-cloudformation',
+        launch_url: '',
+        template_url: '',
+        identrail_account_id: '999999999999',
+        role_name: '',
+        stack_name: '',
+        policy_hash: '',
+        scope_type: 'manual_role',
+        deployment_method: 'manual',
+        onboarding_status: 'draft',
+        target_regions: ['us-east-1'],
+        target_account_ids: [],
+        target_ou_ids: [],
+        excluded_account_ids: [],
+        auto_onboard_new_accounts: false,
+        setup_summary: 'Existing IAM role setup for one AWS account.',
+        next_actions: ['validate_role', 'refresh_status'],
+        permission_preview: [],
+        permission_tiers: []
+      });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click((await screen.findAllByRole('button', { name: /Connect AWS account/i }))[0]);
+    expect(await screen.findAllByRole('link', { name: /Open AWS stack/i })).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('button', { name: /Existing IAM role/i }));
+
+    expect(screen.getByRole('heading', { level: 4, name: /Use an existing IAM role/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('cloudformation-external-id')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate External ID/i }));
+
+    await waitFor(() =>
+      expect(startAWSConnector).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          connector_id: undefined,
+          scope_type: 'manual_role',
+          deployment_method: 'manual'
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(await screen.findByLabelText('External ID')).toHaveValue('manual-external-id-after-cloudformation');
+  });
+
   it('supports advanced manual AWS role setup without making it the default path', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8241,6 +8241,17 @@ describe('Domain-first app routes', () => {
       ],
       permission_tiers: []
     });
+    const validateAWSConnector = vi.spyOn(api.apiClient, 'validateAWSConnector').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-manual-1',
+        display_name: 'Production AWS',
+        scope_type: 'manual_role',
+        deployment_method: 'manual',
+        role_arn: 'arn:aws:iam::123456789012:role/CustomerManagedIdentrail',
+        onboarding_status: 'connected'
+      }
+    });
 
     const { ProductAWSConnectPage } = await import('./productShell');
 
@@ -8394,6 +8405,126 @@ describe('Domain-first app routes', () => {
         }),
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
+    );
+  });
+
+  it('keeps generated manual AWS setup details after refreshing permission health', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    const getAWSProjectConnection = vi
+      .spyOn(api.apiClient, 'getAWSProjectConnection')
+      .mockResolvedValue({ connection: disconnectedAWS });
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-manual-1',
+        display_name: 'Production AWS',
+        scope_type: 'manual_role',
+        deployment_method: 'manual',
+        onboarding_status: 'draft',
+        setup_summary: 'Existing IAM role setup for one AWS account.',
+        next_actions: ['validate_role', 'refresh_status']
+      },
+      connector_id: 'aws-manual-1',
+      external_id: 'manual-external-id-to-keep',
+      launch_url: '',
+      template_url: '',
+      identrail_account_id: '999999999999',
+      role_name: '',
+      stack_name: '',
+      policy_hash: '',
+      scope_type: 'manual_role',
+      deployment_method: 'manual',
+      onboarding_status: 'draft',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: [],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: false,
+      setup_summary: 'Existing IAM role setup for one AWS account.',
+      next_actions: ['validate_role', 'refresh_status'],
+      permission_preview: [
+        { service: 'IAM', actions: ['iam:GetRole'], resources: ['*'], reason: 'Inspect role metadata.' }
+      ],
+      permission_tiers: []
+    });
+    const validateAWSConnector = vi.spyOn(api.apiClient, 'validateAWSConnector').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-manual-1',
+        display_name: 'Production AWS',
+        scope_type: 'manual_role',
+        deployment_method: 'manual',
+        role_arn: 'arn:aws:iam::123456789012:role/CustomerManagedIdentrail',
+        onboarding_status: 'connected'
+      }
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Existing IAM role/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Generate External ID/i }));
+    expect(await screen.findByLabelText('External ID')).toHaveValue('manual-external-id-to-keep');
+    fireEvent.change(screen.getByLabelText('Role ARN'), {
+      target: { value: 'arn:aws:iam::123456789012:role/CustomerManagedIdentrail' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Validate role/i }));
+    await waitFor(() =>
+      expect(validateAWSConnector).toHaveBeenCalledWith(
+        'aws-manual-1',
+        expect.objectContaining({
+          external_id: 'manual-external-id-to-keep',
+          role_arn: 'arn:aws:iam::123456789012:role/CustomerManagedIdentrail'
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+
+    getAWSProjectConnection.mockResolvedValueOnce({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-manual-1',
+        display_name: 'Production AWS',
+        scope_type: 'manual_role',
+        deployment_method: 'manual',
+        role_arn: 'arn:aws:iam::123456789012:role/CustomerManagedIdentrail',
+        onboarding_status: 'connected',
+        setup_summary: 'Existing IAM role setup for one AWS account.',
+        next_actions: ['validate_role', 'refresh_status']
+      }
+    });
+    const refreshButtons = screen.getAllByRole('button', { name: /Refresh status/i });
+    fireEvent.click(refreshButtons[refreshButtons.length - 1]);
+
+    await waitFor(() => expect(getAWSProjectConnection).toHaveBeenCalledTimes(2));
+    expect(screen.getByLabelText('External ID')).toHaveValue('manual-external-id-to-keep');
+    expect(screen.getByLabelText('Role ARN')).toHaveValue('arn:aws:iam::123456789012:role/CustomerManagedIdentrail');
+    expect(String((screen.getByLabelText('Trust policy') as HTMLTextAreaElement).value)).toContain(
+      'manual-external-id-to-keep'
     );
   });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8408,6 +8408,154 @@ describe('Domain-first app routes', () => {
     );
   });
 
+  it('uses the selected AWS partition in manual trust policies', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-manual-1',
+        scope_type: 'manual_role',
+        deployment_method: 'manual',
+        onboarding_status: 'draft'
+      },
+      connector_id: 'aws-manual-1',
+      external_id: 'manual-govcloud-external-id',
+      launch_url: '',
+      template_url: '',
+      identrail_account_id: '999999999999',
+      role_name: '',
+      stack_name: '',
+      policy_hash: '',
+      scope_type: 'manual_role',
+      deployment_method: 'manual',
+      onboarding_status: 'draft',
+      target_regions: ['us-gov-west-1'],
+      target_account_ids: [],
+      target_ou_ids: [],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: false,
+      setup_summary: 'Existing IAM role setup for one AWS account.',
+      next_actions: ['validate_role', 'refresh_status'],
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Existing IAM role/i }));
+    fireEvent.change(screen.getByLabelText('Home region'), { target: { value: 'us-gov-west-1' } });
+    fireEvent.click(screen.getByRole('button', { name: /Generate External ID/i }));
+
+    expect(await screen.findByLabelText('External ID')).toHaveValue('manual-govcloud-external-id');
+    const trustPolicy = String((screen.getByLabelText('Trust policy') as HTMLTextAreaElement).value);
+    expect(trustPolicy).toContain('arn:aws-us-gov:iam::999999999999:root');
+
+    fireEvent.change(screen.getByLabelText('Role ARN'), {
+      target: { value: 'arn:aws-cn:iam::123456789012:role/CustomerManagedIdentrail' }
+    });
+    expect(String((screen.getByLabelText('Trust policy') as HTMLTextAreaElement).value)).toContain(
+      'arn:aws-cn:iam::999999999999:root'
+    );
+  });
+
+  it('lets operators return to CloudFormation after generating a manual External ID', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-manual-1',
+        scope_type: 'manual_role',
+        deployment_method: 'manual',
+        onboarding_status: 'draft'
+      },
+      connector_id: 'aws-manual-1',
+      external_id: 'manual-external-id-to-clear',
+      launch_url: '',
+      template_url: '',
+      identrail_account_id: '999999999999',
+      role_name: '',
+      stack_name: '',
+      policy_hash: '',
+      scope_type: 'manual_role',
+      deployment_method: 'manual',
+      onboarding_status: 'draft',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: [],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: false,
+      setup_summary: 'Existing IAM role setup for one AWS account.',
+      next_actions: ['validate_role', 'refresh_status'],
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Existing IAM role/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Generate External ID/i }));
+    expect(await screen.findByLabelText('External ID')).toHaveValue('manual-external-id-to-clear');
+
+    fireEvent.click(screen.getByRole('button', { name: /This AWS account/i }));
+
+    expect(screen.getByRole('heading', { level: 4, name: /Connect with CloudFormation/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Connect AWS account/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('manual-external-id-to-clear')).not.toBeInTheDocument();
+  });
+
   it('keeps generated manual AWS setup details after refreshing permission health', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20432,6 +20432,7 @@ export function ProductAWSConnectPage() {
   const awsPollRequestRef = useRef(0);
   const awsValidationRequestRef = useRef(0);
   const awsSetupModeTouchedRef = useRef(false);
+  const awsSetupModeRef = useRef<AWSSetupMode>('cloudformation');
   const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
   const scopeKey = scope ? `${scope.tenantID}::${scope.workspaceID}` : '';
   const scopeKeyRef = useRef(scopeKey);
@@ -20470,20 +20471,22 @@ export function ProductAWSConnectPage() {
           return;
         }
         setConnection(response.connection);
-        setAWSSetupMode((current) =>
-          awsSetupModeTouchedRef.current
-            ? current
-            : response.connection.deployment_method === 'manual'
-              ? 'manual'
-              : 'cloudformation'
-        );
+        const responseSetupMode = response.connection.deployment_method === 'manual' ? 'manual' : 'cloudformation';
+        const preserveManualDraft = awsSetupModeTouchedRef.current
+          ? awsSetupModeRef.current === 'manual'
+          : responseSetupMode === 'manual';
+        setAWSSetupMode((current) => {
+          const next = awsSetupModeTouchedRef.current ? current : responseSetupMode;
+          awsSetupModeRef.current = next;
+          return next;
+        });
         setAWSForm((current) => ({
           ...current,
-          roleARN: response.connection.role_arn ?? '',
-          externalID: '',
+          roleARN: response.connection.role_arn ?? (preserveManualDraft ? current.roleARN : ''),
+          externalID: preserveManualDraft ? current.externalID : '',
           region: response.connection.region ?? 'us-east-1',
           displayName: response.connection.display_name ?? '',
-          sessionName: 'identrail-connector-validation'
+          sessionName: preserveManualDraft ? current.sessionName : 'identrail-connector-validation'
         }));
       } catch (error) {
         if (isStale()) {
@@ -20590,6 +20593,7 @@ export function ProductAWSConnectPage() {
     setErrorMessage('');
     setAWSSetupMessage('');
     awsSetupModeTouchedRef.current = false;
+    awsSetupModeRef.current = 'cloudformation';
     setAWSSetupMode('cloudformation');
     setAWSCopiedField('');
     setBaseline(null);
@@ -20673,6 +20677,7 @@ export function ProductAWSConnectPage() {
 
   const chooseAWSSetupMode = (mode: AWSSetupMode) => {
     awsSetupModeTouchedRef.current = true;
+    awsSetupModeRef.current = mode;
     setAWSSetupMode(mode);
     setAWSSetupMessage('');
     setErrorMessage('');
@@ -20729,6 +20734,7 @@ export function ProductAWSConnectPage() {
       }));
       setConnection(response.connection);
       awsSetupModeTouchedRef.current = true;
+      awsSetupModeRef.current = 'cloudformation';
       setAWSSetupMode('cloudformation');
       setSuccessMessage('AWS CloudFormation launch is ready. Open the stack, then refresh status or validate the role.');
       if (typeof window !== 'undefined' && !/jsdom/i.test(window.navigator.userAgent)) {
@@ -20798,6 +20804,7 @@ export function ProductAWSConnectPage() {
       }));
       setConnection(response.connection);
       awsSetupModeTouchedRef.current = true;
+      awsSetupModeRef.current = 'manual';
       setAWSSetupMode('manual');
       setSuccessMessage('Manual setup is ready. Add the trust policy in AWS, then validate the role.');
     } catch (error) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20672,14 +20672,19 @@ export function ProductAWSConnectPage() {
   const statusTone = awsDomainTone(connection, loadingConnection || refreshingConnection || environmentScope.loading);
   const baselineTone = awsBaselineTone(baseline, baselineLoading || environmentScope.loading);
   const canSubmit = !submitting && !loadingConnection && Boolean(selectedEnvironmentID);
-  const activeConnectorID = awsCloudFormationStart?.connector_id ?? connection?.connector_id ?? '';
+  const manualAWSStart = awsCloudFormationStart?.deployment_method === 'manual' ? awsCloudFormationStart : null;
+  const cloudFormationAWSStart =
+    awsCloudFormationStart && awsCloudFormationStart.deployment_method !== 'manual' ? awsCloudFormationStart : null;
   const isManualSetup =
     awsSetupMode === 'manual' ||
-    awsCloudFormationStart?.deployment_method === 'manual';
+    Boolean(manualAWSStart);
+  const activeConnectorID = isManualSetup
+    ? manualAWSStart?.connector_id ?? (connection?.deployment_method === 'manual' ? connection.connector_id : '') ?? ''
+    : cloudFormationAWSStart?.connector_id ?? (connection?.deployment_method !== 'manual' ? connection?.connector_id : '') ?? '';
   const canValidateRole = Boolean(normalizeValue(awsForm.roleARN)) && (!isManualSetup || Boolean(activeConnectorID));
   const selectedAWSRegion = normalizeValue(awsForm.region) || 'us-east-1';
   const manualExternalID = normalizeValue(awsForm.externalID);
-  const manualIdentrailAccountID = normalizeValue(awsCloudFormationStart?.identrail_account_id);
+  const manualIdentrailAccountID = normalizeValue(manualAWSStart?.identrail_account_id);
   const manualTrustPolicy = buildAWSManualTrustPolicy(
     manualIdentrailAccountID,
     manualExternalID,
@@ -20699,7 +20704,10 @@ export function ProductAWSConnectPage() {
     awsSetupModeTouchedRef.current = true;
     awsSetupModeRef.current = mode;
     setAWSSetupMode(mode);
-    if (mode === 'cloudformation' && awsCloudFormationStart?.deployment_method === 'manual') {
+    const switchingAcrossPreparedSetup =
+      (mode === 'cloudformation' && Boolean(manualAWSStart)) ||
+      (mode === 'manual' && Boolean(cloudFormationAWSStart));
+    if (switchingAcrossPreparedSetup) {
       setAWSCloudFormationStart(null);
       setAWSPermissionPreview([]);
       setAWSPermissionTiers([]);
@@ -21009,7 +21017,7 @@ export function ProductAWSConnectPage() {
     }
     return bits.join(' · ');
   })();
-  const launchURL = awsCloudFormationStart?.launch_url ?? connection?.launch_url ?? '';
+  const launchURL = cloudFormationAWSStart?.launch_url ?? connection?.launch_url ?? '';
   const hasConnectorSetup = Boolean(awsCloudFormationStart || connection?.connector_id);
   const hasRoleOnlyConnection = Boolean(connection?.role_arn && !connection?.connector_id && !awsCloudFormationStart);
   const showOperationalPanels = Boolean(
@@ -21191,7 +21199,7 @@ export function ProductAWSConnectPage() {
                         <h4>Connect with CloudFormation</h4>
                         <p>Identrail creates a read-only role with a trust guard for this environment.</p>
                       </div>
-                      {awsCloudFormationStart ? <span>Launch ready</span> : <span>Read-only</span>}
+                      {cloudFormationAWSStart ? <span>Launch ready</span> : <span>Read-only</span>}
                     </div>
                     <div className="idt-aws-permission-summary" aria-label="AWS permission summary">
                       <span>Read-only discovery across IAM, STS, CloudTrail, Access Analyzer, compute, storage, and secrets.</span>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -417,8 +417,24 @@ const AWS_ROLE_ARN_PATTERN = /^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role\/
 const AWS_REGION_PATTERN = /^[a-z]{2}(-gov)?-[a-z]+-[0-9]$/;
 
 type AWSSetupMode = 'cloudformation' | 'manual';
+type AWSPartition = 'aws' | 'aws-us-gov' | 'aws-cn';
 
-function buildAWSManualTrustPolicy(identrailAccountID: string, externalID: string): string {
+function awsPartitionForManualTrustPolicy(roleARN: string, region: string): AWSPartition {
+  const arnPartition = normalizeValue(roleARN).match(/^arn:(aws|aws-us-gov|aws-cn):iam::/)?.[1] as AWSPartition | undefined;
+  if (arnPartition) {
+    return arnPartition;
+  }
+  const normalizedRegion = normalizeValue(region).toLowerCase();
+  if (normalizedRegion.startsWith('us-gov-')) {
+    return 'aws-us-gov';
+  }
+  if (normalizedRegion.startsWith('cn-')) {
+    return 'aws-cn';
+  }
+  return 'aws';
+}
+
+function buildAWSManualTrustPolicy(identrailAccountID: string, externalID: string, partition: AWSPartition = 'aws'): string {
   const accountID = normalizeValue(identrailAccountID);
   const trustGuard = normalizeValue(externalID);
   if (!accountID || !trustGuard) {
@@ -431,7 +447,7 @@ function buildAWSManualTrustPolicy(identrailAccountID: string, externalID: strin
         {
           Effect: 'Allow',
           Principal: {
-            AWS: `arn:aws:iam::${accountID}:root`
+            AWS: `arn:${partition}:iam::${accountID}:root`
           },
           Action: 'sts:AssumeRole',
           Condition: {
@@ -20664,7 +20680,11 @@ export function ProductAWSConnectPage() {
   const selectedAWSRegion = normalizeValue(awsForm.region) || 'us-east-1';
   const manualExternalID = normalizeValue(awsForm.externalID);
   const manualIdentrailAccountID = normalizeValue(awsCloudFormationStart?.identrail_account_id);
-  const manualTrustPolicy = buildAWSManualTrustPolicy(manualIdentrailAccountID, manualExternalID);
+  const manualTrustPolicy = buildAWSManualTrustPolicy(
+    manualIdentrailAccountID,
+    manualExternalID,
+    awsPartitionForManualTrustPolicy(awsForm.roleARN, selectedAWSRegion)
+  );
 
   const copyAWSManualValue = async (field: 'external-id' | 'trust-policy', value: string) => {
     const text = normalizeValue(value);
@@ -20679,6 +20699,18 @@ export function ProductAWSConnectPage() {
     awsSetupModeTouchedRef.current = true;
     awsSetupModeRef.current = mode;
     setAWSSetupMode(mode);
+    if (mode === 'cloudformation' && awsCloudFormationStart?.deployment_method === 'manual') {
+      setAWSCloudFormationStart(null);
+      setAWSPermissionPreview([]);
+      setAWSPermissionTiers([]);
+      setAWSPreviewOpen(false);
+      setAWSForm((current) => ({
+        ...current,
+        roleARN: '',
+        externalID: '',
+        sessionName: 'identrail-connector-validation'
+      }));
+    }
     setAWSSetupMessage('');
     setErrorMessage('');
     setSuccessMessage('');

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -415,6 +415,37 @@ const SOURCE_PROFILES: Record<SourceProvider, SourceProfile> = {
 const GITHUB_REPOSITORY_SPLIT_PATTERN = /[\n,]+/;
 const AWS_ROLE_ARN_PATTERN = /^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role\/[A-Za-z0-9+=,.@_/-]{1,512}$/;
 const AWS_REGION_PATTERN = /^[a-z]{2}(-gov)?-[a-z]+-[0-9]$/;
+
+type AWSSetupMode = 'cloudformation' | 'manual';
+
+function buildAWSManualTrustPolicy(identrailAccountID: string, externalID: string): string {
+  const accountID = normalizeValue(identrailAccountID);
+  const trustGuard = normalizeValue(externalID);
+  if (!accountID || !trustGuard) {
+    return '';
+  }
+  return JSON.stringify(
+    {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: {
+            AWS: `arn:aws:iam::${accountID}:root`
+          },
+          Action: 'sts:AssumeRole',
+          Condition: {
+            StringEquals: {
+              'sts:ExternalId': trustGuard
+            }
+          }
+        }
+      ]
+    },
+    null,
+    2
+  );
+}
 const SOURCE_ORDER: SourceProvider[] = [
   ...(FEATURE_CONNECTOR_GITHUB_V2 ? (['github'] as SourceProvider[]) : []),
   'aws',
@@ -20377,6 +20408,8 @@ export function ProductAWSConnectPage() {
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [awsSetupMessage, setAWSSetupMessage] = useState('');
+  const [awsSetupMode, setAWSSetupMode] = useState<AWSSetupMode>('cloudformation');
+  const [awsCopiedField, setAWSCopiedField] = useState('');
   const [baseline, setBaseline] = useState<AWSPlatformBaselineResult | null>(null);
   const [baselineLoading, setBaselineLoading] = useState(false);
   const [baselineError, setBaselineError] = useState('');
@@ -20398,6 +20431,7 @@ export function ProductAWSConnectPage() {
   const awsStartRequestRef = useRef(0);
   const awsPollRequestRef = useRef(0);
   const awsValidationRequestRef = useRef(0);
+  const awsSetupModeTouchedRef = useRef(false);
   const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
   const scopeKey = scope ? `${scope.tenantID}::${scope.workspaceID}` : '';
   const scopeKeyRef = useRef(scopeKey);
@@ -20436,11 +20470,20 @@ export function ProductAWSConnectPage() {
           return;
         }
         setConnection(response.connection);
+        setAWSSetupMode((current) =>
+          awsSetupModeTouchedRef.current
+            ? current
+            : response.connection.deployment_method === 'manual'
+              ? 'manual'
+              : 'cloudformation'
+        );
         setAWSForm((current) => ({
           ...current,
           roleARN: response.connection.role_arn ?? '',
+          externalID: '',
           region: response.connection.region ?? 'us-east-1',
-          displayName: response.connection.display_name ?? ''
+          displayName: response.connection.display_name ?? '',
+          sessionName: 'identrail-connector-validation'
         }));
       } catch (error) {
         if (isStale()) {
@@ -20546,6 +20589,9 @@ export function ProductAWSConnectPage() {
     setSuccessMessage('');
     setErrorMessage('');
     setAWSSetupMessage('');
+    awsSetupModeTouchedRef.current = false;
+    setAWSSetupMode('cloudformation');
+    setAWSCopiedField('');
     setBaseline(null);
     setBaselineError('');
     setSubmitting(false);
@@ -20558,7 +20604,8 @@ export function ProductAWSConnectPage() {
       roleARN: '',
       externalID: '',
       region: 'us-east-1',
-      displayName: ''
+      displayName: '',
+      sessionName: 'identrail-connector-validation'
     }));
     void refreshConnection('initial');
     void refreshBaseline();
@@ -20606,8 +20653,32 @@ export function ProductAWSConnectPage() {
   const baselineTone = awsBaselineTone(baseline, baselineLoading || environmentScope.loading);
   const canSubmit = !submitting && !loadingConnection && Boolean(selectedEnvironmentID);
   const activeConnectorID = awsCloudFormationStart?.connector_id ?? connection?.connector_id ?? '';
-  const canValidateRole = Boolean(normalizeValue(awsForm.roleARN));
+  const isManualSetup =
+    awsSetupMode === 'manual' ||
+    awsCloudFormationStart?.deployment_method === 'manual';
+  const canValidateRole = Boolean(normalizeValue(awsForm.roleARN)) && (!isManualSetup || Boolean(activeConnectorID));
   const selectedAWSRegion = normalizeValue(awsForm.region) || 'us-east-1';
+  const manualExternalID = normalizeValue(awsForm.externalID);
+  const manualIdentrailAccountID = normalizeValue(awsCloudFormationStart?.identrail_account_id);
+  const manualTrustPolicy = buildAWSManualTrustPolicy(manualIdentrailAccountID, manualExternalID);
+
+  const copyAWSManualValue = async (field: 'external-id' | 'trust-policy', value: string) => {
+    const text = normalizeValue(value);
+    if (!text || typeof navigator === 'undefined' || !navigator.clipboard) {
+      return;
+    }
+    await navigator.clipboard.writeText(text);
+    setAWSCopiedField(field);
+  };
+
+  const chooseAWSSetupMode = (mode: AWSSetupMode) => {
+    awsSetupModeTouchedRef.current = true;
+    setAWSSetupMode(mode);
+    setAWSSetupMessage('');
+    setErrorMessage('');
+    setSuccessMessage('');
+    setAWSCopiedField('');
+  };
 
   const handleAWSCloudFormationStart = async () => {
     if (!selectedEnvironmentID) {
@@ -20657,6 +20728,8 @@ export function ProductAWSConnectPage() {
         displayName: current.displayName || response.connection.display_name || ''
       }));
       setConnection(response.connection);
+      awsSetupModeTouchedRef.current = true;
+      setAWSSetupMode('cloudformation');
       setSuccessMessage('AWS CloudFormation launch is ready. Open the stack, then refresh status or validate the role.');
       if (typeof window !== 'undefined' && !/jsdom/i.test(window.navigator.userAgent)) {
         window.open(response.launch_url, '_blank', 'noopener,noreferrer');
@@ -20667,6 +20740,71 @@ export function ProductAWSConnectPage() {
       }
       const message = formatAWSConnectorSetupError(error);
       setAWSSetupMessage(message);
+    } finally {
+      if (!isStale()) {
+        setSubmitting(false);
+      }
+    }
+  };
+
+  const handleAWSManualStart = async () => {
+    if (!selectedEnvironmentID) {
+      setErrorMessage('Choose an environment before preparing manual AWS setup.');
+      return;
+    }
+    setSubmitting(true);
+    setSuccessMessage('');
+    setErrorMessage('');
+    setAWSSetupMessage('');
+    setAWSCopiedField('');
+    const requestID = ++awsStartRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const requestScopeKey = scopeKeyRef.current;
+    const region = normalizeValue(awsForm.region) || 'us-east-1';
+    if (!AWS_REGION_PATTERN.test(region)) {
+      setSubmitting(false);
+      setErrorMessage('Enter a valid AWS region, for example us-east-1.');
+      return;
+    }
+    const isStale = () =>
+      requestID !== awsStartRequestRef.current ||
+      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+      scopeKeyRef.current !== requestScopeKey;
+    try {
+      const response = await apiClient.startAWSConnector(
+        {
+          workspace_id: scope.workspaceID,
+          project_id: requestEnvironmentID,
+          connector_id: activeConnectorID || undefined,
+          display_name: normalizeValue(awsForm.displayName) || undefined,
+          region,
+          scope_type: 'manual_role',
+          deployment_method: 'manual'
+        },
+        buildProductAuthContext(scope)
+      );
+      if (isStale()) {
+        return;
+      }
+      setAWSCloudFormationStart(response);
+      setAWSPermissionPreview(response.permission_preview);
+      setAWSPermissionTiers(response.permission_tiers ?? []);
+      setAWSForm((current) => ({
+        ...current,
+        externalID: response.external_id,
+        roleARN: current.roleARN || response.connection.role_arn || '',
+        region: current.region || response.connection.region || 'us-east-1',
+        displayName: current.displayName || response.connection.display_name || ''
+      }));
+      setConnection(response.connection);
+      awsSetupModeTouchedRef.current = true;
+      setAWSSetupMode('manual');
+      setSuccessMessage('Manual setup is ready. Add the trust policy in AWS, then validate the role.');
+    } catch (error) {
+      if (isStale()) {
+        return;
+      }
+      setAWSSetupMessage(formatAWSConnectorSetupError(error));
     } finally {
       if (!isStale()) {
         setSubmitting(false);
@@ -20759,7 +20897,11 @@ export function ProductAWSConnectPage() {
       };
       const auth = buildProductAuthContext(scope);
       if (!requestConnectorID) {
-        throw new Error('Start CloudFormation setup before validating the AWS role.');
+        throw new Error(
+          isManualSetup
+            ? 'Generate the manual setup External ID before validating the role.'
+            : 'Start CloudFormation setup before validating the AWS role.'
+        );
       }
       const response = await apiClient.validateAWSConnector(
         requestConnectorID,
@@ -20860,6 +21002,12 @@ export function ProductAWSConnectPage() {
     if (hasRoleOnlyConnection) {
       return 'This environment has a saved IAM role. Start CloudFormation setup to move it onto the connector flow.';
     }
+    if (isManualSetup && !manualExternalID && !connectedNow) {
+      return 'Generate the External ID, add it to your IAM trust policy, then validate the role.';
+    }
+    if (isManualSetup && manualExternalID && !connectedNow) {
+      return 'Add the trust policy in AWS, paste the role ARN, then validate the role.';
+    }
     if ((connectedNow || hasConnectorSetup) && connection?.setup_summary) {
       return connection.setup_summary;
     }
@@ -20931,20 +21079,34 @@ export function ProductAWSConnectPage() {
                 <strong>All accounts</strong>
                 <small>Coming later</small>
               </div>
-              <div className="idt-aws-scope-option is-selected" role="listitem" aria-current="true">
-                <span>Single account</span>
-                <strong>This AWS account</strong>
-                <small>Available now</small>
+              <div className="idt-aws-scope-option-shell" role="listitem">
+                <button
+                  className={`idt-aws-scope-option ${!isManualSetup ? 'is-selected' : ''}`}
+                  type="button"
+                  aria-current={!isManualSetup ? 'true' : undefined}
+                  onClick={() => chooseAWSSetupMode('cloudformation')}
+                >
+                  <span>Single account</span>
+                  <strong>This AWS account</strong>
+                  <small>Available now</small>
+                </button>
               </div>
               <div className="idt-aws-scope-option is-planned" role="listitem" aria-disabled="true">
                 <span>Selected scope</span>
                 <strong>OUs or accounts</strong>
                 <small>Coming later</small>
               </div>
-              <div className="idt-aws-scope-option is-planned" role="listitem" aria-disabled="true">
-                <span>Advanced</span>
-                <strong>Existing IAM role</strong>
-                <small>Manual setup later</small>
+              <div className="idt-aws-scope-option-shell" role="listitem">
+                <button
+                  className={`idt-aws-scope-option ${isManualSetup ? 'is-selected' : ''}`}
+                  type="button"
+                  aria-current={isManualSetup ? 'true' : undefined}
+                  onClick={() => chooseAWSSetupMode('manual')}
+                >
+                  <span>Advanced</span>
+                  <strong>Existing IAM role</strong>
+                  <small>Use your change process</small>
+                </button>
               </div>
             </div>
 
@@ -20981,51 +21143,122 @@ export function ProductAWSConnectPage() {
                 </div>
               </div>
 
-              <div className="idt-aws-wizard-step">
-                <div className="idt-aws-step-index" aria-hidden="true">2</div>
-                <div className="idt-aws-step-body">
-                  <div className="idt-aws-step-heading">
-                    <div>
-                      <h4>Connect with CloudFormation</h4>
-                      <p>Identrail creates a read-only role with a trust guard for this environment.</p>
+              {!isManualSetup ? (
+                <div className="idt-aws-wizard-step">
+                  <div className="idt-aws-step-index" aria-hidden="true">2</div>
+                  <div className="idt-aws-step-body">
+                    <div className="idt-aws-step-heading">
+                      <div>
+                        <h4>Connect with CloudFormation</h4>
+                        <p>Identrail creates a read-only role with a trust guard for this environment.</p>
+                      </div>
+                      {awsCloudFormationStart ? <span>Launch ready</span> : <span>Read-only</span>}
                     </div>
-                    {awsCloudFormationStart ? <span>Launch ready</span> : <span>Read-only</span>}
-                  </div>
-                  <div className="idt-aws-permission-summary" aria-label="AWS permission summary">
-                    <span>Read-only discovery across IAM, STS, CloudTrail, Access Analyzer, compute, storage, and secrets.</span>
-                    <span>No write, delete, or remediation permissions.</span>
-                    <span>Unique trust guard generated for this environment.</span>
-                  </div>
-                  {awsSetupMessage ? (
-                    <p role="status" className="idt-aws-setup-note">
-                      {awsSetupMessage}
-                    </p>
-                  ) : null}
-                  <div className="idt-source-actions">
-                    <button
-                      className="idt-btn idt-btn-primary"
-                      type="button"
-                      onClick={handleAWSCloudFormationStart}
-                      disabled={!canSubmit}
-                    >
-                      {submitting ? 'Preparing...' : launchURL ? 'Prepare stack again' : 'Connect AWS account'}
-                    </button>
-                    {launchURL ? (
-                      <a className="idt-btn idt-btn-dark" href={launchURL} target="_blank" rel="noreferrer">
-                        <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
-                        <span>Open AWS stack</span>
-                      </a>
+                    <div className="idt-aws-permission-summary" aria-label="AWS permission summary">
+                      <span>Read-only discovery across IAM, STS, CloudTrail, Access Analyzer, compute, storage, and secrets.</span>
+                      <span>No write, delete, or remediation permissions.</span>
+                      <span>Unique trust guard generated for this environment.</span>
+                    </div>
+                    {awsSetupMessage ? (
+                      <p role="status" className="idt-aws-setup-note">
+                        {awsSetupMessage}
+                      </p>
                     ) : null}
-                    {awsPermissionPreview.length > 0 ? (
-                      <button className="idt-btn idt-btn-ghost" type="button" onClick={() => setAWSPreviewOpen(true)}>
-                        Preview permissions
+                    <div className="idt-source-actions">
+                      <button
+                        className="idt-btn idt-btn-primary"
+                        type="button"
+                        onClick={handleAWSCloudFormationStart}
+                        disabled={!canSubmit}
+                      >
+                        {submitting ? 'Preparing...' : launchURL ? 'Prepare stack again' : 'Connect AWS account'}
                       </button>
-                    ) : null}
+                      {launchURL ? (
+                        <a className="idt-btn idt-btn-dark" href={launchURL} target="_blank" rel="noreferrer">
+                          <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
+                          <span>Open AWS stack</span>
+                        </a>
+                      ) : null}
+                      {awsPermissionPreview.length > 0 ? (
+                        <button className="idt-btn idt-btn-ghost" type="button" onClick={() => setAWSPreviewOpen(true)}>
+                          Preview permissions
+                        </button>
+                      ) : null}
+                    </div>
                   </div>
                 </div>
-              </div>
+              ) : (
+                <div className="idt-aws-wizard-step idt-aws-manual-step">
+                  <div className="idt-aws-step-index" aria-hidden="true">2</div>
+                  <div className="idt-aws-step-body">
+                    <div className="idt-aws-step-heading">
+                      <div>
+                        <h4>Use an existing IAM role</h4>
+                        <p>For teams that manage IAM through Terraform, CDK, tickets, or change windows.</p>
+                      </div>
+                      <span>Manual</span>
+                    </div>
+                    <div className="idt-aws-permission-summary" aria-label="Manual AWS permission summary">
+                      <span>Use the same read-only permissions as the one-click stack.</span>
+                      <span>Add an External ID condition to the role trust policy.</span>
+                      <span>Identrail never asks for AWS access keys.</span>
+                    </div>
+                    {awsSetupMessage ? (
+                      <p role="status" className="idt-aws-setup-note">
+                        {awsSetupMessage}
+                      </p>
+                    ) : null}
+                    {!manualExternalID ? (
+                      <div className="idt-source-actions">
+                        <button
+                          className="idt-btn idt-btn-secondary"
+                          type="button"
+                          onClick={handleAWSManualStart}
+                          disabled={!canSubmit}
+                        >
+                          {submitting ? 'Preparing...' : 'Generate External ID'}
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="idt-aws-manual-guidance" aria-label="Manual IAM role guidance">
+                        <label>
+                          External ID
+                          <div className="idt-aws-copy-row">
+                            <input value={manualExternalID} readOnly />
+                            <button
+                              className="idt-btn idt-btn-ghost"
+                              type="button"
+                              onClick={() => void copyAWSManualValue('external-id', manualExternalID)}
+                            >
+                              {awsCopiedField === 'external-id' ? 'Copied' : 'Copy'}
+                            </button>
+                          </div>
+                        </label>
+                        {manualTrustPolicy ? (
+                          <label>
+                            Trust policy
+                            <textarea value={manualTrustPolicy} readOnly rows={10} />
+                            <button
+                              className="idt-btn idt-btn-ghost"
+                              type="button"
+                              onClick={() => void copyAWSManualValue('trust-policy', manualTrustPolicy)}
+                            >
+                              {awsCopiedField === 'trust-policy' ? 'Copied trust policy' : 'Copy trust policy'}
+                            </button>
+                          </label>
+                        ) : null}
+                        {awsPermissionPreview.length > 0 ? (
+                          <button className="idt-btn idt-btn-ghost" type="button" onClick={() => setAWSPreviewOpen(true)}>
+                            Preview permissions
+                          </button>
+                        ) : null}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
 
-              {hasConnectorSetup ? (
+              {hasConnectorSetup && !isManualSetup ? (
                 <div className="idt-aws-wizard-step">
                   <div className="idt-aws-step-index" aria-hidden="true">3</div>
                   <div className="idt-aws-step-body">
@@ -21041,7 +21274,7 @@ export function ProductAWSConnectPage() {
                       <input
                         value={awsForm.roleARN}
                         onChange={(event) => setAWSForm((current) => ({ ...current, roleARN: event.target.value }))}
-                        placeholder="arn:aws:iam::123456789012:role/IdentrailReadOnly"
+                        placeholder="Paste the role ARN from the stack output"
                         required={canValidateRole}
                       />
                     </label>
@@ -21058,6 +21291,51 @@ export function ProductAWSConnectPage() {
                   </div>
                 </div>
               ) : null}
+
+              {isManualSetup && manualExternalID ? (
+                <div className="idt-aws-wizard-step">
+                  <div className="idt-aws-step-index" aria-hidden="true">3</div>
+                  <div className="idt-aws-step-body">
+                    <div className="idt-aws-step-heading">
+                      <div>
+                        <h4>Validate the role</h4>
+                        <p>Paste the role ARN after your IAM change is live.</p>
+                      </div>
+                      <span>{connectionHealth(connection ?? undefined)}</span>
+                    </div>
+                    <label>
+                      Role ARN
+                      <input
+                        value={awsForm.roleARN}
+                        onChange={(event) => setAWSForm((current) => ({ ...current, roleARN: event.target.value }))}
+                        placeholder="Paste the IAM role ARN"
+                        required={canValidateRole}
+                      />
+                    </label>
+                    <details className="idt-aws-manual-advanced">
+                      <summary>Advanced details</summary>
+                      <label>
+                        Session name
+                        <input
+                          value={awsForm.sessionName}
+                          onChange={(event) => setAWSForm((current) => ({ ...current, sessionName: event.target.value }))}
+                          placeholder="identrail-connector-validation"
+                        />
+                      </label>
+                    </details>
+                    <div className="idt-source-actions">
+                      {activeConnectorID ? (
+                        <button className="idt-btn idt-btn-secondary" type="button" onClick={handleAWSPoll} disabled={submitting}>
+                          {submitting ? 'Refreshing...' : 'Refresh status'}
+                        </button>
+                      ) : null}
+                      <button className="idt-btn idt-btn-primary" type="submit" disabled={!canSubmit || !canValidateRole}>
+                        {submitting ? 'Validating...' : 'Validate role'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
             </form>
           </section>
 
@@ -21068,7 +21346,7 @@ export function ProductAWSConnectPage() {
               <dl className="idt-source-meta">
                 <div>
                   <dt>Scope</dt>
-                  <dd>Single account</dd>
+                  <dd>{isManualSetup ? 'Existing IAM role' : 'Single account'}</dd>
                 </div>
                 <div>
                   <dt>Health</dt>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -23975,6 +23975,10 @@ html[data-theme='light'] .idt-app-shell-screen select {
   gap: 0.65rem;
 }
 
+.idt-aws-scope-option-shell {
+  display: contents;
+}
+
 .idt-aws-scope-option {
   display: grid;
   gap: 0.22rem;
@@ -23985,6 +23989,8 @@ html[data-theme='light'] .idt-app-shell-screen select {
   padding: 0.72rem;
   background: #050505;
   color: var(--app-muted);
+  cursor: pointer;
+  font: inherit;
   text-align: left;
 }
 
@@ -24017,6 +24023,48 @@ html[data-theme='light'] .idt-app-shell-screen select {
 .idt-aws-scope-option.is-planned {
   cursor: not-allowed;
   opacity: 0.72;
+}
+
+.idt-aws-manual-guidance {
+  display: grid;
+  gap: 0.78rem;
+}
+
+.idt-aws-copy-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+  align-items: end;
+}
+
+.idt-aws-manual-guidance textarea {
+  width: 100%;
+  min-height: 13rem;
+  resize: vertical;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.78rem;
+  background: #050505;
+  color: #d9f9e6;
+  font: 0.78rem/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-manual-advanced {
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.66rem;
+  background: #050505;
+}
+
+.idt-aws-manual-advanced summary {
+  cursor: pointer;
+  color: #ffffff;
+  font-weight: 850;
+}
+
+.idt-aws-manual-advanced label {
+  margin-top: 0.65rem;
 }
 
 .idt-aws-wizard-step {
@@ -24746,7 +24794,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge
 
   .idt-aws-scope-options,
   .idt-aws-wizard-step,
-  .idt-aws-step-heading {
+  .idt-aws-step-heading,
+  .idt-aws-copy-row {
     grid-template-columns: 1fr;
   }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -23976,7 +23976,12 @@ html[data-theme='light'] .idt-app-shell-screen select {
 }
 
 .idt-aws-scope-option-shell {
-  display: contents;
+  min-width: 0;
+}
+
+.idt-aws-scope-option-shell .idt-aws-scope-option {
+  width: 100%;
+  height: 100%;
 }
 
 .idt-aws-scope-option {


### PR DESCRIPTION
## Summary

Adds the hardened Advanced manual IAM role setup path for AWS Connect.

## Why

Some teams cannot launch the one-click CloudFormation connector because IAM roles are managed through Terraform, CDK, ticketed change windows, or central platform controls. This gives them a safe manual path without putting raw role ARN fields on the default AWS connect screen.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Implemented scope:

- Adds `manual_role` + `manual` handling to the AWS connector start API.
- Generates and stores a connector-scoped encrypted External ID for manual setup.
- Returns `identrail_account_id` only in the setup response so the app can render a copyable trust policy.
- Keeps status, poll, and validate responses from exposing the External ID.
- Supports validation using the stored connector External ID when the request omits it.
- Moves manual role setup into the Advanced AWS Connect UI path.
- Shows External ID, trust policy, permission preview, role ARN validation, and optional session name only after the operator starts manual setup.
- Clears manual sensitive drafts on environment/scope changes and guards late status refreshes from overriding an operator's selected setup path.
- Updates API client types, OpenAPI contract, and AWS connector docs.

Risk level: medium. This touches the AWS connector onboarding flow and UI state, but the executable CloudFormation default path remains unchanged and is covered by existing plus updated tests.

## Validation

```bash
go test ./internal/api -run 'TestOpenAPIContractIncludesCurrentSchemas|TestAWSConnectorManualStartAndValidateUsesStoredExternalID|TestAWSConnectorStart|TestRouterAWSConnectorValidationErrors|TestNormalizeAWSConnectorSetupContract'
npm run test --prefix web -- --run src/api/client.test.ts src/productShell.test.tsx -t 'AWS connector|AWS connect|manual AWS|manual role|advanced AWS manual|stale AWS|switching environments'
npm run build --prefix web
```

Also performed a local browser/harness pass against the AWS Connect route. That pass exposed a late-refresh mode reset edge, which is now covered by a regression test.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: Local tests, build, API contract check, and browser layout pass.

## Related Issues

Closes #1751

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Advanced manual IAM role setup path for AWS so teams that can’t use CloudFormation can connect with a generated External ID and trust policy. Also hardens the UI to keep the chosen setup mode (CloudFormation vs. manual) stable.

- **New Features**
  - API: Accepts `scope_type: manual_role` with `deployment_method: manual`; generates and encrypts a connector-scoped External ID; start returns the External ID and `identrail_account_id`; poll/status/validate never expose the External ID; validation falls back to the stored External ID if omitted; sets manual-flow next actions; resumes manual setup and recovers a missing External ID envelope; start/validate return sanitized connection fields for setup.
  - UI: Adds an Advanced “Existing IAM role” path with External ID, copyable trust policy (partition-aware: `aws`, `aws-us-gov`, `aws-cn`), permission preview, role ARN validation, and optional session name; isolates setup modes so switching between CloudFormation and manual clears cross-mode prepared state; preserves the manual selection when initial status resolves late and after status refresh; clears manual drafts when switching environments; CloudFormation stays the default path.
  - Docs/OpenAPI/Client: Docs add manual setup examples, trust policy, and the Identrail AWS account ID to trust; OpenAPI exposes `identrail_account_id`; `web` client types updated; tests cover manual start/resume, envelope recovery, partition handling, UI mode isolation, and validation flow.

<sup>Written for commit 538c491d1650e6f8b3f3f44a7766695049525fa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

