### PR TITLE
Extend repo risk graph with GitHub posture and control-plane nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@
   `posture_amplifier` factor so proven-weak controls such as an unprotected
   default branch, a broad Actions policy, self-hosted runners, writable deploy
   keys, or unprotected production environments widen blast radius. Posture
-  sources the scanner could not read stay visible as unknown nodes, unknown
-  edges, and a `posture_source` score unknown rather than being scored or
-  silently dropped.
+  sources the scanner could not read still return a normal numeric score, but
+  stay visible as unknown graph nodes, unknown graph edges, a `posture_source`
+  entry in the score's `unknowns` list, and a zero `posture_amplifier`, so an
+  unreadable control is never silently dropped or mistaken for a weak one.
 - Replace the first-run **Connect AWS** screen with a scope-first single-account
   setup wizard (#1750). Operators now choose the supported account scope, enter
   a display name and setup region, launch the CloudFormation stack through a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Remove the GitHub stars pill from the marketing homepage hero. The remaining
+  Docker pulls pill now sits where the pair used to, so the hero no longer
+  advertises a low star count. Also drops the GitHub REST call the pill made on
+  every page load.
 - Extend the **repository risk graph with GitHub control-plane posture** (#1710).
   `GET /v1/repo-risk-graph` now represents branch protection, repository
   rulesets, Actions policy, default workflow permissions, reusable workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 ## Unreleased
+- Extend the **repository risk graph with GitHub control-plane posture** (#1710).
+  `GET /v1/repo-risk-graph` now represents branch protection, repository
+  rulesets, Actions policy, default workflow permissions, reusable workflow
+  policy, self-hosted runner groups, deployment environment protection, deploy
+  keys, webhooks, native alert sources, and organization security configuration
+  as graph nodes, linked by `repository_governed_by_control`,
+  `repository_inherits_org_policy`, `workflow_runs_on_runner_group`,
+  `finding_weakens_control`, `finding_exposes_control_risk`, and
+  `finding_depends_on_posture_source` edges. Finding scores gain a
+  `posture_amplifier` factor so proven-weak controls such as an unprotected
+  default branch, a broad Actions policy, self-hosted runners, writable deploy
+  keys, or unprotected production environments widen blast radius. Posture
+  sources the scanner could not read stay visible as unknown nodes, unknown
+  edges, and a `posture_source` score unknown rather than being scored or
+  silently dropped.
 - Replace the first-run **Connect AWS** screen with a scope-first single-account
   setup wizard (#1750). Operators now choose the supported account scope, enter
   a display name and setup region, launch the CloudFormation stack through a

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -26079,7 +26079,7 @@ components:
         id: { type: string }
         kind:
           type: string
-          enum: [repository, default_branch, finding, workflow, workflow_job, environment, secret, deploy_key, github_app, token, oidc_subject, cloud_role, kubernetes_service_account, unknown]
+          enum: [repository, default_branch, finding, workflow, workflow_job, environment, secret, deploy_key, github_app, token, oidc_subject, cloud_role, kubernetes_service_account, branch_protection, repository_ruleset, actions_policy, workflow_permission_default, reusable_workflow_policy, runner_group, environment_protection, webhook, alert_source, org_security_configuration, unknown]
         label: { type: string }
         repository: { type: string }
         evidence_state:
@@ -26094,7 +26094,7 @@ components:
         id: { type: string }
         kind:
           type: string
-          enum: [repository_contains_workflow, repository_default_branch, finding_in_repository, finding_affects_workflow, workflow_runs_job, job_uses_secret, finding_exposes_token, workflow_can_mint_token, oidc_subject_can_assume_role, repo_deploys_to_environment, finding_references_identity, reachability_unknown]
+          enum: [repository_contains_workflow, repository_default_branch, finding_in_repository, finding_affects_workflow, workflow_runs_job, job_uses_secret, finding_exposes_token, workflow_can_mint_token, oidc_subject_can_assume_role, repo_deploys_to_environment, finding_references_identity, repository_governed_by_control, repository_inherits_org_policy, workflow_runs_on_runner_group, finding_weakens_control, finding_exposes_control_risk, finding_depends_on_posture_source, reachability_unknown]
         from_node_id: { type: string }
         to_node_id: { type: string }
         evidence_state:
@@ -26155,6 +26155,17 @@ components:
           type: integer
           minimum: 0
           maximum: 100
+        posture_amplifier:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: >-
+            How strongly a proven-weak GitHub control (branch protection, Actions
+            policy, self-hosted runners, write deploy keys, unprotected
+            environments) widens this finding's blast radius. Zero when the
+            finding is not posture-backed, or when the control could not be read;
+            unreadable posture sources appear as unknown nodes, unknown edges,
+            and a "posture_source" entry in unknowns instead.
     RepoRiskGraphSummary:
       type: object
       properties:

--- a/internal/connectors/github/posture.go
+++ b/internal/connectors/github/posture.go
@@ -672,9 +672,11 @@ func (c RepositoryClient) collectEnvironments(ctx context.Context, token string,
 		return checkFromAPIError("deployment_environments", "deployments", err, RepositoryPostureStateUnavailable, "api_unavailable", "Deployment environments could not be collected.")
 	}
 	unprotected := 0
+	unprotectedCriticality := ""
 	for _, environment := range environments {
 		if len(environment.ProtectionRules) == 0 {
 			unprotected++
+			unprotectedCriticality = higherEnvironmentCriticality(unprotectedCriticality, environmentCriticalityTier(environment.Name))
 		}
 	}
 	if totalCount < len(environments) {
@@ -684,6 +686,12 @@ func (c RepositoryClient) collectEnvironments(ctx context.Context, token string,
 		"repository":               repository,
 		"environment_count":        totalCount,
 		"unprotected_environments": unprotected,
+	}
+	// Carry the highest unprotected-environment criticality tier, not the
+	// environment names, so downstream scoring can amplify unprotected
+	// production environments without leaking environment identifiers.
+	if unprotectedCriticality != "" {
+		evidence["unprotected_environment_criticality"] = unprotectedCriticality
 	}
 	if totalCount > 0 && unprotected > 0 {
 		return RepositoryPostureCheck{
@@ -703,6 +711,45 @@ func (c RepositoryClient) collectEnvironments(ctx context.Context, token string,
 		Summary:  "Deployment environments are protected or none were returned.",
 		Evidence: evidence,
 	}
+}
+
+// environmentCriticalityTier classifies a deployment environment name into a
+// coarse criticality tier. It intentionally returns only the tier, never the
+// name, so posture evidence stays summary-shaped.
+func environmentCriticalityTier(name string) string {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	switch {
+	case normalized == "":
+		return "unknown"
+	case strings.Contains(normalized, "stag") || strings.Contains(normalized, "preprod"):
+		return "staging"
+	case strings.Contains(normalized, "prod") || strings.Contains(normalized, "live"):
+		return "production"
+	case strings.Contains(normalized, "dev") || strings.Contains(normalized, "test") || strings.Contains(normalized, "sandbox"):
+		return "development"
+	default:
+		return "unknown"
+	}
+}
+
+// higherEnvironmentCriticality returns the more severe of two criticality tiers.
+func higherEnvironmentCriticality(left string, right string) string {
+	rank := func(tier string) int {
+		switch tier {
+		case "production":
+			return 3
+		case "staging":
+			return 2
+		case "development":
+			return 1
+		default:
+			return 0
+		}
+	}
+	if rank(right) > rank(left) {
+		return right
+	}
+	return left
 }
 
 // collectSelfHostedRunners reports whether the repository can run jobs on

--- a/internal/connectors/github/posture_findings_test.go
+++ b/internal/connectors/github/posture_findings_test.go
@@ -350,13 +350,13 @@ func TestPostureFindingsBuildControlPlaneRiskGraph(t *testing.T) {
 				ID:       "code_scanning",
 				Category: "security",
 				State:    RepositoryPostureStateInsecure,
-				Reason:   "open_alerts_present",
+				Reason:   "not_configured",
 			},
 			{
 				ID:       "secret_scanning",
 				Category: "security",
 				State:    RepositoryPostureStateInsecure,
-				Reason:   "open_alerts_present",
+				Reason:   "not_configured",
 			},
 			{
 				ID:       "dependabot_security",

--- a/internal/connectors/github/posture_findings_test.go
+++ b/internal/connectors/github/posture_findings_test.go
@@ -206,3 +206,179 @@ func findingByDetector(findings []domain.Finding, detector string) *domain.Findi
 	}
 	return nil
 }
+
+// TestPostureFindingsBuildControlPlaneRiskGraph pins the contract between the
+// posture collector and the repo risk graph: every control-plane check the
+// collector can report must resolve to a graph node. It fails if a check ID is
+// renamed here without updating the graph mapping in internal/domain.
+func TestPostureFindingsBuildControlPlaneRiskGraph(t *testing.T) {
+	collectedAt := time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC)
+	repositoryPosture := RepositoryPosture{
+		Repository:  "owner/repo",
+		CollectedAt: collectedAt,
+		Checks: []RepositoryPostureCheck{
+			{
+				ID:       "default_branch_protection",
+				Category: "branch_protection",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "weak_protection",
+				Evidence: map[string]any{"default_branch": "main", "force_pushes_allowed": true},
+			},
+			{
+				ID:       "repository_rulesets",
+				Category: "branch_protection",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "no_active_rulesets",
+			},
+			{
+				ID:       "actions_permissions",
+				Category: "actions",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "broad_actions_or_write_privileges",
+				Evidence: map[string]any{"allowed_actions": "all"},
+			},
+			{
+				ID:       "deploy_keys",
+				Category: "access",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "writable_deploy_keys_present",
+				Evidence: map[string]any{"writable_deploy_keys": 1},
+			},
+			{
+				ID:       "webhooks",
+				Category: "webhooks",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "risky_webhooks_present",
+				Evidence: map[string]any{"insecure_ssl_hooks": 1},
+			},
+			{
+				ID:       "deployment_environments",
+				Category: "deployments",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "unprotected_environments",
+				Evidence: map[string]any{"unprotected_environments": 1},
+			},
+			{
+				ID:       "self_hosted_runners",
+				Category: "runners",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "self_hosted_runners_present",
+			},
+			{
+				ID:       "code_scanning",
+				Category: "security",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "open_alerts_present",
+			},
+			{
+				ID:       "secret_scanning",
+				Category: "security",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "open_alerts_present",
+			},
+			{
+				ID:       "dependabot_security",
+				Category: "security",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "dependabot_security_disabled",
+			},
+		},
+	}
+	organizationPosture := OrganizationPosture{
+		Organization: "owner",
+		CollectedAt:  collectedAt,
+		Checks: []RepositoryPostureCheck{
+			{
+				ID:       "org_actions_policy",
+				Category: "actions",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "all_actions_allowed",
+			},
+			{
+				ID:       "org_workflow_permissions",
+				Category: "actions",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "write_default",
+			},
+			{
+				ID:       "org_reusable_workflow_policy",
+				Category: "actions",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "verified_creators_allowed",
+			},
+			{
+				ID:       "org_secret_scanning_policy",
+				Category: "secret_scanning",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "push_protection_disabled",
+			},
+			{
+				ID:       "org_code_security_configuration",
+				Category: "code_security",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "configuration_not_enforced",
+			},
+		},
+	}
+
+	findings := RepositoryPostureFindings(repositoryPosture, collectedAt)
+	findings = append(findings, OrganizationPostureFindings(organizationPosture, "owner/repo", collectedAt)...)
+	graph := domain.BuildRepoRiskGraph(findings, domain.RepoRiskGraphOptions{
+		Repository:    "owner/repo",
+		DefaultBranch: "main",
+		Now:           collectedAt,
+	})
+
+	for _, kind := range []domain.RepoRiskGraphNodeKind{
+		domain.RepoRiskNodeBranchProtection,
+		domain.RepoRiskNodeRepositoryRuleset,
+		domain.RepoRiskNodeActionsPolicy,
+		domain.RepoRiskNodeWorkflowPermissionDefault,
+		domain.RepoRiskNodeReusableWorkflowPolicy,
+		domain.RepoRiskNodeRunnerGroup,
+		domain.RepoRiskNodeEnvironmentProtection,
+		domain.RepoRiskNodeDeployKey,
+		domain.RepoRiskNodeWebhook,
+		domain.RepoRiskNodeAlertSource,
+		domain.RepoRiskNodeOrgSecurityConfiguration,
+	} {
+		if !graphHasNodeKind(graph, kind) {
+			t.Fatalf("expected posture findings to build a %q node, got %+v", kind, graph.Nodes)
+		}
+	}
+
+	for _, kind := range []domain.RepoRiskGraphEdgeKind{
+		domain.RepoRiskEdgeRepositoryGovernedBy,
+		domain.RepoRiskEdgeInheritsOrgPolicy,
+		domain.RepoRiskEdgeFindingWeakensControl,
+		domain.RepoRiskEdgeFindingExposesControl,
+	} {
+		if !graphHasEdgeKind(graph, kind) {
+			t.Fatalf("expected posture findings to build a %q edge, got %+v", kind, graph.Edges)
+		}
+	}
+
+	for _, score := range graph.Scores {
+		if score.Factors.PostureAmplifier == 0 {
+			t.Fatalf("expected every insecure posture finding to amplify its score, got %+v", score)
+		}
+	}
+}
+
+func graphHasNodeKind(graph domain.RepoRiskGraph, kind domain.RepoRiskGraphNodeKind) bool {
+	for _, node := range graph.Nodes {
+		if node.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func graphHasEdgeKind(graph domain.RepoRiskGraph, kind domain.RepoRiskGraphEdgeKind) bool {
+	for _, edge := range graph.Edges {
+		if edge.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/connectors/github/posture_test.go
+++ b/internal/connectors/github/posture_test.go
@@ -408,3 +408,35 @@ func postureCheckByID(posture RepositoryPosture, id string) RepositoryPostureChe
 	}
 	return RepositoryPostureCheck{}
 }
+
+func TestEnvironmentCriticalityTierClassifiesRedactedTiers(t *testing.T) {
+	cases := map[string]string{
+		"production":  "production",
+		"prod-us":     "production",
+		"go-live":     "production",
+		"staging":     "staging",
+		"preprod":     "staging",
+		"development": "development",
+		"qa-test":     "development",
+		"sandbox":     "development",
+		"ephemeral":   "unknown",
+		"":            "unknown",
+	}
+	for name, want := range cases {
+		if got := environmentCriticalityTier(name); got != want {
+			t.Errorf("environmentCriticalityTier(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestHigherEnvironmentCriticalityKeepsMostSevereTier(t *testing.T) {
+	if got := higherEnvironmentCriticality("development", "production"); got != "production" {
+		t.Fatalf("expected production to outrank development, got %q", got)
+	}
+	if got := higherEnvironmentCriticality("staging", "development"); got != "staging" {
+		t.Fatalf("expected staging to outrank development, got %q", got)
+	}
+	if got := higherEnvironmentCriticality("production", ""); got != "production" {
+		t.Fatalf("expected an existing production tier to survive an unknown, got %q", got)
+	}
+}

--- a/internal/domain/repo_risk_graph.go
+++ b/internal/domain/repo_risk_graph.go
@@ -33,6 +33,22 @@ const (
 	RepoRiskNodeUnknown                  RepoRiskGraphNodeKind = "unknown"
 )
 
+// GitHub control-plane posture node kinds. Each one is created only from a
+// GitHub posture check that the collector actually ran; a control the scanner
+// could not observe is still represented, but with unknown evidence state.
+const (
+	RepoRiskNodeBranchProtection          RepoRiskGraphNodeKind = "branch_protection"
+	RepoRiskNodeRepositoryRuleset         RepoRiskGraphNodeKind = "repository_ruleset"
+	RepoRiskNodeActionsPolicy             RepoRiskGraphNodeKind = "actions_policy"
+	RepoRiskNodeWorkflowPermissionDefault RepoRiskGraphNodeKind = "workflow_permission_default"
+	RepoRiskNodeReusableWorkflowPolicy    RepoRiskGraphNodeKind = "reusable_workflow_policy"
+	RepoRiskNodeRunnerGroup               RepoRiskGraphNodeKind = "runner_group"
+	RepoRiskNodeEnvironmentProtection     RepoRiskGraphNodeKind = "environment_protection"
+	RepoRiskNodeWebhook                   RepoRiskGraphNodeKind = "webhook"
+	RepoRiskNodeAlertSource               RepoRiskGraphNodeKind = "alert_source"
+	RepoRiskNodeOrgSecurityConfiguration  RepoRiskGraphNodeKind = "org_security_configuration"
+)
+
 // RepoRiskGraphEdgeKind describes directional evidence between graph nodes.
 type RepoRiskGraphEdgeKind string
 
@@ -49,6 +65,16 @@ const (
 	RepoRiskEdgeRepoDeploysEnvironment RepoRiskGraphEdgeKind = "repo_deploys_to_environment"
 	RepoRiskEdgeFindingReferencesID    RepoRiskGraphEdgeKind = "finding_references_identity"
 	RepoRiskEdgeReachabilityUnknown    RepoRiskGraphEdgeKind = "reachability_unknown"
+)
+
+// GitHub control-plane posture edge kinds.
+const (
+	RepoRiskEdgeRepositoryGovernedBy          RepoRiskGraphEdgeKind = "repository_governed_by_control"
+	RepoRiskEdgeInheritsOrgPolicy             RepoRiskGraphEdgeKind = "repository_inherits_org_policy"
+	RepoRiskEdgeWorkflowRunsOnRunnerGroup     RepoRiskGraphEdgeKind = "workflow_runs_on_runner_group"
+	RepoRiskEdgeFindingWeakensControl         RepoRiskGraphEdgeKind = "finding_weakens_control"
+	RepoRiskEdgeFindingExposesControl         RepoRiskGraphEdgeKind = "finding_exposes_control_risk"
+	RepoRiskEdgeFindingDependsOnPostureSource RepoRiskGraphEdgeKind = "finding_depends_on_posture_source"
 )
 
 // RepoRiskGraphEvidenceState records whether a node or edge is backed by direct
@@ -129,6 +155,7 @@ type RepoRiskGraphScoreFactors struct {
 	Exposure               int `json:"exposure"`
 	EnvironmentCriticality int `json:"environment_criticality"`
 	Freshness              int `json:"freshness"`
+	PostureAmplifier       int `json:"posture_amplifier"`
 }
 
 type repoRiskGraphBuilder struct {
@@ -136,6 +163,12 @@ type repoRiskGraphBuilder struct {
 	nodes map[string]RepoRiskGraphNode
 	edges map[string]RepoRiskGraphEdge
 	now   time.Time
+
+	// runnerGroupNodes and workflowNodes are collected per repository so that
+	// workflow-to-runner-group reachability can be linked once every finding has
+	// contributed its nodes.
+	runnerGroupNodes map[string][]string
+	workflowNodes    map[string][]string
 }
 
 // BuildRepoRiskGraph builds a deterministic graph from repository findings and
@@ -156,9 +189,11 @@ func BuildRepoRiskGraph(findings []Finding, options RepoRiskGraphOptions) RepoRi
 		now = time.Now().UTC()
 	}
 	builder := repoRiskGraphBuilder{
-		nodes: map[string]RepoRiskGraphNode{},
-		edges: map[string]RepoRiskGraphEdge{},
-		now:   now.UTC(),
+		nodes:            map[string]RepoRiskGraphNode{},
+		edges:            map[string]RepoRiskGraphEdge{},
+		now:              now.UTC(),
+		runnerGroupNodes: map[string][]string{},
+		workflowNodes:    map[string][]string{},
 	}
 
 	repository := strings.TrimSpace(options.Repository)
@@ -222,11 +257,13 @@ func BuildRepoRiskGraph(findings []Finding, options RepoRiskGraphOptions) RepoRi
 		builder.addSecretAndTokenReachability(finding, findingPublicID, findingNodeID, jobID, findingRepository)
 		builder.addOIDCReachability(finding, findingPublicID, findingNodeID, workflowID, jobID, findingRepository)
 		builder.addIdentityReachability(finding, findingPublicID, findingNodeID, findingRepository)
+		builder.addPostureReachability(finding, findingPublicID, findingNodeID, repositoryNodeID, findingRepository)
 
 		score := scoreRepoRiskFinding(finding, builder.now, findingPublicID, findingNodeID)
 		builder.graph.Scores = append(builder.graph.Scores, score)
 	}
 
+	builder.linkWorkflowsToRunnerGroups()
 	builder.finish()
 	return builder.graph
 }
@@ -280,6 +317,7 @@ func (builder *repoRiskGraphBuilder) addWorkflowReachability(finding Finding, fi
 		"file_path":  workflowPath,
 		"repository": repository,
 	})
+	builder.rememberWorkflowNode(repository, workflowID)
 	if repositoryNodeID != "" {
 		builder.upsertEdge(RepoRiskEdgeContainsWorkflow, repositoryNodeID, workflowID, RepoRiskEvidenceKnown, map[string]any{
 			"file_path": workflowPath,
@@ -581,6 +619,7 @@ func scoreRepoRiskFinding(finding Finding, now time.Time, findingID string, find
 		Exposure:               repoRiskExposureFactor(finding),
 		EnvironmentCriticality: repoRiskEnvironmentFactor(finding),
 		Freshness:              repoRiskFreshnessFactor(finding, now),
+		PostureAmplifier:       repoRiskPostureAmplifierFactor(finding),
 	}
 	weighted := float64(factors.Severity)*0.60 +
 		float64(factors.Confidence)*0.10 +
@@ -589,6 +628,10 @@ func scoreRepoRiskFinding(finding Finding, now time.Time, findingID string, find
 		float64(factors.Exposure)*0.05 +
 		float64(factors.EnvironmentCriticality)*0.02 +
 		float64(factors.Freshness)*0.01
+	// The posture amplifier sits on top of the weighted base rather than inside
+	// it: a weak control raises the blast radius of a proven gap, but it must not
+	// dilute the severity, confidence, and reachability signals below.
+	weighted += float64(factors.PostureAmplifier) * 0.10
 	score := int(math.Round(weighted))
 	score = clampInt(score, 0, 100)
 	return RepoRiskGraphFindingScore{
@@ -755,6 +798,9 @@ func repoRiskUnknowns(finding Finding) []string {
 	if workflowPathForFinding(finding) != "" && strings.TrimSpace(stringFromAny(finding.Evidence["workflow_job"])) == "" {
 		unknowns = append(unknowns, "workflow_job")
 	}
+	if control, ok := repoRiskPostureControlForFinding(finding); ok && !control.Observed() {
+		unknowns = append(unknowns, "posture_source")
+	}
 	sort.Strings(unknowns)
 	return unknowns
 }
@@ -829,6 +875,12 @@ func findingReferencesSecrets(finding Finding) bool {
 	}
 	if references, ok := boolFromAny(finding.Evidence["references_secrets"]); ok && references {
 		return true
+	}
+	// A GitHub posture check reports on a control, not on a secret the workflow
+	// consumes. Detectors such as github_secret_scanning_disabled would otherwise
+	// match the detector-name heuristic below and invent a secret node.
+	if _, ok := repoRiskPostureControlForFinding(finding); ok {
+		return false
 	}
 	detector := strings.ToLower(strings.TrimSpace(finding.Detector))
 	return strings.Contains(detector, "secret")

--- a/internal/domain/repo_risk_graph.go
+++ b/internal/domain/repo_risk_graph.go
@@ -510,10 +510,17 @@ func (builder *repoRiskGraphBuilder) upsertNode(kind RepoRiskGraphNodeKind, natu
 	if node.Label == "" && strings.TrimSpace(label) != "" {
 		node.Label = strings.TrimSpace(label)
 	}
+	// When a later finding observes what an earlier finding could only mark as
+	// unknown, upgrading only EvidenceState would leave the node claiming
+	// "known" while its evidence still describes the earlier unknown state
+	// (state, timestamps, and any other conflicting keys). Prefer the new
+	// observed evidence on conflict so the promoted node reads coherently.
 	if node.EvidenceState == RepoRiskEvidenceUnknown && state == RepoRiskEvidenceKnown {
 		node.EvidenceState = RepoRiskEvidenceKnown
+		node.Evidence = mergeEvidence(evidence, node.Evidence)
+	} else {
+		node.Evidence = mergeEvidence(node.Evidence, evidence)
 	}
-	node.Evidence = mergeEvidence(node.Evidence, evidence)
 	builder.nodes[id] = node
 	return id
 }
@@ -542,8 +549,10 @@ func (builder *repoRiskGraphBuilder) upsertEdge(kind RepoRiskGraphEdgeKind, from
 	}
 	if edge.EvidenceState == RepoRiskEvidenceUnknown && state == RepoRiskEvidenceKnown {
 		edge.EvidenceState = RepoRiskEvidenceKnown
+		edge.Evidence = mergeEvidence(evidence, edge.Evidence)
+	} else {
+		edge.Evidence = mergeEvidence(edge.Evidence, evidence)
 	}
-	edge.Evidence = mergeEvidence(edge.Evidence, evidence)
 	builder.edges[id] = edge
 	return id
 }

--- a/internal/domain/repo_risk_graph_posture.go
+++ b/internal/domain/repo_risk_graph_posture.go
@@ -222,17 +222,26 @@ func (builder *repoRiskGraphBuilder) addPostureReachability(finding Finding, fin
 
 	if repositoryNodeID != "" {
 		governanceKind := RepoRiskEdgeRepositoryGovernedBy
+		emitGovernance := true
 		if control.Scope == repoRiskPostureScopeOrganization {
 			governanceKind = RepoRiskEdgeInheritsOrgPolicy
+			// An inheritance edge asserts the repository is actually governed by
+			// the organization control. When the evidence says the repository is
+			// not attached (or no central configuration exists), claiming
+			// inheritance contradicts the finding and would let traversal treat an
+			// uncovered repository as protected, so no edge is emitted.
+			emitGovernance = repoRiskPostureRepositoryInheritsOrgControl(finding, control)
 		}
-		governanceEvidence := map[string]any{
-			"github_posture_check_id": control.CheckID,
-			"github_posture_scope":    control.Scope,
+		if emitGovernance {
+			governanceEvidence := map[string]any{
+				"github_posture_check_id": control.CheckID,
+				"github_posture_scope":    control.Scope,
+			}
+			if control.Organization != "" {
+				governanceEvidence["organization"] = control.Organization
+			}
+			builder.upsertEdge(governanceKind, repositoryNodeID, controlNodeID, controlState, governanceEvidence)
 		}
-		if control.Organization != "" {
-			governanceEvidence["organization"] = control.Organization
-		}
-		builder.upsertEdge(governanceKind, repositoryNodeID, controlNodeID, controlState, governanceEvidence)
 	}
 
 	if !control.Observed() {
@@ -409,6 +418,31 @@ func repoRiskPostureAmplifierFactor(finding Finding) int {
 		score = 20
 	}
 	return clampInt(score, 0, 100)
+}
+
+// repoRiskPostureRepositoryInheritsOrgControl reports whether an organization
+// posture finding describes a control the repository is actually attached to.
+// Organization-wide policies (Actions source policy, default workflow token,
+// reusable workflow allowlist) apply to every repository in the organization,
+// so inheritance holds. Code security configurations and secret-scanning
+// policies only apply when the repository is attached; a finding that reports it
+// is unattached, or that no central configuration exists, is not inheritance.
+func repoRiskPostureRepositoryInheritsOrgControl(finding Finding, control repoRiskPostureControl) bool {
+	if control.Scope != repoRiskPostureScopeOrganization {
+		return true
+	}
+	switch control.CheckID {
+	case "org_secret_scanning_policy":
+		// An insecure secret-scanning policy always means the repository does not
+		// inherit enforced secret scanning and push protection.
+		return false
+	case "org_code_security_configuration":
+		switch firstEvidenceString(finding.Evidence, "github_posture_reason") {
+		case "no_central_configuration", "configuration_not_applied":
+			return false
+		}
+	}
+	return true
 }
 
 // repoRiskPostureAlertSourceFunctioning reports whether a posture finding names

--- a/internal/domain/repo_risk_graph_posture.go
+++ b/internal/domain/repo_risk_graph_posture.go
@@ -124,13 +124,16 @@ func repoRiskPostureControlForFinding(finding Finding) (repoRiskPostureControl, 
 		control.Kind = RepoRiskNodeRepositoryRuleset
 		control.Label = "repository rulesets"
 	case "actions_permissions":
-		// The repository Actions check is a combined control: it flags both broad
-		// action sources and a write-by-default workflow token. When the action
-		// sources are restricted but the default token is write, the weak control
-		// is the workflow-permission default, not the Actions source policy, so it
-		// must resolve to its own node instead of being attributed to the policy.
+		// The repository Actions check is a combined control: it flags broad
+		// action sources, a write-by-default workflow token, and Actions being
+		// allowed to approve pull-request reviews. When action sources are
+		// restricted, the weak control is the workflow-permission default (either
+		// the write default or the PR-approval privilege it grants), not the
+		// Actions source policy, so it must resolve to its own node instead of
+		// being attributed to the policy.
 		if !strings.EqualFold(firstEvidenceString(finding.Evidence, "allowed_actions"), "all") &&
-			strings.EqualFold(firstEvidenceString(finding.Evidence, "default_workflow_permissions"), "write") {
+			(strings.EqualFold(firstEvidenceString(finding.Evidence, "default_workflow_permissions"), "write") ||
+				evidenceBool(finding.Evidence, "can_approve_pull_request_reviews")) {
 			control.Kind = RepoRiskNodeWorkflowPermissionDefault
 			control.Label = "default workflow permissions: repository"
 		} else {
@@ -429,6 +432,14 @@ func repoRiskPostureAmplifierFactor(finding Finding) int {
 // is unattached, or that no central configuration exists, is not inheritance.
 func repoRiskPostureRepositoryInheritsOrgControl(finding Finding, control repoRiskPostureControl) bool {
 	if control.Scope != repoRiskPostureScopeOrganization {
+		return true
+	}
+	// Only observed evidence can prove the repository is not attached. When the
+	// check is permission_limited, unavailable, or unknown, whether the repository
+	// inherits the control is itself unknown, so the caller must keep an
+	// unknown-state inheritance edge rather than dropping the governance link
+	// silently.
+	if !control.Observed() {
 		return true
 	}
 	switch control.CheckID {

--- a/internal/domain/repo_risk_graph_posture.go
+++ b/internal/domain/repo_risk_graph_posture.go
@@ -189,8 +189,21 @@ func (builder *repoRiskGraphBuilder) addPostureReachability(finding Finding, fin
 	if !control.Observed() {
 		controlState = RepoRiskEvidenceUnknown
 	}
-	naturalKey := strings.Join([]string{repository, string(control.Kind), control.Scope, control.CheckID}, "\x1f")
-	controlNodeID := builder.upsertNode(control.Kind, naturalKey, control.Label, repository, controlState, repoRiskPostureNodeEvidence(finding, control))
+	// One organization policy is one control, however many repositories inherit
+	// it, so org-scoped controls are keyed by organization and left unpinned to
+	// any single repository. Keying them per repository would split one policy
+	// into a node per repository and stop inheritance edges from converging on
+	// the shared blast radius. An organization-scoped check that never reported
+	// its organization falls back to repository keying rather than merging
+	// unrelated policies together.
+	controlKeyScope := repository
+	controlRepository := repository
+	if control.Scope == repoRiskPostureScopeOrganization && control.Organization != "" {
+		controlKeyScope = "organization:" + control.Organization
+		controlRepository = ""
+	}
+	naturalKey := strings.Join([]string{controlKeyScope, string(control.Kind), control.Scope, control.CheckID}, "\x1f")
+	controlNodeID := builder.upsertNode(control.Kind, naturalKey, control.Label, controlRepository, controlState, repoRiskPostureNodeEvidence(finding, control))
 	if control.Kind == RepoRiskNodeRunnerGroup {
 		builder.rememberRunnerGroupNode(repository, controlNodeID)
 	}

--- a/internal/domain/repo_risk_graph_posture.go
+++ b/internal/domain/repo_risk_graph_posture.go
@@ -50,6 +50,8 @@ var repoRiskPostureEvidenceKeys = []string{
 	"org_runner_groups",
 	"public_repository_runner_groups",
 	"readonly_deploy_keys",
+	"repository_configuration_applied",
+	"repository_configuration_status",
 	"required_reviews",
 	"required_status_checks",
 	"ruleset_count",
@@ -443,15 +445,16 @@ func repoRiskPostureRepositoryInheritsOrgControl(finding Finding, control repoRi
 		return true
 	}
 	switch control.CheckID {
-	case "org_secret_scanning_policy":
-		// An insecure secret-scanning policy always means the repository does not
-		// inherit enforced secret scanning and push protection.
-		return false
-	case "org_code_security_configuration":
-		switch firstEvidenceString(finding.Evidence, "github_posture_reason") {
-		case "no_central_configuration", "configuration_not_applied":
-			return false
-		}
+	case "org_secret_scanning_policy", "org_code_security_configuration":
+		// The collector records repository_configuration_applied on findings
+		// whose code path actually reached the repository-attachment query. When
+		// it reports true, the repository is attached to a weak configuration and
+		// still inherits the control; when it reports false or is absent
+		// (early-return reasons that never queried attachment), no inheritance
+		// has been proven, so the edge must be suppressed instead of asserting
+		// governance that contradicts the evidence.
+		applied, ok := boolFromAny(finding.Evidence["repository_configuration_applied"])
+		return ok && applied
 	}
 	return true
 }

--- a/internal/domain/repo_risk_graph_posture.go
+++ b/internal/domain/repo_risk_graph_posture.go
@@ -1,7 +1,9 @@
 package domain
 
 import (
+	"math"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -219,8 +221,21 @@ func (builder *repoRiskGraphBuilder) addPostureReachability(finding Finding, fin
 		controlKeyScope = "organization:" + control.Organization
 		controlRepository = ""
 	}
+	// Code-security and secret-scanning policies are per-configuration, not
+	// per-organization: one organization can host several configurations and
+	// different repositories can be attached to different ones. When the
+	// collector recorded the specific attached configuration, key the node by
+	// it so distinct configurations stay distinct nodes with distinct
+	// inheritance edges. When the ID is absent (permission-limited,
+	// unavailable, or an early-return reason that never observed attachment),
+	// fall back to one shared node per organization.
+	controlLabel := control.Label
+	if configurationID := repoRiskPostureConfigurationKeySuffix(control, finding); configurationID != "" {
+		controlKeyScope = controlKeyScope + "\x1fconfig:" + configurationID
+		controlLabel = control.Label + " (id " + configurationID + ")"
+	}
 	naturalKey := strings.Join([]string{controlKeyScope, string(control.Kind), control.Scope, control.CheckID}, "\x1f")
-	controlNodeID := builder.upsertNode(control.Kind, naturalKey, control.Label, controlRepository, controlState, repoRiskPostureNodeEvidence(finding, control))
+	controlNodeID := builder.upsertNode(control.Kind, naturalKey, controlLabel, controlRepository, controlState, repoRiskPostureNodeEvidence(finding, control))
 	if control.Kind == RepoRiskNodeRunnerGroup {
 		builder.rememberRunnerGroupNode(repository, controlNodeID)
 	}
@@ -457,6 +472,51 @@ func repoRiskPostureRepositoryInheritsOrgControl(finding Finding, control repoRi
 		return ok && applied
 	}
 	return true
+}
+
+// repoRiskPostureConfigurationKeySuffix returns the attached GitHub code-
+// security configuration identifier the collector recorded for a
+// per-configuration control, or the empty string when the finding does not
+// carry one. Only code-security and secret-scanning policies vary per
+// configuration; organization-wide policies (Actions source, workflow token,
+// reusable workflow allowlist) are one control per organization and never key
+// on this suffix even if a stray ID appeared in evidence.
+func repoRiskPostureConfigurationKeySuffix(control repoRiskPostureControl, finding Finding) string {
+	switch control.CheckID {
+	case "org_code_security_configuration", "org_secret_scanning_policy":
+	default:
+		return ""
+	}
+	return normalizeConfigurationID(finding.Evidence["repository_configuration_id"])
+}
+
+func normalizeConfigurationID(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case int:
+		if typed == 0 {
+			return ""
+		}
+		return strconv.Itoa(typed)
+	case int32:
+		if typed == 0 {
+			return ""
+		}
+		return strconv.FormatInt(int64(typed), 10)
+	case int64:
+		if typed == 0 {
+			return ""
+		}
+		return strconv.FormatInt(typed, 10)
+	case float64:
+		if typed == 0 || typed != typed || typed != math.Trunc(typed) {
+			return ""
+		}
+		return strconv.FormatInt(int64(typed), 10)
+	default:
+		return ""
+	}
 }
 
 // repoRiskPostureAlertSourceFunctioning reports whether a posture finding names

--- a/internal/domain/repo_risk_graph_posture.go
+++ b/internal/domain/repo_risk_graph_posture.go
@@ -1,0 +1,389 @@
+package domain
+
+import (
+	"sort"
+	"strings"
+)
+
+// GitHub posture check states carried on repo findings by the GitHub posture
+// adapters. Only "insecure" proves a weak control; the remaining states mean the
+// scanner could not observe the control and must surface uncertainty instead.
+const (
+	repoRiskPostureStateInsecure          = "insecure"
+	repoRiskPostureStatePermissionLimited = "permission_limited"
+	repoRiskPostureStateUnavailable       = "unavailable"
+	repoRiskPostureStateUnknown           = "unknown"
+)
+
+const (
+	repoRiskPostureScopeRepository   = "repository"
+	repoRiskPostureScopeOrganization = "organization"
+)
+
+// repoRiskPostureEvidenceKeys are the summary-shaped posture evidence values
+// worth carrying onto a control node. Runner labels, hook counts, and policy
+// modes describe the control itself; anything not listed here stays on the
+// finding node so control nodes do not accumulate scan-scoped detail.
+var repoRiskPostureEvidenceKeys = []string{
+	"active_rulesets",
+	"active_webhooks",
+	"admins_enforced",
+	"allowed_actions",
+	"allowed_pattern_count",
+	"branch_deletions_allowed",
+	"broadly_available_runner_groups",
+	"can_approve_pull_request_reviews",
+	"default_workflow_permissions",
+	"dependabot_alerts_enabled",
+	"dependabot_security_updates_enabled",
+	"deploy_key_count",
+	"enabled",
+	"enabled_repositories",
+	"environment_count",
+	"evaluate_rulesets",
+	"failing_webhooks",
+	"force_pushes_allowed",
+	"github_owned_allowed",
+	"insecure_ssl_hooks",
+	"online_runners",
+	"open_alerts_sampled",
+	"org_runner_groups",
+	"public_repository_runner_groups",
+	"readonly_deploy_keys",
+	"required_reviews",
+	"required_status_checks",
+	"ruleset_count",
+	"runner_groups_state",
+	"runner_labels",
+	"runner_os",
+	"self_hosted_runner_count",
+	"unprotected_environments",
+	"verified_allowed",
+	"webhook_count",
+	"writable_deploy_keys",
+}
+
+// repoRiskPostureControl is the GitHub control-plane concept behind one posture
+// finding, resolved purely from evidence the posture collector recorded.
+type repoRiskPostureControl struct {
+	Kind         RepoRiskGraphNodeKind
+	Label        string
+	CheckID      string
+	Category     string
+	Scope        string
+	State        string
+	Organization string
+}
+
+// Observed reports whether the posture collector could actually read the
+// control. An unobserved control still belongs in the graph, but as uncertainty.
+func (control repoRiskPostureControl) Observed() bool {
+	switch control.State {
+	case repoRiskPostureStatePermissionLimited, repoRiskPostureStateUnavailable, repoRiskPostureStateUnknown:
+		return false
+	default:
+		return true
+	}
+}
+
+// Weak reports whether the collector proved the control is configured weakly.
+func (control repoRiskPostureControl) Weak() bool {
+	return control.State == repoRiskPostureStateInsecure
+}
+
+// repoRiskPostureControlForFinding resolves the control-plane node a posture
+// finding describes. Findings without posture evidence, and posture checks with
+// no control-plane concept of their own, return false so the graph does not
+// invent structure.
+func repoRiskPostureControlForFinding(finding Finding) (repoRiskPostureControl, bool) {
+	checkID := strings.ToLower(firstEvidenceString(finding.Evidence, "github_posture_check_id"))
+	if checkID == "" {
+		return repoRiskPostureControl{}, false
+	}
+	control := repoRiskPostureControl{
+		CheckID:      checkID,
+		Category:     firstEvidenceString(finding.Evidence, "github_posture_category"),
+		Scope:        strings.ToLower(firstEvidenceString(finding.Evidence, "github_posture_scope")),
+		State:        strings.ToLower(firstEvidenceString(finding.Evidence, "github_posture_state")),
+		Organization: firstEvidenceString(finding.Evidence, "organization"),
+	}
+	if control.Scope == "" {
+		control.Scope = repoRiskPostureScopeRepository
+	}
+
+	switch checkID {
+	case "default_branch_protection":
+		control.Kind = RepoRiskNodeBranchProtection
+		branch := firstEvidenceString(finding.Evidence, "default_branch")
+		if branch == "" {
+			branch = "default branch"
+		}
+		control.Label = "branch protection: " + branch
+	case "repository_rulesets":
+		control.Kind = RepoRiskNodeRepositoryRuleset
+		control.Label = "repository rulesets"
+	case "actions_permissions":
+		control.Kind = RepoRiskNodeActionsPolicy
+		control.Label = "Actions policy: repository"
+	case "org_actions_policy":
+		control.Kind = RepoRiskNodeActionsPolicy
+		control.Label = "Actions policy: " + repoRiskPostureOrgLabel(control.Organization)
+	case "org_workflow_permissions":
+		control.Kind = RepoRiskNodeWorkflowPermissionDefault
+		control.Label = "default workflow permissions: " + repoRiskPostureOrgLabel(control.Organization)
+	case "org_reusable_workflow_policy":
+		control.Kind = RepoRiskNodeReusableWorkflowPolicy
+		control.Label = "reusable workflow policy: " + repoRiskPostureOrgLabel(control.Organization)
+	case "self_hosted_runners":
+		control.Kind = RepoRiskNodeRunnerGroup
+		control.Label = "self-hosted runner group"
+	case "deployment_environments":
+		control.Kind = RepoRiskNodeEnvironmentProtection
+		control.Label = "deployment environment protection"
+	case "deploy_keys":
+		control.Kind = RepoRiskNodeDeployKey
+		control.Label = "repository deploy keys"
+	case "webhooks":
+		control.Kind = RepoRiskNodeWebhook
+		control.Label = "repository webhooks"
+	case "dependabot_security":
+		control.Kind = RepoRiskNodeAlertSource
+		control.Label = "alert source: Dependabot"
+	case "code_scanning":
+		control.Kind = RepoRiskNodeAlertSource
+		control.Label = "alert source: code scanning"
+	case "secret_scanning":
+		control.Kind = RepoRiskNodeAlertSource
+		control.Label = "alert source: secret scanning"
+	case "org_secret_scanning_policy":
+		control.Kind = RepoRiskNodeAlertSource
+		control.Label = "alert source: secret scanning policy: " + repoRiskPostureOrgLabel(control.Organization)
+	case "org_code_security_configuration":
+		control.Kind = RepoRiskNodeOrgSecurityConfiguration
+		control.Label = "code security configuration: " + repoRiskPostureOrgLabel(control.Organization)
+	default:
+		// repository_metadata and any future check without a control-plane
+		// concept stay finding-only rather than becoming a speculative node.
+		return repoRiskPostureControl{}, false
+	}
+	return control, true
+}
+
+func repoRiskPostureOrgLabel(organization string) string {
+	if organization == "" {
+		return "organization"
+	}
+	return organization
+}
+
+// addPostureReachability attaches the GitHub control-plane node behind a posture
+// finding, links the repository to the control it is governed by or inherits,
+// and records the finding's relationship to that control.
+func (builder *repoRiskGraphBuilder) addPostureReachability(finding Finding, findingPublicID string, findingNodeID string, repositoryNodeID string, repository string) {
+	control, ok := repoRiskPostureControlForFinding(finding)
+	if !ok {
+		return
+	}
+
+	controlState := RepoRiskEvidenceKnown
+	if !control.Observed() {
+		controlState = RepoRiskEvidenceUnknown
+	}
+	naturalKey := strings.Join([]string{repository, string(control.Kind), control.Scope, control.CheckID}, "\x1f")
+	controlNodeID := builder.upsertNode(control.Kind, naturalKey, control.Label, repository, controlState, repoRiskPostureNodeEvidence(finding, control))
+	if control.Kind == RepoRiskNodeRunnerGroup {
+		builder.rememberRunnerGroupNode(repository, controlNodeID)
+	}
+
+	if repositoryNodeID != "" {
+		governanceKind := RepoRiskEdgeRepositoryGovernedBy
+		if control.Scope == repoRiskPostureScopeOrganization {
+			governanceKind = RepoRiskEdgeInheritsOrgPolicy
+		}
+		governanceEvidence := map[string]any{
+			"github_posture_check_id": control.CheckID,
+			"github_posture_scope":    control.Scope,
+		}
+		if control.Organization != "" {
+			governanceEvidence["organization"] = control.Organization
+		}
+		builder.upsertEdge(governanceKind, repositoryNodeID, controlNodeID, controlState, governanceEvidence)
+	}
+
+	if !control.Observed() {
+		builder.upsertEdge(RepoRiskEdgeFindingDependsOnPostureSource, findingNodeID, controlNodeID, RepoRiskEvidenceUnknown, map[string]any{
+			"finding_id":              findingPublicID,
+			"github_posture_check_id": control.CheckID,
+			"github_posture_state":    control.State,
+			"reason":                  "posture_source_" + control.State,
+		})
+		return
+	}
+	if !control.Weak() {
+		return
+	}
+
+	findingEdgeKind := RepoRiskEdgeFindingWeakensControl
+	switch control.Kind {
+	case RepoRiskNodeDeployKey, RepoRiskNodeWebhook:
+		findingEdgeKind = RepoRiskEdgeFindingExposesControl
+	}
+	builder.upsertEdge(findingEdgeKind, findingNodeID, controlNodeID, RepoRiskEvidenceKnown, map[string]any{
+		"finding_id":              findingPublicID,
+		"github_posture_check_id": control.CheckID,
+		"github_posture_reason":   firstEvidenceString(finding.Evidence, "github_posture_reason"),
+	})
+}
+
+func repoRiskPostureNodeEvidence(finding Finding, control repoRiskPostureControl) map[string]any {
+	evidence := map[string]any{
+		"github_posture_check_id": control.CheckID,
+		"github_posture_scope":    control.Scope,
+		"github_posture_state":    control.State,
+	}
+	if control.Category != "" {
+		evidence["github_posture_category"] = control.Category
+	}
+	if control.Organization != "" {
+		evidence["organization"] = control.Organization
+	}
+	if collectedAt := firstEvidenceString(finding.Evidence, "github_posture_collected_at"); collectedAt != "" {
+		evidence["github_posture_collected_at"] = collectedAt
+	}
+	for _, key := range repoRiskPostureEvidenceKeys {
+		if value, exists := finding.Evidence[key]; exists && value != nil {
+			evidence[key] = value
+		}
+	}
+	return evidence
+}
+
+func (builder *repoRiskGraphBuilder) rememberWorkflowNode(repository string, nodeID string) {
+	builder.workflowNodes[repository] = appendUniqueNodeID(builder.workflowNodes[repository], nodeID)
+}
+
+func (builder *repoRiskGraphBuilder) rememberRunnerGroupNode(repository string, nodeID string) {
+	builder.runnerGroupNodes[repository] = appendUniqueNodeID(builder.runnerGroupNodes[repository], nodeID)
+}
+
+func appendUniqueNodeID(nodeIDs []string, nodeID string) []string {
+	if nodeID == "" {
+		return nodeIDs
+	}
+	for _, existing := range nodeIDs {
+		if existing == nodeID {
+			return nodeIDs
+		}
+	}
+	return append(nodeIDs, nodeID)
+}
+
+// linkWorkflowsToRunnerGroups connects each workflow to the self-hosted runner
+// groups its repository can reach. Runner availability is repository-scoped
+// evidence and never proves that a given workflow targets the group, so every
+// edge is recorded as unknown reachability.
+func (builder *repoRiskGraphBuilder) linkWorkflowsToRunnerGroups() {
+	repositories := make([]string, 0, len(builder.runnerGroupNodes))
+	for repository := range builder.runnerGroupNodes {
+		repositories = append(repositories, repository)
+	}
+	sort.Strings(repositories)
+
+	for _, repository := range repositories {
+		workflowNodeIDs := append([]string(nil), builder.workflowNodes[repository]...)
+		if len(workflowNodeIDs) == 0 {
+			continue
+		}
+		runnerGroupNodeIDs := append([]string(nil), builder.runnerGroupNodes[repository]...)
+		sort.Strings(workflowNodeIDs)
+		sort.Strings(runnerGroupNodeIDs)
+		for _, workflowNodeID := range workflowNodeIDs {
+			for _, runnerGroupNodeID := range runnerGroupNodeIDs {
+				builder.upsertEdge(RepoRiskEdgeWorkflowRunsOnRunnerGroup, workflowNodeID, runnerGroupNodeID, RepoRiskEvidenceUnknown, map[string]any{
+					"repository": repository,
+					"reason":     "runner_target_unproven",
+				})
+			}
+		}
+	}
+}
+
+// repoRiskPostureAmplifierFactor rates how much a proven-weak GitHub control
+// widens the blast radius of the finding that reported it. Controls the scanner
+// could not read contribute nothing: uncertainty is surfaced through unknown
+// nodes, edges, and score unknowns rather than through an invented score bump.
+func repoRiskPostureAmplifierFactor(finding Finding) int {
+	control, ok := repoRiskPostureControlForFinding(finding)
+	if !ok || !control.Weak() {
+		return 0
+	}
+	score := 0
+	switch strings.ToLower(strings.TrimSpace(finding.Detector)) {
+	case "github_default_branch_unprotected":
+		score = 60
+		if evidenceBool(finding.Evidence, "force_pushes_allowed") || evidenceBool(finding.Evidence, "branch_deletions_allowed") {
+			score += 20
+		}
+		if !evidenceBool(finding.Evidence, "admins_enforced") {
+			score += 10
+		}
+	case "github_rulesets_weak":
+		score = 40
+	case "github_actions_policy_broad":
+		score = 55
+		if strings.EqualFold(firstEvidenceString(finding.Evidence, "allowed_actions"), "all") {
+			score += 20
+		}
+		if strings.EqualFold(firstEvidenceString(finding.Evidence, "default_workflow_permissions"), "write") {
+			score += 15
+		}
+	case "github_workflow_permissions_write_default":
+		score = 70
+	case "github_reusable_workflow_policy_broad":
+		score = 45
+	case "github_self_hosted_runner_unrestricted":
+		score = 65
+		if evidenceCount(finding.Evidence, "public_repository_runner_groups") > 0 {
+			score += 20
+		}
+	case "github_write_deploy_key":
+		score = 70
+		if evidenceCount(finding.Evidence, "writable_deploy_keys") > 1 {
+			score += 10
+		}
+	case "github_environment_unprotected":
+		score = 50
+		if repoRiskEnvironmentFactor(finding) == 100 {
+			score += 25
+		}
+	case "github_webhook_unhealthy":
+		score = 25
+		if evidenceCount(finding.Evidence, "insecure_ssl_hooks") > 0 {
+			score += 15
+		}
+	case "github_secret_scanning_disabled":
+		score = 35
+	case "github_code_scanning_disabled":
+		score = 25
+	case "github_dependabot_disabled":
+		score = 20
+	case "github_code_security_configuration_weak":
+		score = 30
+	default:
+		score = 20
+	}
+	return clampInt(score, 0, 100)
+}
+
+func evidenceBool(evidence map[string]any, key string) bool {
+	value, ok := boolFromAny(evidence[key])
+	return ok && value
+}
+
+func evidenceCount(evidence map[string]any, key string) int {
+	value, ok := floatFromAny(evidence[key])
+	if !ok {
+		return 0
+	}
+	return int(value)
+}

--- a/internal/domain/repo_risk_graph_posture.go
+++ b/internal/domain/repo_risk_graph_posture.go
@@ -57,6 +57,7 @@ var repoRiskPostureEvidenceKeys = []string{
 	"runner_labels",
 	"runner_os",
 	"self_hosted_runner_count",
+	"unprotected_environment_criticality",
 	"unprotected_environments",
 	"verified_allowed",
 	"webhook_count",
@@ -123,8 +124,19 @@ func repoRiskPostureControlForFinding(finding Finding) (repoRiskPostureControl, 
 		control.Kind = RepoRiskNodeRepositoryRuleset
 		control.Label = "repository rulesets"
 	case "actions_permissions":
-		control.Kind = RepoRiskNodeActionsPolicy
-		control.Label = "Actions policy: repository"
+		// The repository Actions check is a combined control: it flags both broad
+		// action sources and a write-by-default workflow token. When the action
+		// sources are restricted but the default token is write, the weak control
+		// is the workflow-permission default, not the Actions source policy, so it
+		// must resolve to its own node instead of being attributed to the policy.
+		if !strings.EqualFold(firstEvidenceString(finding.Evidence, "allowed_actions"), "all") &&
+			strings.EqualFold(firstEvidenceString(finding.Evidence, "default_workflow_permissions"), "write") {
+			control.Kind = RepoRiskNodeWorkflowPermissionDefault
+			control.Label = "default workflow permissions: repository"
+		} else {
+			control.Kind = RepoRiskNodeActionsPolicy
+			control.Label = "Actions policy: repository"
+		}
 	case "org_actions_policy":
 		control.Kind = RepoRiskNodeActionsPolicy
 		control.Label = "Actions policy: " + repoRiskPostureOrgLabel(control.Organization)
@@ -235,6 +247,12 @@ func (builder *repoRiskGraphBuilder) addPostureReachability(finding Finding, fin
 	if !control.Weak() {
 		return
 	}
+	// An alert source that returned open alerts is a functioning control that
+	// surfaced findings, not a weakened one. It still governs the repository, but
+	// the finding must not be recorded as weakening it.
+	if repoRiskPostureAlertSourceFunctioning(finding, control) {
+		return
+	}
 
 	findingEdgeKind := RepoRiskEdgeFindingWeakensControl
 	switch control.Kind {
@@ -330,6 +348,11 @@ func repoRiskPostureAmplifierFactor(finding Finding) int {
 	if !ok || !control.Weak() {
 		return 0
 	}
+	// A functioning alert source that returned open alerts is not a weakened
+	// control, so it does not widen blast radius through a posture amplifier.
+	if repoRiskPostureAlertSourceFunctioning(finding, control) {
+		return 0
+	}
 	score := 0
 	switch strings.ToLower(strings.TrimSpace(finding.Detector)) {
 	case "github_default_branch_unprotected":
@@ -366,7 +389,7 @@ func repoRiskPostureAmplifierFactor(finding Finding) int {
 		}
 	case "github_environment_unprotected":
 		score = 50
-		if repoRiskEnvironmentFactor(finding) == 100 {
+		if repoRiskUnprotectedEnvironmentCriticality(finding) == "production" {
 			score += 25
 		}
 	case "github_webhook_unhealthy":
@@ -386,6 +409,24 @@ func repoRiskPostureAmplifierFactor(finding Finding) int {
 		score = 20
 	}
 	return clampInt(score, 0, 100)
+}
+
+// repoRiskPostureAlertSourceFunctioning reports whether a posture finding names
+// an alert source (code scanning, secret scanning, Dependabot) that the scanner
+// found enabled and returning open alerts. Such a source is doing its job; the
+// finding is an open alert, not a control weakness.
+func repoRiskPostureAlertSourceFunctioning(finding Finding, control repoRiskPostureControl) bool {
+	if control.Kind != RepoRiskNodeAlertSource {
+		return false
+	}
+	return firstEvidenceString(finding.Evidence, "github_posture_reason") == "open_alerts_present"
+}
+
+// repoRiskUnprotectedEnvironmentCriticality returns the redacted criticality
+// tier the environment posture collector recorded for the most sensitive
+// unprotected environment, or an empty string when none was carried.
+func repoRiskUnprotectedEnvironmentCriticality(finding Finding) string {
+	return strings.ToLower(firstEvidenceString(finding.Evidence, "unprotected_environment_criticality"))
 }
 
 func evidenceBool(evidence map[string]any, key string) bool {

--- a/internal/domain/repo_risk_graph_test.go
+++ b/internal/domain/repo_risk_graph_test.go
@@ -700,6 +700,48 @@ func TestBuildRepoRiskGraphAmplifiesUnprotectedProductionEnvironment(t *testing.
 	}
 }
 
+func TestBuildRepoRiskGraphDoesNotClaimInheritanceForUnattachedRepository(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("not-attached", "github_code_security_configuration_weak", SeverityMedium, now, map[string]any{
+			"github_posture_check_id": "org_code_security_configuration",
+			"github_posture_scope":    "organization",
+			"github_posture_state":    "insecure",
+			"github_posture_reason":   "configuration_not_applied",
+			"organization":            "owner",
+		}),
+		postureFinding("not-attached-secrets", "github_secret_scanning_disabled", SeverityHigh, now, map[string]any{
+			"github_posture_check_id": "org_secret_scanning_policy",
+			"github_posture_scope":    "organization",
+			"github_posture_state":    "insecure",
+			"github_posture_reason":   "secret_scanning_policy_weak",
+			"organization":            "owner",
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphNode(t, graph, RepoRiskNodeOrgSecurityConfiguration, "code security configuration: owner")
+	if countEdges(graph, RepoRiskEdgeInheritsOrgPolicy) != 0 {
+		t.Fatalf("expected an unattached repository not to inherit organization controls, got %+v", graph.Edges)
+	}
+	// The control is still reported as weak; only the inheritance claim is dropped.
+	assertGraphEdge(t, graph, RepoRiskEdgeFindingWeakensControl, RepoRiskEvidenceKnown)
+}
+
+func TestBuildRepoRiskGraphKeepsInheritanceForAttachedWeakConfiguration(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("attached-weak", "github_code_security_configuration_weak", SeverityMedium, now, map[string]any{
+			"github_posture_check_id": "org_code_security_configuration",
+			"github_posture_scope":    "organization",
+			"github_posture_state":    "insecure",
+			"github_posture_reason":   "configuration_not_enforced",
+			"organization":            "owner",
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphEdge(t, graph, RepoRiskEdgeInheritsOrgPolicy, RepoRiskEvidenceKnown)
+}
+
 func postureFinding(id string, detector string, severity FindingSeverity, now time.Time, evidence map[string]any) Finding {
 	evidence["repository"] = "owner/repo"
 	evidence["adapter_source"] = "github_posture"

--- a/internal/domain/repo_risk_graph_test.go
+++ b/internal/domain/repo_risk_graph_test.go
@@ -901,6 +901,123 @@ func TestBuildRepoRiskGraphPrefersObservedEvidenceWhenUpgradingSharedOrgControl(
 	}
 }
 
+func TestBuildRepoRiskGraphKeepsDistinctOrgCodeSecurityConfigurationsSeparate(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	// Two repositories in the same organization are attached to two different
+	// GitHub code-security configurations. Each configuration is a distinct
+	// control with its own weakness, so they must stay as separate nodes with
+	// separate inheritance edges rather than converging on a single "org owner"
+	// node that would overstate blast radius and mix evidence.
+	repoA := postureFinding("cfg-a-weak", "github_code_security_configuration_weak", SeverityMedium, now, map[string]any{
+		"github_posture_check_id":          "org_code_security_configuration",
+		"github_posture_scope":             "organization",
+		"github_posture_state":             "insecure",
+		"github_posture_reason":            "configuration_not_protective",
+		"organization":                     "owner",
+		"repository":                       "owner/repo-a",
+		"repository_configuration_applied": true,
+		"repository_configuration_id":      float64(101),
+	})
+	repoA.Repository = "owner/repo-a"
+	repoB := postureFinding("cfg-b-weak", "github_code_security_configuration_weak", SeverityMedium, now, map[string]any{
+		"github_posture_check_id":          "org_code_security_configuration",
+		"github_posture_scope":             "organization",
+		"github_posture_state":             "insecure",
+		"github_posture_reason":            "configuration_not_protective",
+		"organization":                     "owner",
+		"repository":                       "owner/repo-b",
+		"repository_configuration_applied": true,
+		"repository_configuration_id":      float64(202),
+	})
+	repoB.Repository = "owner/repo-b"
+
+	graph := BuildRepoRiskGraph([]Finding{repoA, repoB}, RepoRiskGraphOptions{Now: now})
+
+	if countNodes(graph, RepoRiskNodeOrgSecurityConfiguration) != 2 {
+		t.Fatalf("expected two distinct code security configurations to stay two nodes, got %+v", graph.Nodes)
+	}
+	if countEdges(graph, RepoRiskEdgeInheritsOrgPolicy) != 2 {
+		t.Fatalf("expected each repository to inherit its own configuration, got %+v", graph.Edges)
+	}
+
+	inheritedNodeIDs := map[string]struct{}{}
+	for _, edge := range graph.Edges {
+		if edge.Kind == RepoRiskEdgeInheritsOrgPolicy {
+			inheritedNodeIDs[edge.ToNodeID] = struct{}{}
+		}
+	}
+	if len(inheritedNodeIDs) != 2 {
+		t.Fatalf("expected two distinct inheritance targets, got %+v", graph.Edges)
+	}
+
+	labels := map[string]struct{}{}
+	for _, node := range graph.Nodes {
+		if node.Kind == RepoRiskNodeOrgSecurityConfiguration {
+			labels[node.Label] = struct{}{}
+		}
+	}
+	if _, ok := labels["code security configuration: owner (id 101)"]; !ok {
+		t.Fatalf("expected configuration label to include its id, got %+v", labels)
+	}
+	if _, ok := labels["code security configuration: owner (id 202)"]; !ok {
+		t.Fatalf("expected configuration label to include its id, got %+v", labels)
+	}
+}
+
+func TestBuildRepoRiskGraphConvergesRepositoriesAttachedToSameConfiguration(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	// Both repositories are attached to the same configuration id, so the
+	// per-configuration keying must still let their inheritance edges converge
+	// on one shared node.
+	finding := func(id string, repository string) Finding {
+		result := postureFinding(id, "github_code_security_configuration_weak", SeverityMedium, now, map[string]any{
+			"github_posture_check_id":          "org_code_security_configuration",
+			"github_posture_scope":             "organization",
+			"github_posture_state":             "insecure",
+			"github_posture_reason":            "configuration_not_protective",
+			"organization":                     "owner",
+			"repository":                       repository,
+			"repository_configuration_applied": true,
+			"repository_configuration_id":      float64(101),
+		})
+		result.Repository = repository
+		return result
+	}
+	graph := BuildRepoRiskGraph([]Finding{finding("shared-a", "owner/repo-a"), finding("shared-b", "owner/repo-b")}, RepoRiskGraphOptions{Now: now})
+
+	if countNodes(graph, RepoRiskNodeOrgSecurityConfiguration) != 1 {
+		t.Fatalf("expected one shared configuration to stay one node, got %+v", graph.Nodes)
+	}
+	if countEdges(graph, RepoRiskEdgeInheritsOrgPolicy) != 2 {
+		t.Fatalf("expected both repositories to inherit the shared configuration, got %+v", graph.Edges)
+	}
+}
+
+func TestBuildRepoRiskGraphConvergesOrgWideActionsPolicyEvenWithConfigurationIDPresent(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	// org_actions_policy is organization-wide: even if evidence somehow carries
+	// a repository_configuration_id, the control kind is one per organization,
+	// so the node must still converge across repositories.
+	finding := func(id string, repository string) Finding {
+		result := postureFinding(id, "github_actions_policy_broad", SeverityMedium, now, map[string]any{
+			"github_posture_check_id":     "org_actions_policy",
+			"github_posture_scope":        "organization",
+			"github_posture_state":        "insecure",
+			"organization":                "owner",
+			"repository":                  repository,
+			"repository_configuration_id": float64(999),
+			"allowed_actions":             "all",
+		})
+		result.Repository = repository
+		return result
+	}
+	graph := BuildRepoRiskGraph([]Finding{finding("actions-a", "owner/repo-a"), finding("actions-b", "owner/repo-b")}, RepoRiskGraphOptions{Now: now})
+
+	if countNodes(graph, RepoRiskNodeActionsPolicy) != 1 {
+		t.Fatalf("expected an organization-wide policy to converge regardless of stray config id, got %+v", graph.Nodes)
+	}
+}
+
 func postureFinding(id string, detector string, severity FindingSeverity, now time.Time, evidence map[string]any) Finding {
 	evidence["repository"] = "owner/repo"
 	evidence["adapter_source"] = "github_posture"

--- a/internal/domain/repo_risk_graph_test.go
+++ b/internal/domain/repo_risk_graph_test.go
@@ -595,6 +595,111 @@ func TestBuildRepoRiskGraphSkipsPostureChecksWithoutControlConcept(t *testing.T)
 	}
 }
 
+func TestBuildRepoRiskGraphMapsRepositoryWriteDefaultToItsOwnControl(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("write-default", "github_actions_policy_broad", SeverityHigh, now, map[string]any{
+			"github_posture_check_id":      "actions_permissions",
+			"github_posture_category":      "actions",
+			"github_posture_scope":         "repository",
+			"github_posture_state":         "insecure",
+			"allowed_actions":              "selected",
+			"default_workflow_permissions": "write",
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphNode(t, graph, RepoRiskNodeWorkflowPermissionDefault, "default workflow permissions: repository")
+	if countNodes(graph, RepoRiskNodeActionsPolicy) != 0 {
+		t.Fatalf("expected a restricted-source write-default finding not to attribute to the Actions source policy, got %+v", graph.Nodes)
+	}
+	assertGraphEdge(t, graph, RepoRiskEdgeFindingWeakensControl, RepoRiskEvidenceKnown)
+}
+
+func TestBuildRepoRiskGraphKeepsBroadActionSourcesOnActionsPolicy(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("broad-actions", "github_actions_policy_broad", SeverityHigh, now, map[string]any{
+			"github_posture_check_id":      "actions_permissions",
+			"github_posture_scope":         "repository",
+			"github_posture_state":         "insecure",
+			"allowed_actions":              "all",
+			"default_workflow_permissions": "write",
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphNode(t, graph, RepoRiskNodeActionsPolicy, "Actions policy: repository")
+	if countNodes(graph, RepoRiskNodeWorkflowPermissionDefault) != 0 {
+		t.Fatalf("expected broad action sources to stay on the Actions policy node, got %+v", graph.Nodes)
+	}
+}
+
+func TestBuildRepoRiskGraphDoesNotWeakenFunctioningAlertSource(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("open-alerts", "github_code_scanning_disabled", SeverityHigh, now, map[string]any{
+			"github_posture_check_id": "code_scanning",
+			"github_posture_category": "security",
+			"github_posture_scope":    "repository",
+			"github_posture_state":    "insecure",
+			"github_posture_reason":   "open_alerts_present",
+			"open_alerts_sampled":     4,
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphNode(t, graph, RepoRiskNodeAlertSource, "alert source: code scanning")
+	assertGraphEdge(t, graph, RepoRiskEdgeRepositoryGovernedBy, RepoRiskEvidenceKnown)
+	if countEdges(graph, RepoRiskEdgeFindingWeakensControl) != 0 {
+		t.Fatalf("expected a functioning alert source with open alerts not to be recorded as weakened, got %+v", graph.Edges)
+	}
+	score := scoreForFinding(t, graph, "open-alerts")
+	if score.Factors.PostureAmplifier != 0 {
+		t.Fatalf("expected a functioning alert source not to amplify blast radius, got %+v", score.Factors)
+	}
+}
+
+func TestBuildRepoRiskGraphWeakensDisabledAlertSource(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("disabled-scanning", "github_secret_scanning_disabled", SeverityHigh, now, map[string]any{
+			"github_posture_check_id": "secret_scanning",
+			"github_posture_scope":    "repository",
+			"github_posture_state":    "insecure",
+			"github_posture_reason":   "not_configured",
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphEdge(t, graph, RepoRiskEdgeFindingWeakensControl, RepoRiskEvidenceKnown)
+	score := scoreForFinding(t, graph, "disabled-scanning")
+	if score.Factors.PostureAmplifier == 0 {
+		t.Fatalf("expected a disabled secret-scanning control to amplify blast radius, got %+v", score.Factors)
+	}
+}
+
+func TestBuildRepoRiskGraphAmplifiesUnprotectedProductionEnvironment(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	production := postureFinding("prod-env", "github_environment_unprotected", SeverityHigh, now, map[string]any{
+		"github_posture_check_id":             "deployment_environments",
+		"github_posture_scope":                "repository",
+		"github_posture_state":                "insecure",
+		"unprotected_environments":            1,
+		"unprotected_environment_criticality": "production",
+	})
+	development := postureFinding("dev-env", "github_environment_unprotected", SeverityHigh, now, map[string]any{
+		"github_posture_check_id":             "deployment_environments",
+		"github_posture_scope":                "repository",
+		"github_posture_state":                "insecure",
+		"unprotected_environments":            1,
+		"unprotected_environment_criticality": "development",
+	})
+	graph := BuildRepoRiskGraph([]Finding{production, development}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	prod := scoreForFinding(t, graph, "prod-env")
+	dev := scoreForFinding(t, graph, "dev-env")
+	if prod.Factors.PostureAmplifier <= dev.Factors.PostureAmplifier {
+		t.Fatalf("expected an unprotected production environment to amplify more than a development one, prod=%+v dev=%+v", prod.Factors, dev.Factors)
+	}
+}
+
 func postureFinding(id string, detector string, severity FindingSeverity, now time.Time, evidence map[string]any) Finding {
 	evidence["repository"] = "owner/repo"
 	evidence["adapter_source"] = "github_posture"

--- a/internal/domain/repo_risk_graph_test.go
+++ b/internal/domain/repo_risk_graph_test.go
@@ -319,6 +319,222 @@ func TestBuildRepoRiskGraphDoesNotScoreEmptyWriteScopes(t *testing.T) {
 	}
 }
 
+func TestBuildRepoRiskGraphLinksGitHubPostureControlPlane(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("branch-protection", "github_default_branch_unprotected", SeverityHigh, now, map[string]any{
+			"github_posture_check_id": "default_branch_protection",
+			"github_posture_category": "branch_protection",
+			"github_posture_scope":    "repository",
+			"github_posture_state":    "insecure",
+			"default_branch":          "main",
+			"required_reviews":        0,
+			"admins_enforced":         false,
+			"force_pushes_allowed":    true,
+		}),
+		postureFinding("org-actions", "github_actions_policy_broad", SeverityMedium, now, map[string]any{
+			"github_posture_check_id": "org_actions_policy",
+			"github_posture_category": "actions",
+			"github_posture_scope":    "organization",
+			"github_posture_state":    "insecure",
+			"organization":            "owner",
+			"allowed_actions":         "all",
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", DefaultBranch: "main", Now: now})
+
+	assertGraphNode(t, graph, RepoRiskNodeBranchProtection, "branch protection: main")
+	assertGraphNode(t, graph, RepoRiskNodeActionsPolicy, "Actions policy: owner")
+	assertGraphEdge(t, graph, RepoRiskEdgeRepositoryGovernedBy, RepoRiskEvidenceKnown)
+	assertGraphEdge(t, graph, RepoRiskEdgeInheritsOrgPolicy, RepoRiskEvidenceKnown)
+	assertGraphEdge(t, graph, RepoRiskEdgeFindingWeakensControl, RepoRiskEvidenceKnown)
+
+	if countEdges(graph, RepoRiskEdgeFindingWeakensControl) != 2 {
+		t.Fatalf("expected each posture finding to weaken its own control, got %+v", graph.Edges)
+	}
+	for _, score := range graph.Scores {
+		if score.Factors.PostureAmplifier == 0 {
+			t.Fatalf("expected weak controls to amplify posture score, got %+v", score)
+		}
+		if len(score.Unknowns) != 0 {
+			t.Fatalf("expected observed posture sources to report no unknowns, got %+v", score)
+		}
+	}
+}
+
+func TestBuildRepoRiskGraphSurfacesPermissionLimitedPostureAsUncertainty(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("runner-permission", "github_posture_permission_limited", SeverityMedium, now, map[string]any{
+			"github_posture_check_id": "self_hosted_runners",
+			"github_posture_category": "runners",
+			"github_posture_scope":    "repository",
+			"github_posture_state":    "permission_limited",
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphNode(t, graph, RepoRiskNodeRunnerGroup, "self-hosted runner group")
+	assertGraphEdge(t, graph, RepoRiskEdgeFindingDependsOnPostureSource, RepoRiskEvidenceUnknown)
+	assertGraphEdge(t, graph, RepoRiskEdgeRepositoryGovernedBy, RepoRiskEvidenceUnknown)
+
+	if graph.Summary.UnknownNodeCount != 1 || graph.Summary.UnknownEdgeCount != 2 {
+		t.Fatalf("expected permission-limited posture to count as uncertainty, got %+v", graph.Summary)
+	}
+	if countEdges(graph, RepoRiskEdgeFindingWeakensControl) != 0 {
+		t.Fatalf("expected an unreadable control not to be reported as weak, got %+v", graph.Edges)
+	}
+
+	score := scoreForFinding(t, graph, "runner-permission")
+	if len(score.Unknowns) != 1 || score.Unknowns[0] != "posture_source" {
+		t.Fatalf("expected posture source to be listed as unknown, got %+v", score.Unknowns)
+	}
+	if score.Factors.PostureAmplifier != 0 {
+		t.Fatalf("expected an unreadable control not to amplify the score, got %+v", score.Factors)
+	}
+}
+
+func TestBuildRepoRiskGraphLinksWorkflowsToRunnerGroupsAsUnprovenReachability(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("runners", "github_self_hosted_runner_unrestricted", SeverityHigh, now, map[string]any{
+			"github_posture_check_id":         "self_hosted_runners",
+			"github_posture_category":         "runners",
+			"github_posture_scope":            "repository",
+			"github_posture_state":            "insecure",
+			"self_hosted_runner_count":        2,
+			"public_repository_runner_groups": 1,
+		}),
+		{
+			ID:         "workflow-finding",
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityMedium,
+			Repository: "owner/repo",
+			FilePath:   ".github/workflows/deploy.yml",
+			Detector:   "workflow_unpinned_third_party_action",
+			CreatedAt:  now,
+		},
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphEdge(t, graph, RepoRiskEdgeWorkflowRunsOnRunnerGroup, RepoRiskEvidenceUnknown)
+	if countEdges(graph, RepoRiskEdgeWorkflowRunsOnRunnerGroup) != 1 {
+		t.Fatalf("expected one workflow-to-runner-group edge, got %+v", graph.Edges)
+	}
+	for _, edge := range graph.Edges {
+		if edge.Kind == RepoRiskEdgeWorkflowRunsOnRunnerGroup && edge.EvidenceState != RepoRiskEvidenceUnknown {
+			t.Fatalf("expected runner targeting to stay unproven, got %+v", edge)
+		}
+	}
+}
+
+func TestBuildRepoRiskGraphExposesDeployKeyAndWebhookControlRisk(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("deploy-keys", "github_write_deploy_key", SeverityHigh, now, map[string]any{
+			"github_posture_check_id": "deploy_keys",
+			"github_posture_scope":    "repository",
+			"github_posture_state":    "insecure",
+			"writable_deploy_keys":    2,
+		}),
+		postureFinding("webhooks", "github_webhook_unhealthy", SeverityLow, now, map[string]any{
+			"github_posture_check_id": "webhooks",
+			"github_posture_scope":    "repository",
+			"github_posture_state":    "insecure",
+			"insecure_ssl_hooks":      1,
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphNode(t, graph, RepoRiskNodeDeployKey, "repository deploy keys")
+	assertGraphNode(t, graph, RepoRiskNodeWebhook, "repository webhooks")
+	if countEdges(graph, RepoRiskEdgeFindingExposesControl) != 2 {
+		t.Fatalf("expected deploy key and webhook risk to use the exposure edge, got %+v", graph.Edges)
+	}
+	if countEdges(graph, RepoRiskEdgeFindingWeakensControl) != 0 {
+		t.Fatalf("expected deploy key and webhook risk not to double-report as weakening, got %+v", graph.Edges)
+	}
+}
+
+func TestBuildRepoRiskGraphPostureAmplifierRaisesScore(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	amplified := postureFinding("weak-branch", "github_default_branch_unprotected", SeverityHigh, now, map[string]any{
+		"github_posture_check_id": "default_branch_protection",
+		"github_posture_scope":    "repository",
+		"github_posture_state":    "insecure",
+		"default_branch":          "main",
+		"force_pushes_allowed":    true,
+	})
+	baseline := amplified
+	baseline.ID = "baseline"
+	baseline.Detector = "github_dependabot_disabled"
+	baseline.Evidence = map[string]any{
+		"github_posture_check_id": "dependabot_security",
+		"github_posture_scope":    "repository",
+		"github_posture_state":    "insecure",
+	}
+
+	graph := BuildRepoRiskGraph([]Finding{amplified, baseline}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	weak := scoreForFinding(t, graph, "weak-branch")
+	dependabot := scoreForFinding(t, graph, "baseline")
+	if weak.Factors.PostureAmplifier <= dependabot.Factors.PostureAmplifier {
+		t.Fatalf("expected an unprotected default branch to outweigh a disabled alert source, weak=%+v dependabot=%+v", weak.Factors, dependabot.Factors)
+	}
+	if weak.Score <= dependabot.Score {
+		t.Fatalf("expected the stronger posture amplifier to raise the score, weak=%+v dependabot=%+v", weak, dependabot)
+	}
+}
+
+func TestBuildRepoRiskGraphDoesNotInventSecretsFromPostureDetectors(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("secret-scanning", "github_secret_scanning_disabled", SeverityHigh, now, map[string]any{
+			"github_posture_check_id": "secret_scanning",
+			"github_posture_category": "security",
+			"github_posture_scope":    "repository",
+			"github_posture_state":    "insecure",
+			"open_alerts_sampled":     3,
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphNode(t, graph, RepoRiskNodeAlertSource, "alert source: secret scanning")
+	if countNodes(graph, RepoRiskNodeSecret) != 0 || countNodes(graph, RepoRiskNodeToken) != 0 {
+		t.Fatalf("expected a secret-scanning posture check not to invent a secret, got %+v", graph.Nodes)
+	}
+}
+
+func TestBuildRepoRiskGraphSkipsPostureChecksWithoutControlConcept(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("metadata", "github_repository_metadata_weak", SeverityLow, now, map[string]any{
+			"github_posture_check_id": "repository_metadata",
+			"github_posture_scope":    "repository",
+			"github_posture_state":    "insecure",
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	if countEdges(graph, RepoRiskEdgeRepositoryGovernedBy) != 0 {
+		t.Fatalf("expected a posture check without a control concept not to create a control node, got %+v", graph.Edges)
+	}
+	score := scoreForFinding(t, graph, "metadata")
+	if score.Factors.PostureAmplifier != 0 {
+		t.Fatalf("expected no amplifier without a control concept, got %+v", score.Factors)
+	}
+}
+
+func postureFinding(id string, detector string, severity FindingSeverity, now time.Time, evidence map[string]any) Finding {
+	evidence["repository"] = "owner/repo"
+	evidence["adapter_source"] = "github_posture"
+	return Finding{
+		ID:              id,
+		Type:            FindingRepoMisconfig,
+		Severity:        severity,
+		ConfidenceScore: 0.92,
+		Title:           "GitHub posture gap: " + detector,
+		Repository:      "owner/repo",
+		Detector:        detector,
+		CreatedAt:       now,
+		Evidence:        evidence,
+	}
+}
+
 func assertGraphNode(t *testing.T, graph RepoRiskGraph, kind RepoRiskGraphNodeKind, label string) {
 	t.Helper()
 	for _, node := range graph.Nodes {

--- a/internal/domain/repo_risk_graph_test.go
+++ b/internal/domain/repo_risk_graph_test.go
@@ -723,6 +723,7 @@ func TestBuildRepoRiskGraphAmplifiesUnprotectedProductionEnvironment(t *testing.
 func TestBuildRepoRiskGraphDoesNotClaimInheritanceForUnattachedRepository(t *testing.T) {
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
 	graph := BuildRepoRiskGraph([]Finding{
+		// configuration_not_applied: collector never queried repo attachment.
 		postureFinding("not-attached", "github_code_security_configuration_weak", SeverityMedium, now, map[string]any{
 			"github_posture_check_id": "org_code_security_configuration",
 			"github_posture_scope":    "organization",
@@ -730,20 +731,71 @@ func TestBuildRepoRiskGraphDoesNotClaimInheritanceForUnattachedRepository(t *tes
 			"github_posture_reason":   "configuration_not_applied",
 			"organization":            "owner",
 		}),
+		// configuration_not_enforced: early return before attachment query.
+		postureFinding("not-enforced", "github_code_security_configuration_weak", SeverityMedium, now, map[string]any{
+			"github_posture_check_id": "org_code_security_configuration",
+			"github_posture_scope":    "organization",
+			"github_posture_state":    "insecure",
+			"github_posture_reason":   "configuration_not_enforced",
+			"organization":            "owner-b",
+		}),
+		// configuration_not_protective: same, and Codex specifically called out
+		// that this reason contains no attachment evidence.
+		postureFinding("not-protective", "github_code_security_configuration_weak", SeverityMedium, now, map[string]any{
+			"github_posture_check_id": "org_code_security_configuration",
+			"github_posture_scope":    "organization",
+			"github_posture_state":    "insecure",
+			"github_posture_reason":   "configuration_not_protective",
+			"organization":            "owner-c",
+		}),
+		// Reached the attachment query, repo is genuinely unattached.
+		postureFinding("no-repo-config", "github_code_security_configuration_weak", SeverityMedium, now, map[string]any{
+			"github_posture_check_id":          "org_code_security_configuration",
+			"github_posture_scope":             "organization",
+			"github_posture_state":             "insecure",
+			"github_posture_reason":            "configuration_not_protective",
+			"organization":                     "owner-d",
+			"repository_configuration_applied": false,
+		}),
+		// Secret-scanning weak with no attachment flag: unattached.
 		postureFinding("not-attached-secrets", "github_secret_scanning_disabled", SeverityHigh, now, map[string]any{
 			"github_posture_check_id": "org_secret_scanning_policy",
 			"github_posture_scope":    "organization",
 			"github_posture_state":    "insecure",
 			"github_posture_reason":   "secret_scanning_policy_weak",
-			"organization":            "owner",
+			"organization":            "owner-e",
 		}),
 	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
 
 	assertGraphNode(t, graph, RepoRiskNodeOrgSecurityConfiguration, "code security configuration: owner")
 	if countEdges(graph, RepoRiskEdgeInheritsOrgPolicy) != 0 {
-		t.Fatalf("expected an unattached repository not to inherit organization controls, got %+v", graph.Edges)
+		t.Fatalf("expected unattached repositories not to inherit organization controls, got %+v", graph.Edges)
 	}
-	// The control is still reported as weak; only the inheritance claim is dropped.
+	// The controls are still reported as weak; only the inheritance claim is dropped.
+	if countEdges(graph, RepoRiskEdgeFindingWeakensControl) != 5 {
+		t.Fatalf("expected every weak organization control to still weaken its node, got %+v", graph.Edges)
+	}
+}
+
+func TestBuildRepoRiskGraphRetainsInheritanceForAttachedWeakSecretScanningPolicy(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	// Repository is attached to an organization configuration that does not
+	// enable both secret scanning and push protection. Inheritance still holds:
+	// the config governs the repository, the config is weak, so the risk
+	// propagates through the inheritance edge.
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("attached-weak-secrets", "github_secret_scanning_disabled", SeverityHigh, now, map[string]any{
+			"github_posture_check_id":          "org_secret_scanning_policy",
+			"github_posture_scope":             "organization",
+			"github_posture_state":             "insecure",
+			"github_posture_reason":            "secret_scanning_policy_weak",
+			"organization":                     "owner",
+			"repository_configuration_applied": true,
+			"repository_configuration_status":  "attached",
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphEdge(t, graph, RepoRiskEdgeInheritsOrgPolicy, RepoRiskEvidenceKnown)
 	assertGraphEdge(t, graph, RepoRiskEdgeFindingWeakensControl, RepoRiskEvidenceKnown)
 }
 
@@ -768,17 +820,85 @@ func TestBuildRepoRiskGraphKeepsUnknownInheritanceForUnreadableSecretScanningPol
 
 func TestBuildRepoRiskGraphKeepsInheritanceForAttachedWeakConfiguration(t *testing.T) {
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	// A code security configuration finding that reached the repository
+	// attachment query and confirmed the repository is attached must still emit
+	// the inheritance edge even when the configuration itself is not protective.
 	graph := BuildRepoRiskGraph([]Finding{
 		postureFinding("attached-weak", "github_code_security_configuration_weak", SeverityMedium, now, map[string]any{
-			"github_posture_check_id": "org_code_security_configuration",
-			"github_posture_scope":    "organization",
-			"github_posture_state":    "insecure",
-			"github_posture_reason":   "configuration_not_enforced",
-			"organization":            "owner",
+			"github_posture_check_id":          "org_code_security_configuration",
+			"github_posture_scope":             "organization",
+			"github_posture_state":             "insecure",
+			"github_posture_reason":            "configuration_not_protective",
+			"organization":                     "owner",
+			"repository_configuration_applied": true,
+			"repository_configuration_status":  "attached",
 		}),
 	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
 
 	assertGraphEdge(t, graph, RepoRiskEdgeInheritsOrgPolicy, RepoRiskEvidenceKnown)
+}
+
+func TestBuildRepoRiskGraphPrefersObservedEvidenceWhenUpgradingSharedOrgControl(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	// Two repositories share one organization Actions policy. The first
+	// finding was permission_limited (unknown), the second observed it as
+	// insecure. The shared control node must upgrade to known and its evidence
+	// must describe the observed state, not the earlier unknown one.
+	graph := BuildRepoRiskGraph([]Finding{
+		{
+			ID:         "unknown-first",
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityMedium,
+			Repository: "owner/repo-a",
+			Detector:   "github_posture_permission_limited",
+			CreatedAt:  now,
+			Evidence: map[string]any{
+				"repository":                  "owner/repo-a",
+				"github_posture_check_id":     "org_actions_policy",
+				"github_posture_scope":        "organization",
+				"github_posture_state":        "permission_limited",
+				"github_posture_collected_at": "2026-05-20T10:00:00Z",
+				"organization":                "owner",
+			},
+		},
+		{
+			ID:         "observed-second",
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityHigh,
+			Repository: "owner/repo-b",
+			Detector:   "github_actions_policy_broad",
+			CreatedAt:  now,
+			Evidence: map[string]any{
+				"repository":                  "owner/repo-b",
+				"github_posture_check_id":     "org_actions_policy",
+				"github_posture_scope":        "organization",
+				"github_posture_state":        "insecure",
+				"github_posture_collected_at": "2026-05-20T12:00:00Z",
+				"organization":                "owner",
+				"allowed_actions":             "all",
+			},
+		},
+	}, RepoRiskGraphOptions{Now: now})
+
+	var policyNode *RepoRiskGraphNode
+	for i := range graph.Nodes {
+		if graph.Nodes[i].Kind == RepoRiskNodeActionsPolicy {
+			policyNode = &graph.Nodes[i]
+			break
+		}
+	}
+	if policyNode == nil {
+		t.Fatalf("expected one shared Actions policy node, got %+v", graph.Nodes)
+	}
+	if policyNode.EvidenceState != RepoRiskEvidenceKnown {
+		t.Fatalf("expected observed evidence to upgrade the node to known, got %+v", policyNode)
+	}
+	if state := policyNode.Evidence["github_posture_state"]; state != "insecure" {
+		t.Fatalf("expected upgraded node to reflect observed posture state, got %v", state)
+	}
+	if collectedAt := policyNode.Evidence["github_posture_collected_at"]; collectedAt != "2026-05-20T12:00:00Z" {
+		t.Fatalf("expected upgraded node to carry the observed collection timestamp, got %v", collectedAt)
+	}
 }
 
 func postureFinding(id string, detector string, severity FindingSeverity, now time.Time, evidence map[string]any) Finding {

--- a/internal/domain/repo_risk_graph_test.go
+++ b/internal/domain/repo_risk_graph_test.go
@@ -361,6 +361,82 @@ func TestBuildRepoRiskGraphLinksGitHubPostureControlPlane(t *testing.T) {
 	}
 }
 
+func TestBuildRepoRiskGraphConvergesOrgPolicyAcrossRepositories(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	orgPolicyFinding := func(id string, repository string) Finding {
+		return Finding{
+			ID:         id,
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityMedium,
+			Repository: repository,
+			Detector:   "github_actions_policy_broad",
+			CreatedAt:  now,
+			Evidence: map[string]any{
+				"repository":              repository,
+				"github_posture_check_id": "org_actions_policy",
+				"github_posture_scope":    "organization",
+				"github_posture_state":    "insecure",
+				"organization":            "owner",
+				"allowed_actions":         "all",
+			},
+		}
+	}
+	graph := BuildRepoRiskGraph([]Finding{
+		orgPolicyFinding("repo-a-policy", "owner/repo-a"),
+		orgPolicyFinding("repo-b-policy", "owner/repo-b"),
+	}, RepoRiskGraphOptions{Now: now})
+
+	if countNodes(graph, RepoRiskNodeActionsPolicy) != 1 {
+		t.Fatalf("expected one organization policy to stay one node across repositories, got %+v", graph.Nodes)
+	}
+	for _, node := range graph.Nodes {
+		if node.Kind == RepoRiskNodeActionsPolicy && node.Repository != "" {
+			t.Fatalf("expected a shared organization policy not to be pinned to one repository, got %+v", node)
+		}
+	}
+	if countEdges(graph, RepoRiskEdgeInheritsOrgPolicy) != 2 {
+		t.Fatalf("expected both repositories to inherit the shared organization policy, got %+v", graph.Edges)
+	}
+
+	inheritedNodeIDs := map[string]struct{}{}
+	for _, edge := range graph.Edges {
+		if edge.Kind == RepoRiskEdgeInheritsOrgPolicy {
+			inheritedNodeIDs[edge.ToNodeID] = struct{}{}
+		}
+	}
+	if len(inheritedNodeIDs) != 1 {
+		t.Fatalf("expected inheritance edges to converge on one policy node, got %+v", graph.Edges)
+	}
+}
+
+func TestBuildRepoRiskGraphKeepsOrgPolicyPerRepositoryWithoutOrganizationEvidence(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	unattributedFinding := func(id string, repository string) Finding {
+		return Finding{
+			ID:         id,
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityMedium,
+			Repository: repository,
+			Detector:   "github_actions_policy_broad",
+			CreatedAt:  now,
+			Evidence: map[string]any{
+				"repository":              repository,
+				"github_posture_check_id": "org_actions_policy",
+				"github_posture_scope":    "organization",
+				"github_posture_state":    "insecure",
+			},
+		}
+	}
+	graph := BuildRepoRiskGraph([]Finding{
+		unattributedFinding("repo-a-policy", "owner-a/repo"),
+		unattributedFinding("repo-b-policy", "owner-b/repo"),
+	}, RepoRiskGraphOptions{Now: now})
+
+	if countNodes(graph, RepoRiskNodeActionsPolicy) != 2 {
+		t.Fatalf("expected policies without organization evidence to stay separate rather than merge, got %+v", graph.Nodes)
+	}
+}
+
 func TestBuildRepoRiskGraphSurfacesPermissionLimitedPostureAsUncertainty(t *testing.T) {
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
 	graph := BuildRepoRiskGraph([]Finding{

--- a/internal/domain/repo_risk_graph_test.go
+++ b/internal/domain/repo_risk_graph_test.go
@@ -615,6 +615,26 @@ func TestBuildRepoRiskGraphMapsRepositoryWriteDefaultToItsOwnControl(t *testing.
 	assertGraphEdge(t, graph, RepoRiskEdgeFindingWeakensControl, RepoRiskEvidenceKnown)
 }
 
+func TestBuildRepoRiskGraphMapsPRApprovalPrivilegeToWorkflowPermissionControl(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("pr-approval", "github_actions_policy_broad", SeverityHigh, now, map[string]any{
+			"github_posture_check_id":          "actions_permissions",
+			"github_posture_category":          "actions",
+			"github_posture_scope":             "repository",
+			"github_posture_state":             "insecure",
+			"allowed_actions":                  "selected",
+			"default_workflow_permissions":     "read",
+			"can_approve_pull_request_reviews": true,
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphNode(t, graph, RepoRiskNodeWorkflowPermissionDefault, "default workflow permissions: repository")
+	if countNodes(graph, RepoRiskNodeActionsPolicy) != 0 {
+		t.Fatalf("expected PR-approval privilege to attribute to the workflow permission control, not the Actions source policy, got %+v", graph.Nodes)
+	}
+}
+
 func TestBuildRepoRiskGraphKeepsBroadActionSourcesOnActionsPolicy(t *testing.T) {
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
 	graph := BuildRepoRiskGraph([]Finding{
@@ -725,6 +745,25 @@ func TestBuildRepoRiskGraphDoesNotClaimInheritanceForUnattachedRepository(t *tes
 	}
 	// The control is still reported as weak; only the inheritance claim is dropped.
 	assertGraphEdge(t, graph, RepoRiskEdgeFindingWeakensControl, RepoRiskEvidenceKnown)
+}
+
+func TestBuildRepoRiskGraphKeepsUnknownInheritanceForUnreadableSecretScanningPolicy(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		postureFinding("permission-limited-secrets", "github_posture_permission_limited", SeverityMedium, now, map[string]any{
+			"github_posture_check_id": "org_secret_scanning_policy",
+			"github_posture_scope":    "organization",
+			"github_posture_state":    "permission_limited",
+			"organization":            "owner",
+		}),
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphNode(t, graph, RepoRiskNodeAlertSource, "alert source: secret scanning policy: owner")
+	// The scanner could not read the policy, so whether the repository inherits
+	// it is itself unknown; the graph must retain an unknown-state inheritance
+	// edge rather than drop it and disconnect the control from the repository.
+	assertGraphEdge(t, graph, RepoRiskEdgeInheritsOrgPolicy, RepoRiskEvidenceUnknown)
+	assertGraphEdge(t, graph, RepoRiskEdgeFindingDependsOnPostureSource, RepoRiskEvidenceUnknown)
 }
 
 func TestBuildRepoRiskGraphKeepsInheritanceForAttachedWeakConfiguration(t *testing.T) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -221,9 +221,55 @@ export type RepoFindingRemediationPublishResponse = {
   publish: RepoRemediationPublishResult;
 };
 
+export type RepoRiskGraphNodeKind =
+  | 'repository'
+  | 'default_branch'
+  | 'finding'
+  | 'workflow'
+  | 'workflow_job'
+  | 'environment'
+  | 'secret'
+  | 'deploy_key'
+  | 'github_app'
+  | 'token'
+  | 'oidc_subject'
+  | 'cloud_role'
+  | 'kubernetes_service_account'
+  | 'branch_protection'
+  | 'repository_ruleset'
+  | 'actions_policy'
+  | 'workflow_permission_default'
+  | 'reusable_workflow_policy'
+  | 'runner_group'
+  | 'environment_protection'
+  | 'webhook'
+  | 'alert_source'
+  | 'org_security_configuration'
+  | 'unknown';
+
+export type RepoRiskGraphEdgeKind =
+  | 'repository_contains_workflow'
+  | 'repository_default_branch'
+  | 'finding_in_repository'
+  | 'finding_affects_workflow'
+  | 'workflow_runs_job'
+  | 'job_uses_secret'
+  | 'finding_exposes_token'
+  | 'workflow_can_mint_token'
+  | 'oidc_subject_can_assume_role'
+  | 'repo_deploys_to_environment'
+  | 'finding_references_identity'
+  | 'repository_governed_by_control'
+  | 'repository_inherits_org_policy'
+  | 'workflow_runs_on_runner_group'
+  | 'finding_weakens_control'
+  | 'finding_exposes_control_risk'
+  | 'finding_depends_on_posture_source'
+  | 'reachability_unknown';
+
 export type RepoRiskGraphNode = {
   id: string;
-  kind: string;
+  kind: RepoRiskGraphNodeKind;
   label: string;
   repository?: string;
   evidence_state: 'known' | 'unknown';
@@ -232,7 +278,7 @@ export type RepoRiskGraphNode = {
 
 export type RepoRiskGraphEdge = {
   id: string;
-  kind: string;
+  kind: RepoRiskGraphEdgeKind;
   from_node_id: string;
   to_node_id: string;
   evidence_state: 'known' | 'unknown';
@@ -247,6 +293,7 @@ export type RepoRiskGraphScoreFactors = {
   exposure: number;
   environment_criticality: number;
   freshness: number;
+  posture_amplifier: number;
 };
 
 export type RepoRiskGraphFindingScore = {

--- a/web/src/components/home/HeroOpenSourceProofPills.test.tsx
+++ b/web/src/components/home/HeroOpenSourceProofPills.test.tsx
@@ -62,9 +62,9 @@ describe('HeroOpenSourceProofPills', () => {
   });
 
   it('does not render a GitHub stars pill and does not call the GitHub API', async () => {
-    const fetchedURLs: string[] = [];
+    const fetchedHostnames: string[] = [];
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
-      fetchedURLs.push(fetchURL(input));
+      fetchedHostnames.push(new URL(fetchURL(input)).hostname);
       return okJSON({ message: '2.4k' });
     });
     vi.stubGlobal('fetch', fetchMock);
@@ -73,6 +73,6 @@ describe('HeroOpenSourceProofPills', () => {
 
     await waitFor(() => expect(screen.getByText('2.4k+')).toBeInTheDocument());
     expect(screen.queryByText('GitHub stars')).not.toBeInTheDocument();
-    expect(fetchedURLs.some((url) => url.includes('api.github.com'))).toBe(false);
+    expect(fetchedHostnames).not.toContain('api.github.com');
   });
 });

--- a/web/src/components/home/HeroOpenSourceProofPills.test.tsx
+++ b/web/src/components/home/HeroOpenSourceProofPills.test.tsx
@@ -25,7 +25,6 @@ describe('HeroOpenSourceProofPills', () => {
   it('does not show zero Docker pulls when pull metrics are unavailable', async () => {
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = new URL(fetchURL(input));
-      if (url.hostname === 'api.github.com') return okJSON({ stargazers_count: 3 });
       if (url.hostname === 'img.shields.io' && url.pathname.includes('/docker/pulls')) {
         return okJSON({ message: 'repo not found' });
       }
@@ -35,11 +34,11 @@ describe('HeroOpenSourceProofPills', () => {
 
     render(<HeroOpenSourceProofPills />);
 
-    await waitFor(() => expect(screen.getByText('3')).toBeInTheDocument());
-
-    const dockerPill = screen.getByText('Docker pulls').closest('a');
+    const dockerPill = (await screen.findByText('Docker pulls')).closest('a');
     expect(dockerPill).not.toBeNull();
-    expect(within(dockerPill as HTMLElement).getByText('Live')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(within(dockerPill as HTMLElement).getByText('Live')).toBeInTheDocument()
+    );
     expect(within(dockerPill as HTMLElement).queryByText('0')).not.toBeInTheDocument();
   });
 
@@ -47,7 +46,6 @@ describe('HeroOpenSourceProofPills', () => {
     const dockerMetricPaths: string[] = [];
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = new URL(fetchURL(input));
-      if (url.hostname === 'api.github.com') return okJSON({ stargazers_count: 3 });
       if (url.hostname === 'img.shields.io' && url.pathname.includes('/docker/pulls')) {
         dockerMetricPaths.push(url.pathname);
         return okJSON({ message: '2.4k' });
@@ -61,5 +59,20 @@ describe('HeroOpenSourceProofPills', () => {
     await waitFor(() => expect(screen.getByText('2.4k+')).toBeInTheDocument());
 
     expect(dockerMetricPaths).toEqual(['/docker/pulls/identrail/identrail.json']);
+  });
+
+  it('does not render a GitHub stars pill and does not call the GitHub API', async () => {
+    const fetchedURLs: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      fetchedURLs.push(fetchURL(input));
+      return okJSON({ message: '2.4k' });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<HeroOpenSourceProofPills />);
+
+    await waitFor(() => expect(screen.getByText('2.4k+')).toBeInTheDocument());
+    expect(screen.queryByText('GitHub stars')).not.toBeInTheDocument();
+    expect(fetchedURLs.some((url) => url.includes('api.github.com'))).toBe(false);
   });
 });

--- a/web/src/components/home/HeroOpenSourceProofPills.tsx
+++ b/web/src/components/home/HeroOpenSourceProofPills.tsx
@@ -3,13 +3,12 @@ import { projectMetricsSource, siteLinks } from '../../siteConfig';
 import { SafeLink } from '../SafeLink';
 
 type HeroProofStats = {
-  stars: number | null;
   pulls: number | null;
 };
 
-const CACHE_KEY = 'identrail_hero_proof_stats_v2';
+const CACHE_KEY = 'identrail_hero_proof_stats_v3';
 const CACHE_TTL_MS = 30 * 60 * 1000;
-const EMPTY_STATS: HeroProofStats = { stars: null, pulls: null };
+const EMPTY_STATS: HeroProofStats = { pulls: null };
 
 function formatMetric(value: number | null): string {
   if (value === null) return 'Live';
@@ -49,18 +48,6 @@ function cacheStats(stats: HeroProofStats) {
   }
 }
 
-async function fetchGitHubStars(signal: AbortSignal): Promise<number | null> {
-  const { owner, name } = projectMetricsSource.github;
-  const response = await fetch(`https://api.github.com/repos/${owner}/${name}`, {
-    signal,
-    headers: { Accept: 'application/vnd.github+json' }
-  });
-  if (!response.ok) return null;
-
-  const payload = (await response.json()) as { stargazers_count?: number };
-  return typeof payload.stargazers_count === 'number' ? payload.stargazers_count : null;
-}
-
 async function fetchDockerPulls(repoPath: string, signal: AbortSignal): Promise<number | null> {
   try {
     const response = await fetch(`https://img.shields.io/docker/pulls/${repoPath}.json`, { signal });
@@ -75,14 +62,12 @@ async function fetchDockerPulls(repoPath: string, signal: AbortSignal): Promise<
 }
 
 async function fetchHeroProofStats(signal: AbortSignal): Promise<HeroProofStats> {
-  const [stars, pullResults] = await Promise.all([
-    fetchGitHubStars(signal),
-    Promise.all(projectMetricsSource.dockerHubRepos.map((repoPath) => fetchDockerPulls(repoPath, signal)))
-  ]);
-
+  const pullResults = await Promise.all(
+    projectMetricsSource.dockerHubRepos.map((repoPath) => fetchDockerPulls(repoPath, signal))
+  );
   const availablePulls = pullResults.filter((current): current is number => current !== null);
   const pulls = availablePulls.length > 0 ? availablePulls.reduce((total, current) => total + current, 0) : null;
-  return { stars, pulls };
+  return { pulls };
 }
 
 export function HeroOpenSourceProofPills() {
@@ -98,10 +83,7 @@ export function HeroOpenSourceProofPills() {
     void fetchHeroProofStats(controller.signal)
       .then((liveStats) => {
         setStats((current) => {
-          const next = {
-            stars: liveStats.stars ?? current.stars,
-            pulls: liveStats.pulls ?? current.pulls
-          };
+          const next = { pulls: liveStats.pulls ?? current.pulls };
           cacheStats(next);
           return next;
         });
@@ -114,19 +96,13 @@ export function HeroOpenSourceProofPills() {
   const proofItems = useMemo(
     () => [
       {
-        label: 'GitHub stars',
-        value: formatMetric(stats.stars),
-        href: siteLinks.starOnGithub,
-        icon: '/brand-logos/github.svg'
-      },
-      {
         label: 'Docker pulls',
         value: formatMetric(stats.pulls),
         href: siteLinks.quickstartDocker,
         icon: '/brand-logos/docker.svg'
       }
     ],
-    [stats.pulls, stats.stars]
+    [stats.pulls]
   );
 
   return (

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -11407,7 +11407,8 @@ describe('ProductFindingsPage states', () => {
               privilege: 70,
               exposure: 70,
               environment_criticality: 60,
-              freshness: 90
+              freshness: 90,
+              posture_amplifier: 0
             },
             unknowns: []
           }

--- a/web/src/siteConfig.ts
+++ b/web/src/siteConfig.ts
@@ -55,12 +55,6 @@ export const siteLinks = {
   x: 'https://x.com/identrail'
 } as const;
 
-export const githubRepo = {
-  owner: 'identrail',
-  name: 'identrail'
-} as const;
-
 export const projectMetricsSource = {
-  github: githubRepo,
   dockerHubRepos: ['identrail/identrail']
 } as const;


### PR DESCRIPTION
## Summary

Represents GitHub control-plane posture as structure in the repository risk graph.

New node kinds, each built only from a posture check the collector actually ran: `branch_protection`, `repository_ruleset`, `actions_policy`, `workflow_permission_default`, `reusable_workflow_policy`, `runner_group`, `environment_protection`, `webhook`, `alert_source`, `org_security_configuration`. Deploy keys reuse the existing `deploy_key` kind.

New edge kinds: `repository_governed_by_control`, `repository_inherits_org_policy`, `workflow_runs_on_runner_group`, `finding_weakens_control`, `finding_exposes_control_risk`, `finding_depends_on_posture_source`.

Scores gain a `posture_amplifier` factor so proven-weak controls widen blast radius: an unprotected default branch, a broad Actions policy, a write-by-default workflow token, self-hosted runners, writable deploy keys, and unprotected production environments all rate higher than a disabled alert source. The amplifier applies on top of the existing weighted base rather than inside it, so it cannot dilute severity, confidence, and reachability — and non-posture finding scores are byte-for-byte unchanged.

## Why

The graph derived reachability from repository finding evidence only. That covered workflow, token, OIDC, secret, environment, and identity paths, but GitHub control-plane posture had no graph structure, so branch protection, Actions policy, runner groups, deploy keys, webhooks, environments, and org-level posture could not be reasoned about in one blast-radius view. Closes #1710.

## Uncertainty is preserved, not scored

The graph principle that missing evidence is never invented is kept:

- A posture check the scanner could not read (`permission_limited`, `unavailable`, `unknown`) still produces its control node, but with unknown evidence state, an unknown governance edge, a `finding_depends_on_posture_source` edge, and a `posture_source` entry in the score's `unknowns`. It contributes zero amplifier — an unreadable control is not evidence of a weak control.
- Runner-group availability is repository-scoped evidence and never proves a given workflow targets that group, so every `workflow_runs_on_runner_group` edge is recorded as unknown reachability.
- Posture checks with no control-plane concept of their own (`repository_metadata`, and any future check) stay finding-only rather than becoming a speculative node.

## Drive-by fix

`findingReferencesSecrets` fell back to a detector-name substring match, so `github_secret_scanning_disabled` would have invented a secret node labelled "referenced GitHub secret". Posture findings report on a control, not on a secret a workflow consumes, so they now short-circuit that heuristic. Covered by a regression test.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered — additive node/edge kinds and one additive score factor; existing kinds, edges, and non-posture scores are unchanged
- [x] Risk level assessed — read-path only; no collector, storage, or migration changes

## Validation

```bash
make fmt-check                    # passed
make vet                          # passed
go test ./internal/domain/ ./internal/connectors/github/ ./internal/api/ ./internal/cli/   # all ok
go test ./internal/domain/ -cover # 83.6% (>= 80% target)
make api-example-contract-check   # passed
npx tsc --noEmit --prefix web     # passed
npx vitest run src/productShell.test.tsx   # passed
```

Test coverage added:

- Graph construction for repo-scope and org-scope posture controls, including governance and inheritance edges.
- Permission-limited posture surfacing as unknown nodes/edges plus a `posture_source` score unknown, with no amplifier and no weakening edge.
- Workflow-to-runner-group edges staying unknown.
- Deploy key and webhook risk using the exposure edge, not the weakening edge.
- Amplifier ordering: an unprotected default branch outranks a disabled alert source.
- `internal/connectors/github`: a contract test that runs real `RepositoryPostureFindings` and `OrganizationPostureFindings` output through `BuildRepoRiskGraph` and asserts every control-plane check resolves to a node and every insecure check amplifies its score. This fails if a check ID is renamed in the collector without updating the graph mapping.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes — `docs/openapi-v1.yaml` node/edge enums and `posture_amplifier`; `web/src/api/client.ts` now exports `RepoRiskGraphNodeKind`/`RepoRiskGraphEdgeKind` unions in place of a bare `string`
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included — control nodes carry summary-shaped posture evidence only (counts, policy modes, states); no runner hostnames, tokens, or hook secrets

## AI Assistance Disclosure

- AI-assisted: no

## Related Issues

Closes #1710

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the repository risk graph with GitHub control‑plane posture and adds a `posture_amplifier` so weak controls widen blast radius. Gates org‑policy inheritance on explicit repo attachment, converges shared org controls, and keys per‑configuration policies by attached configuration id. Closes #1710.

- **New Features**
  - New node kinds: `branch_protection`, `repository_ruleset`, `actions_policy`, `workflow_permission_default`, `reusable_workflow_policy`, `runner_group`, `environment_protection`, `deploy_key`, `webhook`, `alert_source`, `org_security_configuration`.
  - New edge kinds: `repository_governed_by_control`, `repository_inherits_org_policy`, `workflow_runs_on_runner_group`, `finding_weakens_control`, `finding_exposes_control_risk`, `finding_depends_on_posture_source` (runner‑group edges stay `unknown` reachability).
  - Org policies converge: org‑scoped controls key by organization; `org_code_security_configuration` and `org_secret_scanning_policy` key by attached configuration id (labels include id); if org missing, keep per‑repo.
  - Adds `posture_amplifier` to finding scores; unreadable posture sources surface as unknown nodes/edges with a `posture_source` unknown and zero amplification. Environment evidence carries redacted `unprotected_environment_criticality`.
  - API and types: OpenAPI enums include new node/edge kinds and `posture_amplifier`. `web/src/api/client.ts` exports `RepoRiskGraphNodeKind`/`RepoRiskGraphEdgeKind` unions and includes `posture_amplifier` in `RepoRiskGraphScoreFactors`.
  - Marketing: removed the GitHub stars pill from the homepage hero and its GitHub REST call; Docker pulls pill remains.

- **Bug Fixes**
  - Map repo `actions_permissions` write‑default and PR‑approval privilege to `workflow_permission_default` when sources are restricted.
  - Treat alert sources with `open_alerts_present` as governance only — no weakening edge or amplifier.
  - Emit `repository_inherits_org_policy` only when the repo actually inherits the org control: gate on `repository_configuration_applied`; keep an unknown‑state inheritance edge for unreadable org policies; inherit even when attached to a weak configuration.
  - Prefer observed evidence when upgrading shared org‑policy nodes/edges from unknown to known so evidence matches the promoted state.
  - Stop posture detectors (e.g., `github_secret_scanning_disabled`) from inventing secret nodes via the detector‑name heuristic.

<sup>Written for commit 29766f62e624fa9a9b6315f63abc1c22a196bb63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

