### PR TITLE
Integrate GitHub posture findings into lifecycle, trends, and clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Changelog
 
 ## Unreleased
+- Integrate **GitHub posture findings into the repository finding lifecycle,
+  trends, and clusters** (#1709). Posture gaps promoted from GitHub posture
+  collection now age, close, reopen, and roll up like every other durable
+  repository finding instead of behaving like one-off scan output. Posture
+  closure is now gated on the posture source itself rather than on the scan as a
+  whole: a posture finding closes only when a completed, non-truncated deep scan
+  reported its own posture source (`github_repository_posture` or
+  `github_organization_posture`) as `complete` and no longer saw the gap. Scans
+  that never ran posture collection, or whose posture collection was
+  permission-limited, rate-limited, or unavailable, leave posture findings open.
+  Previously an unrelated source failing — a rate-limited Dependabot call, or a
+  code-scanning collector that was simply not configured — marked the whole run
+  partial and blocked closure for every source, which could strand posture
+  findings as permanently open even after the underlying control was fixed.
+  Reappearing gaps reuse their stable lifecycle key and transition to
+  `reopened` while keeping their original first-seen age.
+- Key repository finding clusters by promotion `source` in addition to detector,
+  and expose `source` on cluster responses. Repository-scoped and
+  organization-scoped posture checks intentionally share some detectors (both
+  report `github_secret_scanning_disabled`, for example) but are distinct
+  findings; they previously merged into a single cluster, hiding an
+  organization policy gap behind a repository setting. Clusters for findings
+  without an adapter source keep their existing identity.
 - Replace the first-run **Connect AWS** screen with a scope-first single-account
   setup wizard (#1750). Operators now choose the supported account scope, enter
   a display name and setup region, launch the CloudFormation stack through a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   code-scanning collector that was simply not configured — marked the whole run
   partial and blocked closure for every source, which could strand posture
   findings as permanently open even after the underlying control was fixed.
+  Closure is also decided per check: a gap closes only when GitHub answered that
+  control definitively (`secure`, or `unsupported` because the repository owner
+  is a user account and organization policy no longer applies). A control that
+  is permission-limited, unavailable, unknown, or no longer exposed by the
+  account plan is never treated as fixed, since it was never re-evaluated.
   Reappearing gaps reuse their stable lifecycle key and transition to
   `reopened` while keeping their original first-seen age.
 - Key repository finding clusters by promotion `source` in addition to detector,

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -26027,6 +26027,13 @@ components:
         type: { $ref: "#/components/schemas/FindingType" }
         severity: { $ref: "#/components/schemas/FindingSeverity" }
         detector: { type: string }
+        source:
+          type: string
+          description: >-
+            Adapter source that promoted the findings in this cluster (for
+            example `github_posture` or `github_org_posture`). Clusters are keyed
+            by source in addition to detector, so distinct sources that share one
+            detector stay separate.
         title: { type: string }
         human_summary: { type: string }
         remediation: { type: string }

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -155,6 +155,27 @@ whole:
   branch-protection gap was fixed, and blocking on it would strand posture
   findings as permanently open.
 
+Closure is additionally decided per check, not only per source, because GitHub
+can answer some controls and not others in the same collection. A check only
+closes its finding when GitHub answered it definitively:
+
+| Check state | Closes a prior gap? | Why |
+|---|---|---|
+| `secure` | yes | The control was evaluated and is now configured safely. |
+| `insecure` | no (stays open) | The gap is still present and is re-promoted. |
+| `permission_limited` | no | The GitHub App cannot read the control, so the gap was never re-checked. |
+| `unavailable` / `unknown` | no | GitHub did not return a usable answer for the control. |
+| `unsupported` (`not_an_organization`) | yes | A user-owned repository has no organization policy, so the gap no longer applies. |
+| `unsupported` (plan or availability change) | no | GitHub stopped exposing the control, so the gap was never verified as fixed. Suppress it if the exposure is intentional. |
+
+This matters because a control that cannot be evaluated still promotes a finding
+under the same `lifecycle_key`, but at a confidence and severity the
+GitHub App reportable filter drops. Without per-check gating, that filtered
+finding would look absent from the scan and a real, unverified gap would be
+marked `fixed`. Per-check gating also avoids the opposite failure: a plan that
+permanently lacks one control (GitHub Advanced Security, for example) does not
+stop every other posture finding in that source from closing.
+
 Reappearing posture gaps reuse the same lifecycle key and transition to
 `reopened` while keeping their original `first_seen_at` age.
 

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -107,7 +107,8 @@ Read APIs:
 - repo finding responses expose stable repository, lifecycle, and location fields when available: `repository`, `file_path`, `line_number`, `commit`, `detector`, `line_snippet`, `line_snippet_redacted`, `source_url`, `lifecycle_key`, `lifecycle_status`, `owner`, `first_seen_at`, `last_seen_at`, `fixed_at`, `reopened_at`, `dismissed_at`, and `suppression_expires_at`
 - `source_url` is a direct GitHub blob link pinned to the detected commit when Identrail can derive one
 - repo finding pages include a `summary` object with open, fixed, reopened, suppressed, SLA-aged, and MTTR-ready counts plus owner, detector, and severity rollups
-- grouped cluster responses roll duplicate repo findings into cluster counts with `first_seen_at`, `last_seen_at`, `spread`, and a per-occurrence `members` list
+- grouped cluster responses roll duplicate repo findings into cluster counts with `first_seen_at`, `last_seen_at`, `spread`, `source`, and a per-occurrence `members` list
+- clusters are keyed by promotion `source` in addition to detector, so sources that share one detector (repository and organization posture both report `github_secret_scanning_disabled`) stay in separate clusters
 
 ## Finding Lifecycle
 
@@ -129,6 +130,33 @@ Identrail preserves `first_seen_at` when a finding persists, updates
 no longer sees it, and sets `reopened_at` when a fixed finding returns. Delta,
 quick, changed-path, and truncated scans do not close missing findings because
 they did not inspect the whole repository.
+
+### GitHub Posture Findings
+
+Posture gaps promoted from GitHub posture collection (`adapter_source` of
+`github_posture` or `github_org_posture`) are durable repository findings and
+follow the same lifecycle model. Their `lifecycle_key` is derived from the
+repository, finding type, adapter source, posture scope, and posture check id,
+so it stays stable across scans and never depends on a scan row id.
+
+Posture closure is gated on the posture source rather than on the scan as a
+whole:
+
+- A posture finding closes only when a completed, non-truncated deep scan
+  reported its own posture source (`github_repository_posture` or
+  `github_organization_posture`) as `complete` and no longer observed the gap —
+  because the check became secure or no longer applies.
+- A scan that never ran posture collection (a plain repository scan, for
+  example) leaves posture findings open, since it could not re-observe them.
+- A scan whose posture collection was permission-limited, rate-limited, or
+  unavailable leaves posture findings open.
+- An unrelated source failing (Dependabot or code scanning, for example) no
+  longer blocks posture closure. That source says nothing about whether a
+  branch-protection gap was fixed, and blocking on it would strand posture
+  findings as permanently open.
+
+Reappearing posture gaps reuse the same lifecycle key and transition to
+`reopened` while keeping their original `first_seen_at` age.
 
 Operational guidance:
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1904,9 +1904,12 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	}
 	result = applyRepoScanContextToResult(result, target, scanContext)
 	sourceErrors := []providers.SourceError{}
+	inconclusiveLifecycleKeys := []string{}
 	if !result.Truncated {
-		externalFindings, externalSourceErrors, externalErr := s.repoScanExternalFindings(ctx, record, s.Now().UTC())
-		sourceErrors = append(sourceErrors, externalSourceErrors...)
+		externalEvidence, externalErr := s.repoScanExternalFindings(ctx, record, s.Now().UTC())
+		externalFindings := externalEvidence.Findings
+		sourceErrors = append(sourceErrors, externalEvidence.SourceErrors...)
+		inconclusiveLifecycleKeys = append(inconclusiveLifecycleKeys, externalEvidence.InconclusiveLifecycleKeys...)
 		if len(sourceErrors) > 0 {
 			s.appendScanEvent(ctx, record.ID, db.ScanEventLevelWarn, "repo scan completed with partial source errors", map[string]any{
 				"source_error_count": len(sourceErrors),
@@ -1948,13 +1951,14 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	}
 	cursorAfter := firstNonEmptyString(result.HeadRevision, record.HeadRevision)
 	completionContext := db.RepoScanContext{
-		ScanMode:         result.ScanMode,
-		BaseRevision:     result.BaseRevision,
-		HeadRevision:     result.HeadRevision,
-		ChangedPaths:     append([]string(nil), result.ChangedPaths...),
-		PartialSourceRun: partialSourceRun,
-		SourceHealth:     sourceHealth,
-		SourceDetails:    sourceHealthDetails,
+		ScanMode:                  result.ScanMode,
+		BaseRevision:              result.BaseRevision,
+		HeadRevision:              result.HeadRevision,
+		ChangedPaths:              append([]string(nil), result.ChangedPaths...),
+		InconclusiveLifecycleKeys: inconclusiveLifecycleKeys,
+		PartialSourceRun:          partialSourceRun,
+		SourceHealth:              sourceHealth,
+		SourceDetails:             sourceHealthDetails,
 	}
 	if !result.Truncated && !partialSourceRun {
 		completionContext.CursorAfter = cursorAfter
@@ -2122,11 +2126,23 @@ func repoScanLastDeepScannedAt(mode string, completedAt time.Time) *time.Time {
 	return &converted
 }
 
-func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoScanRecord, detectedAt time.Time) ([]domain.Finding, []providers.SourceError, error) {
+// repoScanExternalEvidence is the outcome of enriching one repo scan with
+// GitHub-native sources.
+type repoScanExternalEvidence struct {
+	Findings     []domain.Finding
+	SourceErrors []providers.SourceError
+	// InconclusiveLifecycleKeys are lifecycle keys whose control this scan could
+	// not evaluate. They must not be closed at completion even though they are
+	// absent from Findings.
+	InconclusiveLifecycleKeys []string
+}
+
+func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoScanRecord, detectedAt time.Time) (repoScanExternalEvidence, error) {
 	source := record.Source.Normalize()
 	if source.Provider != "github_app" || source.InstallationID <= 0 {
-		return nil, nil, nil
+		return repoScanExternalEvidence{}, nil
 	}
+	inconclusiveLifecycleKeys := []string{}
 	sourceErrors := make([]providers.SourceError, 0)
 	recordSourceError := func(collector, code, message string) {
 		sourceErrors = append(sourceErrors, providers.SourceError{
@@ -2150,14 +2166,14 @@ func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoSc
 		alerts, err := s.GitHubCodeScanningAlertCollector.ListCodeScanningAlerts(ctx, source.InstallationID, record.Repository)
 		if err != nil {
 			if ctx.Err() != nil {
-				return nil, nil, ctx.Err()
+				return repoScanExternalEvidence{}, ctx.Err()
 			}
 			recordSourceErr("github_code_scanning", "alert_list_error", err)
 		} else {
 			imported, normErr := repoexposure.NormalizeGitHubCodeScanningAlerts(ctx, record.Repository, "", githubCodeScanningAlertsToRepoExposure(alerts), detectedAt)
 			if normErr != nil {
 				if ctx.Err() != nil {
-					return nil, nil, ctx.Err()
+					return repoScanExternalEvidence{}, ctx.Err()
 				}
 				recordSourceErr("github_code_scanning", "normalize_error", normErr)
 			} else {
@@ -2169,14 +2185,14 @@ func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoSc
 		alerts, err := s.GitHubSecretScanningAlertCollector.ListSecretScanningAlerts(ctx, source.InstallationID, record.Repository)
 		if err != nil {
 			if ctx.Err() != nil {
-				return nil, nil, ctx.Err()
+				return repoScanExternalEvidence{}, ctx.Err()
 			}
 			recordSourceErr("github_secret_scanning", "alert_list_error", err)
 		} else {
 			imported, normErr := repoexposure.NormalizeGitHubSecretScanningAlerts(ctx, record.Repository, "", githubSecretScanningAlertsToRepoExposure(alerts), detectedAt)
 			if normErr != nil {
 				if ctx.Err() != nil {
-					return nil, nil, ctx.Err()
+					return repoScanExternalEvidence{}, ctx.Err()
 				}
 				recordSourceErr("github_secret_scanning", "normalize_error", normErr)
 			} else {
@@ -2188,14 +2204,14 @@ func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoSc
 		alerts, err := s.GitHubDependabotAlertCollector.ListDependabotAlerts(ctx, source.InstallationID, record.Repository)
 		if err != nil {
 			if ctx.Err() != nil {
-				return nil, nil, ctx.Err()
+				return repoScanExternalEvidence{}, ctx.Err()
 			}
 			recordSourceErr("github_dependabot", "alert_list_error", err)
 		} else {
 			imported, normErr := repoexposure.NormalizeGitHubDependabotAlerts(ctx, record.Repository, "", githubDependabotAlertsToRepoExposure(alerts), detectedAt)
 			if normErr != nil {
 				if ctx.Err() != nil {
-					return nil, nil, ctx.Err()
+					return repoScanExternalEvidence{}, ctx.Err()
 				}
 				recordSourceErr("github_dependabot", "normalize_error", normErr)
 			} else {
@@ -2207,25 +2223,36 @@ func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoSc
 		posture, err := s.GitHubRepositoryPostureCollector.CollectRepositoryPosture(ctx, source.InstallationID, record.Repository)
 		if err != nil {
 			if ctx.Err() != nil {
-				return nil, nil, ctx.Err()
+				return repoScanExternalEvidence{}, ctx.Err()
 			}
 			recordSourceErr("github_repository_posture", "posture_collect_error", err)
 		} else {
 			findings = append(findings, githubconnector.RepositoryPostureFindings(posture, detectedAt)...)
+			inconclusiveLifecycleKeys = append(inconclusiveLifecycleKeys, githubconnector.RepositoryPostureInconclusiveLifecycleKeys(posture)...)
 		}
 		if owner, _, ok := strings.Cut(record.Repository, "/"); ok && strings.TrimSpace(owner) != "" {
 			orgPosture, orgErr := s.GitHubRepositoryPostureCollector.CollectOrganizationPosture(ctx, source.InstallationID, owner, record.Repository)
 			if orgErr != nil {
 				if ctx.Err() != nil {
-					return nil, nil, ctx.Err()
+					return repoScanExternalEvidence{}, ctx.Err()
 				}
 				recordSourceErr("github_organization_posture", "posture_collect_error", orgErr)
-			} else if githubOrganizationPostureAvailable(orgPosture) {
-				findings = append(findings, githubconnector.OrganizationPostureFindings(orgPosture, record.Repository, detectedAt)...)
+			} else {
+				// Checks GitHub could not evaluate are collected even when the
+				// organization posture is otherwise skipped, so an organization
+				// control that stops being exposed never reads as a fix.
+				inconclusiveLifecycleKeys = append(inconclusiveLifecycleKeys, githubconnector.OrganizationPostureInconclusiveLifecycleKeys(orgPosture, record.Repository)...)
+				if githubOrganizationPostureAvailable(orgPosture) {
+					findings = append(findings, githubconnector.OrganizationPostureFindings(orgPosture, record.Repository, detectedAt)...)
+				}
 			}
 		}
 	}
-	return findings, sourceErrors, nil
+	return repoScanExternalEvidence{
+		Findings:                  findings,
+		SourceErrors:              sourceErrors,
+		InconclusiveLifecycleKeys: inconclusiveLifecycleKeys,
+	}, nil
 }
 
 func repoScanUsesGitHubAppSource(record db.RepoScanRecord) bool {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -5095,6 +5095,310 @@ func TestServiceProcessQueuedGitHubAppRepoScanPreservesPostureFindingsWhenPostur
 	}
 }
 
+func TestServiceGitHubAppRepoScanClosesAndReopensPostureFindingsAcrossCompleteScans(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.GitHubInstallationTokenMinter = &fakeGitHubInstallationTokenMinter{
+		token: githubconnector.InstallationToken{Token: "ghs_installation_token", ExpiresAt: time.Now().Add(24 * time.Hour)},
+	}
+	svc.AuthenticatedRepoScannerFactory = func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/private",
+				CommitsScanned: 1,
+				FilesScanned:   1,
+			},
+		}
+	}
+	current := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return current }
+	insecureCheck := githubconnector.RepositoryPostureCheck{
+		ID:       "default_branch_protection",
+		Category: "branch_protection",
+		State:    githubconnector.RepositoryPostureStateInsecure,
+		Reason:   "weak_protection",
+		Summary:  "Default branch protection is weak.",
+	}
+	secureCheck := insecureCheck
+	secureCheck.State = githubconnector.RepositoryPostureStateSecure
+	secureCheck.Reason = "protected"
+	secureCheck.Summary = "Default branch protection is enforced."
+	postureWithCheck := func(check githubconnector.RepositoryPostureCheck) *fakeGitHubRepositoryPostureCollector {
+		return &fakeGitHubRepositoryPostureCollector{
+			posture: githubconnector.RepositoryPosture{
+				Repository:     "owner/private",
+				InstallationID: 101,
+				CollectedAt:    current,
+				Checks:         []githubconnector.RepositoryPostureCheck{check},
+			},
+			organizationPosture: githubconnector.OrganizationPosture{
+				Organization:   "owner",
+				InstallationID: 101,
+				CollectedAt:    current,
+				Checks: []githubconnector.RepositoryPostureCheck{{
+					ID:       "org_workflow_permissions",
+					Category: "actions",
+					State:    githubconnector.RepositoryPostureStateSecure,
+					Reason:   "read_only_default",
+					Summary:  "Organization defaults workflow tokens to read-only.",
+				}},
+			},
+		}
+	}
+	runScan := func(label string) {
+		t.Helper()
+		if _, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{Repository: "owner/private", ProjectID: "project-1"}); err != nil {
+			t.Fatalf("enqueue %s repo scan: %v", label, err)
+		}
+		processed, err := svc.ProcessNextQueuedRepoScan(ctx)
+		if err != nil {
+			t.Fatalf("process %s repo scan: %v", label, err)
+		}
+		if !processed {
+			t.Fatalf("expected %s repo scan to be processed", label)
+		}
+	}
+
+	// Scan 1: the posture gap is promoted into an open durable finding.
+	svc.GitHubRepositoryPostureCollector = postureWithCheck(insecureCheck)
+	runScan("first")
+	openFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Status:     string(domain.RepoFindingLifecycleOpen),
+	})
+	if err != nil {
+		t.Fatalf("list open findings after first scan: %v", err)
+	}
+	if len(openFindings) != 1 || openFindings[0].Detector != "github_default_branch_unprotected" {
+		t.Fatalf("expected one open posture finding, got %+v", openFindings)
+	}
+	lifecycleKey := openFindings[0].LifecycleKey
+	firstScanID := openFindings[0].ScanID
+	if lifecycleKey == "" {
+		t.Fatalf("expected stable posture lifecycle key, got %+v", openFindings[0])
+	}
+	firstSeenAt := openFindings[0].FirstSeenAt
+	if firstSeenAt == nil {
+		t.Fatalf("expected first seen timestamp, got %+v", openFindings[0])
+	}
+
+	// Scan 2: the check is secure again, posture collection is complete, so the
+	// missing posture finding closes.
+	current = current.Add(24 * time.Hour)
+	svc.GitHubRepositoryPostureCollector = postureWithCheck(secureCheck)
+	runScan("second")
+	fixedFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Status:     string(domain.RepoFindingLifecycleFixed),
+	})
+	if err != nil {
+		t.Fatalf("list fixed findings after second scan: %v", err)
+	}
+	if len(fixedFindings) != 1 || fixedFindings[0].LifecycleKey != lifecycleKey || fixedFindings[0].FixedAt == nil {
+		t.Fatalf("expected the posture finding to close after a complete secure scan, got %+v", fixedFindings)
+	}
+
+	// Scan 3: the gap reappears, so the same lifecycle key transitions to
+	// reopened on a new scan row while keeping its first-seen age.
+	current = current.Add(24 * time.Hour)
+	svc.GitHubRepositoryPostureCollector = postureWithCheck(insecureCheck)
+	runScan("third")
+	reopenedFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Status:     string(domain.RepoFindingLifecycleReopened),
+	})
+	if err != nil {
+		t.Fatalf("list reopened findings after third scan: %v", err)
+	}
+	if len(reopenedFindings) != 1 || reopenedFindings[0].LifecycleKey != lifecycleKey || reopenedFindings[0].ReopenedAt == nil {
+		t.Fatalf("expected the reappearing posture gap to reopen, got %+v", reopenedFindings)
+	}
+	if reopenedFindings[0].ScanID == firstScanID {
+		t.Fatalf("expected the reopened row to come from a new scan, got %+v", reopenedFindings[0])
+	}
+	if reopenedFindings[0].FirstSeenAt == nil || !reopenedFindings[0].FirstSeenAt.Equal(*firstSeenAt) {
+		t.Fatalf("expected reopened posture finding to keep first seen %v, got %+v", firstSeenAt, reopenedFindings[0].FirstSeenAt)
+	}
+
+	// The lifecycle summary, clusters, and trends all include the posture
+	// finding with its detector/source metadata.
+	summary, err := svc.GetRepoFindingsSummary(ctx, db.RepoFindingFilter{Repository: "owner/private"})
+	if err != nil {
+		t.Fatalf("summarize repo findings: %v", err)
+	}
+	if summary.ReopenedCount != 1 || summary.ByDetector["github_default_branch_unprotected"] == 0 {
+		t.Fatalf("expected reopened posture finding in summary, got %+v", summary)
+	}
+
+	// Operator drill-down filters resolve posture findings by their promotion
+	// source and detector.
+	bySource, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Source:     "github_posture",
+	})
+	if err != nil {
+		t.Fatalf("filter repo findings by source: %v", err)
+	}
+	if len(bySource) != 1 || bySource[0].LifecycleKey != lifecycleKey {
+		t.Fatalf("expected source filter to select the posture finding, got %+v", bySource)
+	}
+	byDetector, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Detector:   "github_default_branch_unprotected",
+	})
+	if err != nil {
+		t.Fatalf("filter repo findings by detector: %v", err)
+	}
+	if len(byDetector) != 1 || byDetector[0].LifecycleKey != lifecycleKey {
+		t.Fatalf("expected detector filter to select the posture finding, got %+v", byDetector)
+	}
+	clusters, err := svc.ListRepoFindingClusters(ctx, 10, RepoFindingClusterFilter{})
+	if err != nil {
+		t.Fatalf("list repo finding clusters: %v", err)
+	}
+	var postureCluster *domain.RepoFindingCluster
+	for i := range clusters {
+		if clusters[i].Detector == "github_default_branch_unprotected" {
+			postureCluster = &clusters[i]
+			break
+		}
+	}
+	if postureCluster == nil || postureCluster.Count != 2 || postureCluster.Spread.RepoScans != 2 {
+		t.Fatalf("expected posture findings to cluster across repeated scans, got %+v", clusters)
+	}
+	trend, err := svc.GetRepoFindingsTrendFiltered(ctx, 10, "", string(domain.FindingRepoMisconfig), 0)
+	if err != nil {
+		t.Fatalf("repo findings trend: %v", err)
+	}
+	trendTotal := 0
+	for _, point := range trend {
+		trendTotal += point.Total
+	}
+	if trendTotal != 2 {
+		t.Fatalf("expected posture findings in trend buckets across scans, got %+v", trend)
+	}
+}
+
+func TestServiceRepoScanWithoutPostureCollectionPreservesPostureFindings(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+
+	firstScan, err := store.CreateRepoScan(ctx, "owner/private", db.RepoScanSource{}, db.RepoScanContext{ScanMode: db.RepoScanModeDeep}, now)
+	if err != nil {
+		t.Fatalf("create first repo scan: %v", err)
+	}
+	postureFindings := githubconnector.RepositoryPostureFindings(githubconnector.RepositoryPosture{
+		Repository:     "owner/private",
+		InstallationID: 101,
+		CollectedAt:    now,
+		Checks: []githubconnector.RepositoryPostureCheck{{
+			ID:       "default_branch_protection",
+			Category: "branch_protection",
+			State:    githubconnector.RepositoryPostureStateInsecure,
+			Reason:   "weak_protection",
+			Summary:  "Default branch protection is weak.",
+		}},
+	}, now)
+	if len(postureFindings) != 1 {
+		t.Fatalf("expected one posture finding, got %+v", postureFindings)
+	}
+	nativeFinding := domain.Finding{
+		ID:              "finding:native-secret",
+		Type:            domain.FindingSecretExposure,
+		Severity:        domain.SeverityHigh,
+		ConfidenceScore: 0.95,
+		Title:           "GitHub token exposed",
+		HumanSummary:    "A token-like value was committed.",
+		Repository:      "owner/private",
+		Commit:          "abc123",
+		FilePath:        "config/app.env",
+		LineNumber:      7,
+		Detector:        "github_token",
+		Evidence: map[string]any{
+			"repository":         "owner/private",
+			"detector":           "github_token",
+			"file_path":          "config/app.env",
+			"line_number":        7,
+			"secret_fingerprint": "fp-token",
+		},
+		CreatedAt: now,
+	}
+	if err := store.UpsertRepoFindings(ctx, firstScan.ID, append(postureFindings, nativeFinding)); err != nil {
+		t.Fatalf("upsert first scan findings: %v", err)
+	}
+	if err := store.CompleteRepoScan(ctx, firstScan.ID, "succeeded", now.Add(time.Minute), 1, 1, 2, false, db.RepoScanContext{ScanMode: db.RepoScanModeDeep}, ""); err != nil {
+		t.Fatalf("complete first repo scan: %v", err)
+	}
+
+	// A complete plain scan never runs GitHub posture collection: it may close
+	// the missing native finding but must leave the posture finding open.
+	secondScan, err := store.CreateRepoScan(ctx, "owner/private", db.RepoScanSource{}, db.RepoScanContext{ScanMode: db.RepoScanModeDeep}, now.Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("create second repo scan: %v", err)
+	}
+	if err := store.CompleteRepoScan(ctx, secondScan.ID, "succeeded", now.Add(24*time.Hour+time.Minute), 1, 1, 0, false, db.RepoScanContext{
+		ScanMode: db.RepoScanModeDeep,
+		SourceDetails: []db.RepoScanSourceHealth{
+			{Source: "identrail_repo_scanner", Status: db.RepoScanSourceHealthComplete},
+		},
+	}, ""); err != nil {
+		t.Fatalf("complete second repo scan: %v", err)
+	}
+	openFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Status:     string(domain.RepoFindingLifecycleOpen),
+	})
+	if err != nil {
+		t.Fatalf("list open findings after plain scan: %v", err)
+	}
+	if len(openFindings) != 1 || openFindings[0].LifecycleKey != postureFindings[0].LifecycleKey {
+		t.Fatalf("expected the posture finding to stay open after a plain scan, got %+v", openFindings)
+	}
+	fixedFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Status:     string(domain.RepoFindingLifecycleFixed),
+	})
+	if err != nil {
+		t.Fatalf("list fixed findings after plain scan: %v", err)
+	}
+	if len(fixedFindings) != 1 || fixedFindings[0].Detector != "github_token" {
+		t.Fatalf("expected only the native finding to close after a plain scan, got %+v", fixedFindings)
+	}
+
+	// A complete scan that collected the repository posture source closes the
+	// still-missing posture finding.
+	thirdScan, err := store.CreateRepoScan(ctx, "owner/private", db.RepoScanSource{}, db.RepoScanContext{ScanMode: db.RepoScanModeDeep}, now.Add(48*time.Hour))
+	if err != nil {
+		t.Fatalf("create third repo scan: %v", err)
+	}
+	if err := store.CompleteRepoScan(ctx, thirdScan.ID, "succeeded", now.Add(48*time.Hour+time.Minute), 1, 1, 0, false, db.RepoScanContext{
+		ScanMode: db.RepoScanModeDeep,
+		SourceDetails: []db.RepoScanSourceHealth{
+			{Source: "identrail_repo_scanner", Status: db.RepoScanSourceHealthComplete},
+			{Source: "github_repository_posture", Status: db.RepoScanSourceHealthComplete},
+			{Source: "github_organization_posture", Status: db.RepoScanSourceHealthComplete},
+		},
+	}, ""); err != nil {
+		t.Fatalf("complete third repo scan: %v", err)
+	}
+	openAfterPosture, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Status:     string(domain.RepoFindingLifecycleOpen),
+	})
+	if err != nil {
+		t.Fatalf("list open findings after posture scan: %v", err)
+	}
+	if len(openAfterPosture) != 0 {
+		t.Fatalf("expected posture finding to close after posture collection, got %+v", openAfterPosture)
+	}
+}
+
 func TestRepoScanSourceHealthClassification(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -5283,6 +5283,210 @@ func TestServiceGitHubAppRepoScanClosesAndReopensPostureFindingsAcrossCompleteSc
 	}
 }
 
+func TestServiceGitHubAppRepoScanKeepsPostureFindingsOpenWhenCheckIsNotConclusive(t *testing.T) {
+	// A posture check that GitHub could not evaluate still promotes a finding
+	// under the same lifecycle key, but at a confidence/severity the reportable
+	// filter drops. The durable gap must stay open rather than read as fixed,
+	// because the control was never re-checked.
+	states := []struct {
+		name   string
+		state  githubconnector.RepositoryPostureState
+		reason string
+	}{
+		{name: "permission_limited", state: githubconnector.RepositoryPostureStatePermissionLimited},
+		{name: "unavailable", state: githubconnector.RepositoryPostureStateUnavailable},
+		{name: "unknown", state: githubconnector.RepositoryPostureStateUnknown},
+		{name: "unsupported_plan_change", state: githubconnector.RepositoryPostureStateUnsupported, reason: "plan_unavailable"},
+	}
+	for _, tc := range states {
+		t.Run(tc.name, func(t *testing.T) {
+			store := db.NewMemoryStore()
+			svc := NewService(store, fakeScanner{}, "aws")
+			ctx := defaultScopeContext()
+			seedDefaultProject(t, store, ctx, "project-1")
+			seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+			svc.RepoScanAllowedTargets = []string{"owner/*"}
+			svc.GitHubInstallationTokenMinter = &fakeGitHubInstallationTokenMinter{
+				token: githubconnector.InstallationToken{Token: "ghs_installation_token", ExpiresAt: time.Now().Add(24 * time.Hour)},
+			}
+			svc.AuthenticatedRepoScannerFactory = func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+				return &fakeRepoExecutor{result: repoexposure.ScanResult{Repository: "owner/private", CommitsScanned: 1, FilesScanned: 1}}
+			}
+			current := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+			svc.Now = func() time.Time { return current }
+			postureWith := func(check githubconnector.RepositoryPostureCheck) *fakeGitHubRepositoryPostureCollector {
+				return &fakeGitHubRepositoryPostureCollector{
+					posture: githubconnector.RepositoryPosture{
+						Repository:     "owner/private",
+						InstallationID: 101,
+						CollectedAt:    current,
+						Checks:         []githubconnector.RepositoryPostureCheck{check},
+					},
+					organizationPosture: githubconnector.OrganizationPosture{
+						Organization:   "owner",
+						InstallationID: 101,
+						CollectedAt:    current,
+						Checks: []githubconnector.RepositoryPostureCheck{{
+							ID:    "org_workflow_permissions",
+							State: githubconnector.RepositoryPostureStateSecure,
+						}},
+					},
+				}
+			}
+			runScan := func(label string) {
+				t.Helper()
+				if _, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{Repository: "owner/private", ProjectID: "project-1"}); err != nil {
+					t.Fatalf("enqueue %s repo scan: %v", label, err)
+				}
+				processed, err := svc.ProcessNextQueuedRepoScan(ctx)
+				if err != nil {
+					t.Fatalf("process %s repo scan: %v", label, err)
+				}
+				if !processed {
+					t.Fatalf("expected %s repo scan to be processed", label)
+				}
+			}
+
+			svc.GitHubRepositoryPostureCollector = postureWith(githubconnector.RepositoryPostureCheck{
+				ID:       "default_branch_protection",
+				Category: "branch_protection",
+				State:    githubconnector.RepositoryPostureStateInsecure,
+				Reason:   "weak_protection",
+			})
+			runScan("first")
+			openFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+				Repository: "owner/private",
+				Status:     string(domain.RepoFindingLifecycleOpen),
+			})
+			if err != nil {
+				t.Fatalf("list open findings: %v", err)
+			}
+			if len(openFindings) != 1 {
+				t.Fatalf("expected the posture gap to be open, got %+v", openFindings)
+			}
+			lifecycleKey := openFindings[0].LifecycleKey
+
+			// The same control now reports an inconclusive state.
+			current = current.Add(24 * time.Hour)
+			svc.GitHubRepositoryPostureCollector = postureWith(githubconnector.RepositoryPostureCheck{
+				ID:       "default_branch_protection",
+				Category: "branch_protection",
+				State:    tc.state,
+				Reason:   tc.reason,
+			})
+			runScan("second")
+
+			fixedFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+				Repository: "owner/private",
+				Status:     string(domain.RepoFindingLifecycleFixed),
+			})
+			if err != nil {
+				t.Fatalf("list fixed findings: %v", err)
+			}
+			if len(fixedFindings) != 0 {
+				t.Fatalf("expected an unverified posture check not to close the gap, got %+v", fixedFindings)
+			}
+			stillOpen, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+				Repository: "owner/private",
+				Status:     string(domain.RepoFindingLifecycleOpen),
+			})
+			if err != nil {
+				t.Fatalf("list open findings after inconclusive scan: %v", err)
+			}
+			if len(stillOpen) != 1 || stillOpen[0].LifecycleKey != lifecycleKey {
+				t.Fatalf("expected the posture gap to stay open, got %+v", stillOpen)
+			}
+		})
+	}
+}
+
+func TestServiceGitHubAppRepoScanClosesPostureFindingWhenOrganizationNoLongerApplies(t *testing.T) {
+	// A repository owned by a user account genuinely has no organization policy,
+	// so an organization posture gap no longer applies and must close rather than
+	// linger forever.
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.GitHubInstallationTokenMinter = &fakeGitHubInstallationTokenMinter{
+		token: githubconnector.InstallationToken{Token: "ghs_installation_token", ExpiresAt: time.Now().Add(24 * time.Hour)},
+	}
+	svc.AuthenticatedRepoScannerFactory = func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+		return &fakeRepoExecutor{result: repoexposure.ScanResult{Repository: "owner/private", CommitsScanned: 1, FilesScanned: 1}}
+	}
+	current := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return current }
+	collectorWith := func(orgChecks []githubconnector.RepositoryPostureCheck) *fakeGitHubRepositoryPostureCollector {
+		return &fakeGitHubRepositoryPostureCollector{
+			posture: githubconnector.RepositoryPosture{
+				Repository:     "owner/private",
+				InstallationID: 101,
+				CollectedAt:    current,
+				Checks: []githubconnector.RepositoryPostureCheck{{
+					ID:    "default_branch_protection",
+					State: githubconnector.RepositoryPostureStateSecure,
+				}},
+			},
+			organizationPosture: githubconnector.OrganizationPosture{
+				Organization:   "owner",
+				InstallationID: 101,
+				CollectedAt:    current,
+				Checks:         orgChecks,
+			},
+		}
+	}
+	runScan := func(label string) {
+		t.Helper()
+		if _, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{Repository: "owner/private", ProjectID: "project-1"}); err != nil {
+			t.Fatalf("enqueue %s repo scan: %v", label, err)
+		}
+		processed, err := svc.ProcessNextQueuedRepoScan(ctx)
+		if err != nil {
+			t.Fatalf("process %s repo scan: %v", label, err)
+		}
+		if !processed {
+			t.Fatalf("expected %s repo scan to be processed", label)
+		}
+	}
+
+	svc.GitHubRepositoryPostureCollector = collectorWith([]githubconnector.RepositoryPostureCheck{{
+		ID:     "org_workflow_permissions",
+		State:  githubconnector.RepositoryPostureStateInsecure,
+		Reason: "write_token_or_pr_approval",
+	}})
+	runScan("first")
+	openFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Status:     string(domain.RepoFindingLifecycleOpen),
+	})
+	if err != nil {
+		t.Fatalf("list open findings: %v", err)
+	}
+	if len(openFindings) != 1 || openFindings[0].AdapterSource != "github_org_posture" {
+		t.Fatalf("expected an open org posture gap, got %+v", openFindings)
+	}
+
+	current = current.Add(24 * time.Hour)
+	svc.GitHubRepositoryPostureCollector = collectorWith([]githubconnector.RepositoryPostureCheck{{
+		ID:     "org_workflow_permissions",
+		State:  githubconnector.RepositoryPostureStateUnsupported,
+		Reason: "not_an_organization",
+	}})
+	runScan("second")
+	fixedFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Status:     string(domain.RepoFindingLifecycleFixed),
+	})
+	if err != nil {
+		t.Fatalf("list fixed findings: %v", err)
+	}
+	if len(fixedFindings) != 1 || fixedFindings[0].AdapterSource != "github_org_posture" {
+		t.Fatalf("expected the org posture gap to close once it no longer applies, got %+v", fixedFindings)
+	}
+}
+
 func TestServiceRepoScanWithoutPostureCollectionPreservesPostureFindings(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")

--- a/internal/connectors/github/posture_findings.go
+++ b/internal/connectors/github/posture_findings.go
@@ -76,14 +76,7 @@ func postureCheckToFinding(repository string, organization string, installationI
 	}
 	severity := postureFindingSeverity(check, detector)
 	confidence := postureFindingConfidence(check.State)
-	lifecycleKey := strings.Join([]string{
-		"repo_finding",
-		repository,
-		string(domain.FindingRepoMisconfig),
-		adapterSource,
-		scope,
-		check.ID,
-	}, "\x1f")
+	lifecycleKey := postureFindingLifecycleKey(repository, adapterSource, scope, check.ID)
 	evidence := postureFindingEvidence(repository, organization, installationID, collectedAt, check, adapterSource, scope, detector, confidence)
 	finding := domain.Finding{
 		ID:                  postureFindingID(lifecycleKey),
@@ -109,6 +102,80 @@ func postureCheckToFinding(repository string, organization string, installationI
 	}
 	domain.NormalizeRepoFindingMetadata(&finding)
 	return finding, true
+}
+
+// postureFindingLifecycleKey builds the scanner-stable identity for one posture
+// check. It deliberately keys on the check id rather than the detector, so the
+// same control keeps one durable finding even when its state (and therefore its
+// detector, severity, and confidence) changes between scans.
+func postureFindingLifecycleKey(repository string, adapterSource string, scope string, checkID string) string {
+	return strings.Join([]string{
+		"repo_finding",
+		repository,
+		string(domain.FindingRepoMisconfig),
+		adapterSource,
+		scope,
+		checkID,
+	}, "\x1f")
+}
+
+// RepositoryPostureInconclusiveLifecycleKeys returns the lifecycle keys of
+// repository posture checks this collection could not conclusively evaluate.
+// Callers must not close a durable finding for these keys: the control was never
+// re-checked, so its absence from the promoted findings says nothing about
+// whether the gap was fixed.
+func RepositoryPostureInconclusiveLifecycleKeys(posture RepositoryPosture) []string {
+	return postureInconclusiveLifecycleKeys(posture.Repository, posture.Checks, githubPostureAdapterSource, "repository")
+}
+
+// OrganizationPostureInconclusiveLifecycleKeys returns the lifecycle keys of
+// organization posture checks this collection could not conclusively evaluate,
+// scoped to the repository that inherits the organization policy.
+func OrganizationPostureInconclusiveLifecycleKeys(posture OrganizationPosture, repository string) []string {
+	return postureInconclusiveLifecycleKeys(repository, posture.Checks, githubOrgPostureAdapterSource, "organization")
+}
+
+func postureInconclusiveLifecycleKeys(repository string, checks []RepositoryPostureCheck, adapterSource string, scope string) []string {
+	repository = strings.ToLower(strings.TrimSpace(repository))
+	if repository == "" || len(checks) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(checks))
+	seen := map[string]struct{}{}
+	for _, check := range checks {
+		checkID := strings.TrimSpace(check.ID)
+		if checkID == "" || postureCheckConclusive(check) {
+			continue
+		}
+		key := postureFindingLifecycleKey(repository, adapterSource, scope, checkID)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// postureCheckConclusive reports whether GitHub gave a definitive answer for one
+// posture check, so a prior finding for it may be closed when the check no
+// longer reports a gap.
+//
+// `secure` and `insecure` are definitive. `unsupported` is definitive only when
+// the control genuinely does not apply to this owner (a user account has no
+// organization policy); an `unsupported` caused by the account plan no longer
+// exposing the control means the gap was never verified as fixed, so it stays
+// open for an operator to suppress or act on. `permission_limited`,
+// `unavailable`, and `unknown` are never definitive.
+func postureCheckConclusive(check RepositoryPostureCheck) bool {
+	switch check.State {
+	case RepositoryPostureStateSecure, RepositoryPostureStateInsecure:
+		return true
+	case RepositoryPostureStateUnsupported:
+		return strings.TrimSpace(check.Reason) == "not_an_organization"
+	default:
+		return false
+	}
 }
 
 func postureFindingDetector(check RepositoryPostureCheck) string {

--- a/internal/connectors/github/posture_findings_test.go
+++ b/internal/connectors/github/posture_findings_test.go
@@ -198,6 +198,88 @@ func TestPostureFindingsKeepLifecycleWhenCheckStateDegrades(t *testing.T) {
 	}
 }
 
+func TestPostureInconclusiveLifecycleKeysCoverUnverifiedChecks(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	posture := RepositoryPosture{
+		Repository:  "owner/repo",
+		CollectedAt: now,
+		Checks: []RepositoryPostureCheck{
+			{ID: "default_branch_protection", State: RepositoryPostureStateInsecure},
+			{ID: "repository_rulesets", State: RepositoryPostureStateSecure},
+			{ID: "secret_scanning", State: RepositoryPostureStatePermissionLimited},
+			{ID: "code_scanning", State: RepositoryPostureStateUnavailable},
+			{ID: "webhooks", State: RepositoryPostureStateUnknown},
+			{ID: "deploy_keys", State: RepositoryPostureStateUnsupported, Reason: "plan_unavailable"},
+		},
+	}
+
+	keys := RepositoryPostureInconclusiveLifecycleKeys(posture)
+	if len(keys) != 4 {
+		t.Fatalf("expected the four unverified checks to be inconclusive, got %d: %+v", len(keys), keys)
+	}
+	inconclusive := map[string]struct{}{}
+	for _, key := range keys {
+		inconclusive[key] = struct{}{}
+	}
+	keyFor := func(checkID string) string {
+		return postureFindingLifecycleKey("owner/repo", githubPostureAdapterSource, "repository", checkID)
+	}
+	for _, checkID := range []string{"secret_scanning", "code_scanning", "webhooks", "deploy_keys"} {
+		if _, ok := inconclusive[keyFor(checkID)]; !ok {
+			t.Errorf("expected %s to be inconclusive, got %+v", checkID, keys)
+		}
+	}
+	// Conclusively evaluated checks must stay closable, otherwise a plan that
+	// permanently lacks one control would strand every other posture finding.
+	for _, checkID := range []string{"default_branch_protection", "repository_rulesets"} {
+		if _, ok := inconclusive[keyFor(checkID)]; ok {
+			t.Errorf("expected %s to remain conclusive, got %+v", checkID, keys)
+		}
+	}
+
+	// A permission-limited check keeps the lifecycle key of the gap it replaced,
+	// so the inconclusive key matches the durable finding that must stay open.
+	insecure := RepositoryPostureFindings(RepositoryPosture{
+		Repository:  "owner/repo",
+		CollectedAt: now,
+		Checks:      []RepositoryPostureCheck{{ID: "secret_scanning", State: RepositoryPostureStateInsecure}},
+	}, now)
+	if len(insecure) != 1 || insecure[0].LifecycleKey != keyFor("secret_scanning") {
+		t.Fatalf("expected the insecure finding to share the inconclusive key, got %+v", insecure)
+	}
+}
+
+func TestOrganizationPostureInconclusiveLifecycleKeysDistinguishUnsupportedReasons(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	// A user-owned repository genuinely has no organization policy, so those
+	// checks are conclusive and prior findings may close.
+	userOwned := OrganizationPosture{
+		Organization: "owner",
+		CollectedAt:  now,
+		Checks: []RepositoryPostureCheck{
+			{ID: "org_secret_scanning_policy", State: RepositoryPostureStateUnsupported, Reason: "not_an_organization"},
+		},
+	}
+	if keys := OrganizationPostureInconclusiveLifecycleKeys(userOwned, "owner/repo"); len(keys) != 0 {
+		t.Fatalf("expected not_an_organization checks to be conclusive, got %+v", keys)
+	}
+
+	// The organization exists but GitHub stopped exposing the control (a plan
+	// change), so the gap was never verified as fixed and must stay open.
+	planLimited := OrganizationPosture{
+		Organization: "owner",
+		CollectedAt:  now,
+		Checks: []RepositoryPostureCheck{
+			{ID: "org_secret_scanning_policy", State: RepositoryPostureStateUnsupported, Reason: "plan_unavailable"},
+		},
+	}
+	keys := OrganizationPostureInconclusiveLifecycleKeys(planLimited, "owner/repo")
+	want := postureFindingLifecycleKey("owner/repo", githubOrgPostureAdapterSource, "organization", "org_secret_scanning_policy")
+	if len(keys) != 1 || keys[0] != want {
+		t.Fatalf("expected plan-unavailable org checks to be inconclusive, got %+v", keys)
+	}
+}
+
 func findingByDetector(findings []domain.Finding, detector string) *domain.Finding {
 	for i := range findings {
 		if findings[i].Detector == detector {

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2330,7 +2330,13 @@ func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, s
 	record.ErrorMessage = strings.TrimSpace(errorMessage)
 	m.repoScans[repoScanID] = record
 	if shouldCloseMissingPostureRepoFindings(record.Status, record.Truncated, normalizedContext) {
-		m.markMissingRepoFindingsFixedLocked(scope, record, finished, shouldCloseMissingRepoFindings(record.Status, record.Truncated, normalizedContext))
+		m.markMissingRepoFindingsFixedLocked(
+			scope,
+			record,
+			finished,
+			shouldCloseMissingRepoFindings(record.Status, record.Truncated, normalizedContext),
+			normalizedContext.InconclusiveLifecycleKeys,
+		)
 	}
 	return nil
 }
@@ -2787,7 +2793,11 @@ func (m *MemoryStore) latestRepoFindingLifecycleLocked(scope Scope, repository s
 	return latest, found
 }
 
-func (m *MemoryStore) markMissingRepoFindingsFixedLocked(scope Scope, repoScan RepoScanRecord, fixedAt time.Time, closeNonPostureFindings bool) {
+func (m *MemoryStore) markMissingRepoFindingsFixedLocked(scope Scope, repoScan RepoScanRecord, fixedAt time.Time, closeNonPostureFindings bool, inconclusiveLifecycleKeys []string) {
+	inconclusiveKeys := make(map[string]struct{}, len(inconclusiveLifecycleKeys))
+	for _, key := range inconclusiveLifecycleKeys {
+		inconclusiveKeys[key] = struct{}{}
+	}
 	currentKeys := map[string]struct{}{}
 	for _, key := range m.repoFindingIDs[repoScan.ID] {
 		finding, exists := m.repoFindings[key]
@@ -2818,6 +2828,11 @@ func (m *MemoryStore) markMissingRepoFindingsFixedLocked(scope Scope, repoScan R
 			continue
 		}
 		if _, stillObserved := currentKeys[finding.LifecycleKey]; stillObserved {
+			continue
+		}
+		// The scan saw this control but could not evaluate it, so its absence
+		// from the promoted findings is not evidence the gap was fixed.
+		if _, inconclusive := inconclusiveKeys[finding.LifecycleKey]; inconclusive {
 			continue
 		}
 		if finding.LifecycleStatus != domain.RepoFindingLifecycleOpen && finding.LifecycleStatus != domain.RepoFindingLifecycleReopened {

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2329,8 +2329,8 @@ func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, s
 	}
 	record.ErrorMessage = strings.TrimSpace(errorMessage)
 	m.repoScans[repoScanID] = record
-	if shouldCloseMissingRepoFindings(record.Status, record.Truncated, normalizedContext) {
-		m.markMissingRepoFindingsFixedLocked(scope, record, finished)
+	if shouldCloseMissingPostureRepoFindings(record.Status, record.Truncated, normalizedContext) {
+		m.markMissingRepoFindingsFixedLocked(scope, record, finished, shouldCloseMissingRepoFindings(record.Status, record.Truncated, normalizedContext))
 	}
 	return nil
 }
@@ -2787,7 +2787,7 @@ func (m *MemoryStore) latestRepoFindingLifecycleLocked(scope Scope, repository s
 	return latest, found
 }
 
-func (m *MemoryStore) markMissingRepoFindingsFixedLocked(scope Scope, repoScan RepoScanRecord, fixedAt time.Time) {
+func (m *MemoryStore) markMissingRepoFindingsFixedLocked(scope Scope, repoScan RepoScanRecord, fixedAt time.Time, closeNonPostureFindings bool) {
 	currentKeys := map[string]struct{}{}
 	for _, key := range m.repoFindingIDs[repoScan.ID] {
 		finding, exists := m.repoFindings[key]
@@ -2821,6 +2821,13 @@ func (m *MemoryStore) markMissingRepoFindingsFixedLocked(scope Scope, repoScan R
 			continue
 		}
 		if finding.LifecycleStatus != domain.RepoFindingLifecycleOpen && finding.LifecycleStatus != domain.RepoFindingLifecycleReopened {
+			continue
+		}
+		if postureSource := repoFindingPostureCollectionSource(finding.AdapterSource); postureSource != "" {
+			if !repoScanSourceCollectedComplete(repoScan.SourceHealthDetails, postureSource) {
+				continue
+			}
+		} else if !closeNonPostureFindings {
 			continue
 		}
 		latest, exists := m.latestRepoFindingLifecycleLocked(scope, repoScan.Repository, finding.LifecycleKey, repoScan.ID)

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3382,7 +3382,7 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 	}
 	if shouldCloseMissingPostureRepoFindings(strings.TrimSpace(status), truncated, normalizedContext) {
 		closeNonPosture := shouldCloseMissingRepoFindings(strings.TrimSpace(status), truncated, normalizedContext)
-		if err := p.markMissingRepoFindingsFixed(ctx, tx, scope, repoScanID, finishedAt.UTC(), sourceHealthDetails, closeNonPosture); err != nil {
+		if err := p.markMissingRepoFindingsFixed(ctx, tx, scope, repoScanID, finishedAt.UTC(), sourceHealthDetails, closeNonPosture, normalizedContext.InconclusiveLifecycleKeys); err != nil {
 			return err
 		}
 	}
@@ -3392,16 +3392,36 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 	return nil
 }
 
-func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, executor sqlExecutor, scope Scope, repoScanID string, fixedAt time.Time, sourceDetails []RepoScanSourceHealth, closeNonPostureFindings bool) error {
+func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, executor sqlExecutor, scope Scope, repoScanID string, fixedAt time.Time, sourceDetails []RepoScanSourceHealth, closeNonPostureFindings bool, inconclusiveLifecycleKeys []string) error {
 	// Posture-origin findings only close when the completing scan collected the
 	// matching posture source; scans that never ran posture collection cannot
 	// re-observe the gap and must leave those findings open. Every other source
 	// keeps the scan-level closure gate.
 	repositoryPostureCollected := repoScanSourceCollectedComplete(sourceDetails, "github_repository_posture")
 	organizationPostureCollected := repoScanSourceCollectedComplete(sourceDetails, "github_organization_posture")
+	args := []any{
+		fixedAt.UTC(),
+		scope.TenantID,
+		scope.WorkspaceID,
+		repoScanID,
+		repositoryPostureCollected,
+		organizationPostureCollected,
+		closeNonPostureFindings,
+	}
+	// Controls this scan saw but could not evaluate are never evidence of a fix,
+	// so exclude their lifecycle keys from closure.
+	inconclusiveClause := ""
+	if len(inconclusiveLifecycleKeys) > 0 {
+		placeholders := make([]string, 0, len(inconclusiveLifecycleKeys))
+		for _, key := range inconclusiveLifecycleKeys {
+			args = append(args, key)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		inconclusiveClause = fmt.Sprintf("\n\t\t   AND COALESCE(rf.lifecycle_key, '') NOT IN (%s)", strings.Join(placeholders, ", "))
+	}
 	_, err := executor.ExecContext(
 		ctx,
-		`UPDATE repo_findings rf
+		fmt.Sprintf(`UPDATE repo_findings rf
 		 SET lifecycle_status = 'fixed',
 		     fixed_at = $1
 		 FROM repo_scans rs, repo_scans current_rs
@@ -3419,7 +3439,7 @@ func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, execut
 		       WHEN 'github_posture' THEN $5
 		       WHEN 'github_org_posture' THEN $6
 		       ELSE $7
-		       END
+		       END%s
 		   AND NOT EXISTS (
 		       SELECT 1
 		       FROM repo_findings current_rf
@@ -3435,14 +3455,8 @@ func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, execut
 		         AND LOWER(newer_rs.repository) = LOWER(rs.repository)
 		         AND COALESCE(newer_rf.lifecycle_key, '') = COALESCE(rf.lifecycle_key, '')
 		         AND COALESCE(newer_rf.last_seen_at, newer_rf.created_at) > COALESCE(rf.last_seen_at, rf.created_at)
-		   )`,
-		fixedAt.UTC(),
-		scope.TenantID,
-		scope.WorkspaceID,
-		repoScanID,
-		repositoryPostureCollected,
-		organizationPostureCollected,
-		closeNonPostureFindings,
+		   )`, inconclusiveClause),
+		args...,
 	)
 	if err != nil {
 		return fmt.Errorf("mark missing repo findings fixed: %w", err)

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3380,8 +3380,9 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		}
 		return err
 	}
-	if shouldCloseMissingRepoFindings(strings.TrimSpace(status), truncated, normalizedContext) {
-		if err := p.markMissingRepoFindingsFixed(ctx, tx, scope, repoScanID, finishedAt.UTC()); err != nil {
+	if shouldCloseMissingPostureRepoFindings(strings.TrimSpace(status), truncated, normalizedContext) {
+		closeNonPosture := shouldCloseMissingRepoFindings(strings.TrimSpace(status), truncated, normalizedContext)
+		if err := p.markMissingRepoFindingsFixed(ctx, tx, scope, repoScanID, finishedAt.UTC(), sourceHealthDetails, closeNonPosture); err != nil {
 			return err
 		}
 	}
@@ -3391,7 +3392,13 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 	return nil
 }
 
-func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, executor sqlExecutor, scope Scope, repoScanID string, fixedAt time.Time) error {
+func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, executor sqlExecutor, scope Scope, repoScanID string, fixedAt time.Time, sourceDetails []RepoScanSourceHealth, closeNonPostureFindings bool) error {
+	// Posture-origin findings only close when the completing scan collected the
+	// matching posture source; scans that never ran posture collection cannot
+	// re-observe the gap and must leave those findings open. Every other source
+	// keeps the scan-level closure gate.
+	repositoryPostureCollected := repoScanSourceCollectedComplete(sourceDetails, "github_repository_posture")
+	organizationPostureCollected := repoScanSourceCollectedComplete(sourceDetails, "github_organization_posture")
 	_, err := executor.ExecContext(
 		ctx,
 		`UPDATE repo_findings rf
@@ -3408,6 +3415,11 @@ func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, execut
 		   AND rf.repo_scan_id <> $4::uuid
 		   AND COALESCE(rf.lifecycle_key, '') <> ''
 		   AND COALESCE(rf.lifecycle_status, 'open') IN ('open', 'reopened')
+		   AND CASE LOWER(COALESCE(NULLIF(rf.adapter_source, ''), rf.evidence->>'adapter_source', ''))
+		       WHEN 'github_posture' THEN $5
+		       WHEN 'github_org_posture' THEN $6
+		       ELSE $7
+		       END
 		   AND NOT EXISTS (
 		       SELECT 1
 		       FROM repo_findings current_rf
@@ -3428,6 +3440,9 @@ func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, execut
 		scope.TenantID,
 		scope.WorkspaceID,
 		repoScanID,
+		repositoryPostureCollected,
+		organizationPostureCollected,
+		closeNonPostureFindings,
 	)
 	if err != nil {
 		return fmt.Errorf("mark missing repo findings fixed: %w", err)
@@ -4340,6 +4355,7 @@ cluster_summaries AS (
 		MIN(type) AS type,
 		MAX(severity_rank) AS severity_rank,
 		MAX(detector) AS detector,
+		MAX(source) AS source,
 		COUNT(*) AS finding_count,
 		MIN(created_at) AS first_seen_at,
 		MAX(created_at) AS last_seen_at,
@@ -4371,6 +4387,7 @@ SELECT
 		ELSE ''
 	END AS severity,
 	s.detector,
+	s.source,
 	d.title,
 	d.human_summary,
 	d.remediation,
@@ -4402,6 +4419,7 @@ LIMIT $%d`,
 		Type          string
 		Severity      string
 		Detector      string
+		Source        string
 		Title         string
 		HumanSummary  string
 		Remediation   string
@@ -4423,6 +4441,7 @@ LIMIT $%d`,
 			&row.Type,
 			&row.Severity,
 			&row.Detector,
+			&row.Source,
 			&row.Title,
 			&row.HumanSummary,
 			&row.Remediation,
@@ -4441,6 +4460,7 @@ LIMIT $%d`,
 			Type:         domain.FindingType(row.Type),
 			Severity:     domain.FindingSeverity(row.Severity),
 			Detector:     strings.TrimSpace(row.Detector),
+			Source:       strings.TrimSpace(row.Source),
 			Title:        row.Title,
 			HumanSummary: row.HumanSummary,
 			Remediation:  row.Remediation,
@@ -4619,12 +4639,19 @@ func repoFindingClusterFilteredCTE(scope Scope, filter RepoFindingClusterListFil
 		ELSE 0
 	END`
 	detectorExpr := "COALESCE(NULLIF(rf.evidence->>'detector', ''), '')"
+	sourceExpr := "COALESCE(NULLIF(rf.adapter_source, ''), NULLIF(rf.evidence->>'adapter_source', ''), '')"
 	fingerprintExpr := "NULLIF(rf.evidence->>'secret_fingerprint', '')"
+	// Mirrors domain.repoFindingClusterKey: detector clusters append the adapter
+	// source only when present, so distinct promotion sources sharing one
+	// detector (repository vs organization posture) stay in separate clusters
+	// while findings without a source keep their existing cluster identity.
 	clusterKeyExpr := fmt.Sprintf(`CASE
 		WHEN rf.type = 'secret_exposure' AND %s <> '' AND %s IS NOT NULL
 			THEN CONCAT_WS(E'\x1f', 'secret', %s, rf.type, %s, %s)
 		WHEN rf.type = 'secret_exposure'
 			THEN CONCAT_WS(E'\x1f', 'finding', %s, rf.type, rf.repo_scan_id::text, rf.finding_id)
+		WHEN %s <> '' AND %s <> ''
+			THEN CONCAT_WS(E'\x1f', 'detector', %s, rf.type, %s, 'source', %s)
 		WHEN %s <> ''
 			THEN CONCAT_WS(E'\x1f', 'detector', %s, rf.type, %s)
 		ELSE CONCAT_WS(E'\x1f', 'finding', %s, rf.type, rf.finding_id)
@@ -4635,6 +4662,11 @@ func repoFindingClusterFilteredCTE(scope Scope, filter RepoFindingClusterListFil
 		detectorExpr,
 		fingerprintExpr,
 		repositoryExpr,
+		detectorExpr,
+		sourceExpr,
+		repositoryExpr,
+		detectorExpr,
+		sourceExpr,
 		detectorExpr,
 		repositoryExpr,
 		detectorExpr,
@@ -4667,6 +4699,7 @@ func repoFindingClusterFilteredCTE(scope Scope, filter RepoFindingClusterListFil
 		%s AS file_path,
 		%s AS line_number,
 		%s AS detector,
+		%s AS source,
 		%s AS cluster_key,
 		%s AS severity_rank
 	FROM repo_findings rf
@@ -4678,6 +4711,7 @@ func repoFindingClusterFilteredCTE(scope Scope, filter RepoFindingClusterListFil
 		filePathExpr,
 		lineNumberExpr,
 		detectorExpr,
+		sourceExpr,
 		clusterKeyExpr,
 		severityRankExpr,
 		strings.Join(conditions, " AND "),

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -919,6 +919,53 @@ func TestPostgresStoreCompleteRepoScanPassesPostureCollectionToClosure(t *testin
 	}
 }
 
+func TestPostgresStoreCompleteRepoScanExcludesInconclusiveLifecycleKeysFromClosure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+	repoScanID := "9a5f2c31-6a41-4a4e-9f22-1d0d0f7ab512"
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE repo_scans").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// Keys the scan could not evaluate are excluded from the closure statement
+	// and normalized (trimmed, deduped, sorted).
+	mock.ExpectExec("COALESCE\\(rf.lifecycle_key, ''\\) NOT IN").
+		WithArgs(
+			sqlmock.AnyArg(), "default", "default", repoScanID, true, true, true,
+			"repo_finding\x1fowner/repo\x1frepo_misconfiguration\x1fgithub_org_posture\x1forganization\x1forg_secret_scanning_policy",
+			"repo_finding\x1fowner/repo\x1frepo_misconfiguration\x1fgithub_posture\x1frepository\x1fdefault_branch_protection",
+		).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err = store.CompleteRepoScan(defaultScopeContext(), repoScanID, "succeeded", now, 1, 1, 0, false, RepoScanContext{
+		ScanMode: RepoScanModeDeep,
+		InconclusiveLifecycleKeys: []string{
+			"repo_finding\x1fowner/repo\x1frepo_misconfiguration\x1fgithub_posture\x1frepository\x1fdefault_branch_protection",
+			"  repo_finding\x1fowner/repo\x1frepo_misconfiguration\x1fgithub_org_posture\x1forganization\x1forg_secret_scanning_policy  ",
+			"repo_finding\x1fowner/repo\x1frepo_misconfiguration\x1fgithub_posture\x1frepository\x1fdefault_branch_protection",
+			"",
+		},
+		SourceDetails: []RepoScanSourceHealth{
+			{Source: "identrail_repo_scanner", Status: RepoScanSourceHealthComplete},
+			{Source: "github_repository_posture", Status: RepoScanSourceHealthComplete},
+			{Source: "github_organization_posture", Status: RepoScanSourceHealthComplete},
+		},
+	}, "")
+	if err != nil {
+		t.Fatalf("complete repo scan failed: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreUpsertRepoFindingsReopensExpiredSuppressionSnapshot(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -806,7 +806,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, "", "", "", "[]", "complete", "[]", nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE repo_findings rf").
-		WithArgs(sqlmock.AnyArg(), "default", "default", record.ID).
+		WithArgs(sqlmock.AnyArg(), "default", "default", record.ID, false, false, true).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
@@ -874,6 +874,46 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("unexpected repo scan: %+v", gotRepoScan)
 	}
 
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreCompleteRepoScanPassesPostureCollectionToClosure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+	repoScanID := "5e7b6f7a-52a3-4d76-8f43-24a1a92d0f11"
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE repo_scans").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// An unrelated source (Dependabot) failed, so the run is partial and
+	// non-posture findings must not close. Repository posture was still
+	// collected completely, so its findings stay eligible; organization posture
+	// was not collected and must not close.
+	mock.ExpectExec("UPDATE repo_findings rf").
+		WithArgs(sqlmock.AnyArg(), "default", "default", repoScanID, true, false, false).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err = store.CompleteRepoScan(defaultScopeContext(), repoScanID, "succeeded", now, 1, 1, 0, false, RepoScanContext{
+		ScanMode:         RepoScanModeDeep,
+		PartialSourceRun: true,
+		SourceDetails: []RepoScanSourceHealth{
+			{Source: "identrail_repo_scanner", Status: RepoScanSourceHealthComplete},
+			{Source: "github_repository_posture", Status: RepoScanSourceHealthComplete},
+			{Source: "github_dependabot", Status: RepoScanSourceHealthRateLimited},
+		},
+	}, "")
+	if err != nil {
+		t.Fatalf("complete repo scan failed: %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
@@ -1153,6 +1193,7 @@ func TestPostgresStoreListRepoFindingClustersPagesInStore(t *testing.T) {
 		"type",
 		"severity",
 		"detector",
+		"source",
 		"title",
 		"human_summary",
 		"remediation",
@@ -1163,8 +1204,8 @@ func TestPostgresStoreListRepoFindingClustersPagesInStore(t *testing.T) {
 		"commit_count",
 		"repo_scan_count",
 	}).
-		AddRow("cluster-key-1", "owner/repo-a", "repo_misconfig", "medium", "workflow_pull_request_target", "title-a", "summary-a", "fix-a", 2, now.Add(-2*time.Hour), now.Add(-1*time.Hour), 2, 1, 2).
-		AddRow("cluster-key-2", "owner/repo-b", "repo_misconfig", "low", "workflow_pull_request_target", "title-b", "summary-b", "fix-b", 1, now.Add(-30*time.Minute), now, 1, 1, 1)
+		AddRow("cluster-key-1", "owner/repo-a", "repo_misconfig", "medium", "workflow_pull_request_target", "", "title-a", "summary-a", "fix-a", 2, now.Add(-2*time.Hour), now.Add(-1*time.Hour), 2, 1, 2).
+		AddRow("cluster-key-2", "owner/repo-b", "repo_misconfig", "low", "workflow_pull_request_target", "github_posture", "title-b", "summary-b", "fix-b", 1, now.Add(-30*time.Minute), now, 1, 1, 1)
 	mock.ExpectQuery("cluster_summaries AS").
 		WithArgs("default", "default", 1, 2).
 		WillReturnRows(summaryRows)
@@ -1205,6 +1246,9 @@ func TestPostgresStoreListRepoFindingClustersPagesInStore(t *testing.T) {
 	}
 	if clusters[0].Members[0].Commit != "abc123" || clusters[0].Members[1].FindingID != "rf-2" {
 		t.Fatalf("expected ordered cluster members, got %+v", clusters[0].Members)
+	}
+	if clusters[1].Source != "github_posture" {
+		t.Fatalf("expected cluster to carry its promotion source, got %+v", clusters[1])
 	}
 	if clusters[1].Repository != "owner/repo-b" || clusters[1].Count != 1 {
 		t.Fatalf("expected second cluster summary, got %+v", clusters[1])

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -382,15 +382,22 @@ type RepoScanSourceHealth struct {
 
 // RepoScanContext captures incremental execution metadata for one scan.
 type RepoScanContext struct {
-	ScanMode         string
-	BaseRevision     string
-	HeadRevision     string
-	CursorBefore     string
-	CursorAfter      string
-	ChangedPaths     []string
-	PartialSourceRun bool
-	SourceHealth     string
-	SourceDetails    []RepoScanSourceHealth
+	ScanMode     string
+	BaseRevision string
+	HeadRevision string
+	CursorBefore string
+	CursorAfter  string
+	ChangedPaths []string
+	// InconclusiveLifecycleKeys are lifecycle keys this scan observed but could
+	// not conclusively re-evaluate, so completion must not close them. A GitHub
+	// posture check that is permission-limited or unavailable still promotes a
+	// finding under the same lifecycle key, but at a confidence and severity the
+	// reportable filter drops. Without this list the key looks absent from the
+	// scan and a real, unverified gap would be marked fixed.
+	InconclusiveLifecycleKeys []string
+	PartialSourceRun          bool
+	SourceHealth              string
+	SourceDetails             []RepoScanSourceHealth
 }
 
 // NormalizeRepoScanContext returns stable scan-mode and revision metadata.
@@ -400,13 +407,14 @@ func NormalizeRepoScanContext(scanContext RepoScanContext) RepoScanContext {
 		mode = RepoScanModeDeep
 	}
 	normalized := RepoScanContext{
-		ScanMode:         mode,
-		BaseRevision:     strings.TrimSpace(scanContext.BaseRevision),
-		HeadRevision:     strings.TrimSpace(scanContext.HeadRevision),
-		CursorBefore:     strings.TrimSpace(scanContext.CursorBefore),
-		CursorAfter:      strings.TrimSpace(scanContext.CursorAfter),
-		ChangedPaths:     normalizeRepoScanChangedPaths(scanContext.ChangedPaths),
-		PartialSourceRun: scanContext.PartialSourceRun,
+		ScanMode:                  mode,
+		BaseRevision:              strings.TrimSpace(scanContext.BaseRevision),
+		HeadRevision:              strings.TrimSpace(scanContext.HeadRevision),
+		CursorBefore:              strings.TrimSpace(scanContext.CursorBefore),
+		CursorAfter:               strings.TrimSpace(scanContext.CursorAfter),
+		ChangedPaths:              normalizeRepoScanChangedPaths(scanContext.ChangedPaths),
+		InconclusiveLifecycleKeys: normalizeRepoScanLifecycleKeys(scanContext.InconclusiveLifecycleKeys),
+		PartialSourceRun:          scanContext.PartialSourceRun,
 	}
 	normalized.SourceHealth, normalized.SourceDetails = NormalizeRepoScanSourceHealth(scanContext.SourceHealth, scanContext.SourceDetails)
 	return normalized
@@ -604,6 +612,30 @@ func (s RepoScanSource) Empty() bool {
 		normalized.ProjectID == "" &&
 		normalized.ConnectorID == "" &&
 		normalized.InstallationID == 0
+}
+
+func normalizeRepoScanLifecycleKeys(keys []string) []string {
+	if len(keys) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(keys))
+	for _, key := range keys {
+		item := strings.TrimSpace(key)
+		if item == "" {
+			continue
+		}
+		if _, exists := seen[item]; exists {
+			continue
+		}
+		seen[item] = struct{}{}
+		normalized = append(normalized, item)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	sort.Strings(normalized)
+	return normalized
 }
 
 func normalizeRepoScanChangedPaths(paths []string) []string {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2911,7 +2911,10 @@ func NormalizeRepoFindingFilter(filter RepoFindingFilter) RepoFindingFilter {
 	return normalized
 }
 
-func shouldCloseMissingRepoFindings(status string, truncated bool, scanContext RepoScanContext) bool {
+// repoScanClosureEligible reports the scan-level gates that apply to closing a
+// missing finding from any source: the scan finished successfully, was not
+// truncated, and covered the whole repository rather than a changed-path slice.
+func repoScanClosureEligible(status string, truncated bool, scanContext RepoScanContext) bool {
 	normalizedStatus := strings.ToLower(strings.TrimSpace(status))
 	if normalizedStatus != "succeeded" && normalizedStatus != "completed" {
 		return false
@@ -2920,10 +2923,54 @@ func shouldCloseMissingRepoFindings(status string, truncated bool, scanContext R
 		return false
 	}
 	normalizedContext := NormalizeRepoScanContext(scanContext)
-	if normalizedContext.PartialSourceRun {
+	return normalizedContext.ScanMode == "deep" && len(normalizedContext.ChangedPaths) == 0
+}
+
+func shouldCloseMissingRepoFindings(status string, truncated bool, scanContext RepoScanContext) bool {
+	if !repoScanClosureEligible(status, truncated, scanContext) {
 		return false
 	}
-	return normalizedContext.ScanMode == "deep" && len(normalizedContext.ChangedPaths) == 0
+	return !NormalizeRepoScanContext(scanContext).PartialSourceRun
+}
+
+// shouldCloseMissingPostureRepoFindings reports whether a completed scan may
+// close missing posture-origin findings. Posture findings are promoted from the
+// GitHub posture collectors rather than from repository content, so their
+// closure is gated on their own posture source being collected completely
+// (checked per finding) instead of on every unrelated enrichment source
+// succeeding. A Dependabot or code-scanning outage says nothing about whether a
+// branch-protection gap was fixed, and blocking closure on it would strand
+// posture findings as permanently open.
+func shouldCloseMissingPostureRepoFindings(status string, truncated bool, scanContext RepoScanContext) bool {
+	return repoScanClosureEligible(status, truncated, scanContext)
+}
+
+// repoFindingPostureCollectionSource maps a posture-origin repo finding to the
+// scan source that must be completely collected before a missing finding may
+// close. A scan that never ran the posture collectors (for example a plain git
+// scan of the same repository) cannot re-observe the gap and must not close it.
+// Non-posture findings return "" and keep the scan-level closure semantics.
+func repoFindingPostureCollectionSource(adapterSource string) string {
+	switch strings.ToLower(strings.TrimSpace(adapterSource)) {
+	case "github_posture":
+		return "github_repository_posture"
+	case "github_org_posture":
+		return "github_organization_posture"
+	default:
+		return ""
+	}
+}
+
+// repoScanSourceCollectedComplete reports whether the scan explicitly recorded a
+// complete collection for one source. A source the scan never reported counts as
+// not collected, so absent telemetry never closes a posture finding.
+func repoScanSourceCollectedComplete(details []RepoScanSourceHealth, source string) bool {
+	for _, detail := range details {
+		if strings.EqualFold(strings.TrimSpace(detail.Source), source) {
+			return detail.Status == RepoScanSourceHealthComplete
+		}
+	}
+	return false
 }
 
 func repoScanCompletionSourceHealth(status string, scanContext RepoScanContext) (string, []RepoScanSourceHealth) {

--- a/internal/domain/repo_finding_clusters.go
+++ b/internal/domain/repo_finding_clusters.go
@@ -36,6 +36,7 @@ type RepoFindingCluster struct {
 	Type         FindingType                `json:"type"`
 	Severity     FindingSeverity            `json:"severity"`
 	Detector     string                     `json:"detector,omitempty"`
+	Source       string                     `json:"source,omitempty"`
 	Title        string                     `json:"title"`
 	HumanSummary string                     `json:"human_summary"`
 	Remediation  string                     `json:"remediation"`
@@ -73,6 +74,7 @@ func BuildRepoFindingClusters(findings []Finding) []RepoFindingCluster {
 					Type:         finding.Type,
 					Severity:     finding.Severity,
 					Detector:     strings.TrimSpace(finding.Detector),
+					Source:       strings.TrimSpace(finding.AdapterSource),
 					Title:        finding.Title,
 					HumanSummary: finding.HumanSummary,
 					Remediation:  finding.Remediation,
@@ -95,6 +97,9 @@ func BuildRepoFindingClusters(findings []Finding) []RepoFindingCluster {
 		}
 		if detector := strings.TrimSpace(finding.Detector); accumulator.cluster.Detector == "" && detector != "" {
 			accumulator.cluster.Detector = detector
+		}
+		if source := strings.TrimSpace(finding.AdapterSource); accumulator.cluster.Source == "" && source != "" {
+			accumulator.cluster.Source = source
 		}
 		if higherRepoFindingSeverity(finding.Severity, accumulator.cluster.Severity) {
 			accumulator.cluster.Severity = finding.Severity
@@ -201,7 +206,16 @@ func repoFindingClusterKey(finding Finding) string {
 	case finding.Type == FindingSecretExposure:
 		return strings.Join([]string{"finding", repository, string(finding.Type), strings.TrimSpace(finding.ScanID), strings.TrimSpace(finding.ID)}, "\x1f")
 	case detector != "":
-		return strings.Join([]string{"detector", repository, string(finding.Type), detector}, "\x1f")
+		parts := []string{"detector", repository, string(finding.Type), detector}
+		// Distinct promotion sources can share one detector (repository and
+		// organization posture both report `github_secret_scanning_disabled`, for
+		// example). Those are separate durable findings, so keep their clusters
+		// separate. The source is only appended when present, so clusters for
+		// findings without an adapter source keep their existing identity.
+		if source := strings.TrimSpace(finding.AdapterSource); source != "" {
+			parts = append(parts, "source", source)
+		}
+		return strings.Join(parts, "\x1f")
 	default:
 		return strings.Join([]string{"finding", repository, string(finding.Type), strings.TrimSpace(finding.ID)}, "\x1f")
 	}

--- a/internal/domain/repo_finding_clusters_test.go
+++ b/internal/domain/repo_finding_clusters_test.go
@@ -66,6 +66,58 @@ func TestBuildRepoFindingClustersGroupsMisconfigMembersByRepositoryAndDetector(t
 	}
 }
 
+func TestBuildRepoFindingClustersSeparatesPostureScopesSharingOneDetector(t *testing.T) {
+	// Repository-scoped `secret_scanning` and organization-scoped
+	// `org_secret_scanning_policy` posture checks intentionally share the
+	// `github_secret_scanning_disabled` detector, but they are distinct durable
+	// findings with distinct lifecycle keys. Clustering must keep them apart so
+	// an org policy gap never hides behind a repository setting.
+	findings := []Finding{
+		{
+			ID:            "f-repo",
+			ScanID:        "scan-1",
+			Type:          FindingRepoMisconfig,
+			Severity:      SeverityHigh,
+			Title:         "GitHub posture gap: secret scanning",
+			Repository:    "owner/repo",
+			Detector:      "github_secret_scanning_disabled",
+			AdapterSource: "github_posture",
+			CreatedAt:     time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC),
+		},
+		{
+			ID:            "f-org",
+			ScanID:        "scan-1",
+			Type:          FindingRepoMisconfig,
+			Severity:      SeverityHigh,
+			Title:         "GitHub posture gap: org secret scanning policy",
+			Repository:    "owner/repo",
+			Detector:      "github_secret_scanning_disabled",
+			AdapterSource: "github_org_posture",
+			CreatedAt:     time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC),
+		},
+	}
+
+	clusters := BuildRepoFindingClusters(findings)
+	if len(clusters) != 2 {
+		t.Fatalf("expected posture scopes to cluster separately, got %+v", clusters)
+	}
+	bySource := map[string]RepoFindingCluster{}
+	for _, cluster := range clusters {
+		bySource[cluster.Source] = cluster
+	}
+	repoCluster, ok := bySource["github_posture"]
+	if !ok || repoCluster.Count != 1 || repoCluster.Detector != "github_secret_scanning_disabled" {
+		t.Fatalf("expected repository posture cluster, got %+v", clusters)
+	}
+	orgCluster, ok := bySource["github_org_posture"]
+	if !ok || orgCluster.Count != 1 || orgCluster.Detector != "github_secret_scanning_disabled" {
+		t.Fatalf("expected organization posture cluster, got %+v", clusters)
+	}
+	if repoCluster.ID == orgCluster.ID {
+		t.Fatalf("expected distinct cluster ids per posture source, got %s", repoCluster.ID)
+	}
+}
+
 func TestBuildRepoFindingClustersGroupsSecretsByFingerprint(t *testing.T) {
 	findings := []Finding{
 		{


### PR DESCRIPTION
## Summary

Makes GitHub posture gaps behave like durable repository findings (#1709) rather
than one-off scan output: they age, close, reopen, suppress, cluster, and appear
in trends through the existing repository finding lifecycle model.

Posture findings already carried stable `lifecycle_key`s (repository + type +
adapter source + posture scope + check id, independent of scan row ids). The
gaps were in closure semantics and aggregation:

**Posture closure is now gated on the posture source, not the whole scan.**
`shouldCloseMissingRepoFindings` bailed out globally whenever `PartialSourceRun`
was set, which happens when *any* source is degraded. So a rate-limited
Dependabot call — or a code-scanning collector that was simply not configured —
marked the run partial and blocked closure for every source, including posture
findings whose own `github_repository_posture` collection completed cleanly. A
Dependabot outage says nothing about whether a branch-protection gap was fixed,
so that could strand posture findings as permanently open after the underlying
control was already remediated.

Closure is now decided per finding:

- A posture finding closes only when a completed, non-truncated deep scan
  reported its own posture source (`github_repository_posture` /
  `github_organization_posture`) as `complete` and no longer observed the gap.
- A scan that never ran posture collection (a plain repository scan) leaves
  posture findings open — it could not re-observe them. Absent telemetry is
  treated as "not collected", never as "gone".
- Permission-limited, rate-limited, or unavailable posture collection leaves
  posture findings open.
- Non-posture findings keep exactly their existing scan-level closure gate.

**Clusters are now keyed by promotion source in addition to detector.**
Repository- and organization-scoped posture checks intentionally share some
detectors (`secret_scanning` and `org_secret_scanning_policy` both map to
`github_secret_scanning_disabled`; likewise `actions_permissions` /
`org_actions_policy`). Those are distinct durable findings with distinct
lifecycle keys, but the cluster key ignored source, so they silently merged into
one cluster — hiding an org policy gap behind a repository setting. Clusters now
carry a `source` field and separate by source. The source is only appended to
the key when present, so clusters for findings without an adapter source keep
their existing identity.

Memory and Postgres stores implement identical semantics (the Postgres cluster
CTE mirrors `domain.repoFindingClusterKey`).

## Why

Once posture gaps are promoted into repository findings, operators need them to
behave like findings: to close when the control is fixed, to reopen when it
regresses, and to roll up correctly. Without per-source closure they either
never close (blocked by unrelated source health) or would close unsafely if the
global gate were simply removed.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered — non-posture closure behavior is
      unchanged; cluster identity is unchanged for findings without an adapter
      source; no schema migration (reuses the existing `adapter_source` column)
- [x] Risk level assessed — lifecycle transitions are covered by regression
      tests on both complete and partial collection paths

## Validation

```bash
go test ./...                              # pass (full suite)
make fmt-check                             # pass
go vet ./...                               # pass
./scripts/check_api_example_contract.sh    # pass
./scripts/check_web_route_integrity.sh     # pass
```

New regression tests:

- `TestServiceGitHubAppRepoScanClosesAndReopensPostureFindingsAcrossCompleteScans`
  — full open → fixed → reopened cycle across three scans, asserting the stable
  lifecycle key, preserved `first_seen_at` age, and that summary counts,
  owner/detector/source filters, clusters, and trend buckets all include the
  posture finding.
- `TestServiceRepoScanWithoutPostureCollectionPreservesPostureFindings`
  — a complete plain scan closes a missing native finding but leaves the posture
  finding open; a later scan that did collect posture closes it.
- `TestPostgresStoreCompleteRepoScanPassesPostureCollectionToClosure`
  — a partial run (Dependabot rate-limited) still allows repository-posture
  closure while blocking non-posture and uncollected organization posture.
- `TestBuildRepoFindingClustersSeparatesPostureScopesSharingOneDetector`
  — repository and organization posture sharing one detector cluster separately.

Existing coverage kept green, including
`TestServiceProcessQueuedGitHubAppRepoScanPreservesPostureFindingsWhenPostureSourceFails`
and `TestServiceRepoFindingLifecycleTracksFixedAndReopenedAcrossScans`.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no

## Related Issues

Closes #1709

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates GitHub posture findings into the durable repo finding lifecycle and trends/clusters, and ensures posture gaps only close when their own source ran and the check had a definitive fix. Implements #1709, including cluster keys by promotion source and `source` in cluster APIs.

- **New Features**
  - Posture findings close only when a completed, non-truncated deep scan collected their own posture source (`github_repository_posture` or `github_organization_posture`) and the check was conclusively fixed: `secure`, or `unsupported:not_an_organization`. Inconclusive checks (`permission_limited`, `unavailable`, `unknown`, or `unsupported` due to plan limits) never close; their lifecycle keys are passed through as inconclusive to prevent false fixes.
  - Clusters include `source` and are keyed by detector + source (e.g., `github_posture` vs `github_org_posture`); findings without a source keep their current cluster identity.
  - Trends, summary rollups, and filters include posture findings using their stable `lifecycle_key`.

- **Bug Fixes**
  - Removed the global partial-run gate for posture closure. Unrelated source failures (e.g., Dependabot) no longer block closing posture gaps; scans that didn’t collect posture leave them open. Non-posture findings keep existing scan-level closure rules.

<sup>Written for commit 831475af8bde23c994c2e3884b3b3f886ee46550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

