### PR TITLE
Add organization and selected-scope AWS onboarding UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 ## Unreleased
+- Add **organization and selected-scope onboarding UI** to the Connect AWS
+  wizard (#1753). Operators can now pick `AWS Organization`, `Selected OUs`,
+  or `Selected accounts` alongside the existing single-account and manual
+  paths. Target region, OU, account, and exclusion inputs feed the
+  service-managed StackSet backend from #1752, and an auto-onboard toggle is
+  exposed for organization and selected-OU deployments. Client-side validation
+  blocks empty or malformed targets before the API call is made. A new
+  StackSet progress panel renders pending / active / degraded / failed /
+  permission-denied / resumable counts, per-instance state, coverage
+  expectation, and recovery actions returned by the backend. Blocking
+  prerequisites disable the launch button, and stale in-flight starts are
+  dropped after an environment switch.
 - Remove the GitHub stars pill from the marketing homepage hero. The remaining
   Docker pulls pill now sits where the pair used to, so the hero no longer
   advertises a low star count. Also drops the GitHub REST call the pill made on

--- a/docs/aws-stackset-onboarding.md
+++ b/docs/aws-stackset-onboarding.md
@@ -215,20 +215,30 @@ calls. The wizard is available at `AWS → Connect` inside a workspace and
 supports:
 
 - **AWS Organization** — Recommended for teams. Uses a service-managed
-  StackSet across the whole organization; exclusions and auto-onboard for new
-  accounts are exposed as first-class controls. Identrail never claims
-  organization-wide coverage while exclusions or missing trusted access are
-  present.
+  StackSet across the whole organization; the wizard requires the
+  Organizations root ID (`r-...`), and exposes exclusions and an
+  auto-onboard toggle for new accounts as first-class controls. Identrail
+  never claims organization-wide coverage while exclusions or missing
+  trusted access are present.
 - **Selected OUs** — Comma or space separated Organizations OU IDs
-  (`ou-1234-abcd5678`). Root IDs (`r-...`) are also accepted for whole-org
-  intent. Auto-onboard applies to accounts moved into the covered OUs later.
-- **Selected accounts** — Comma or space separated 12-digit AWS account IDs.
-  Auto-onboard is disabled by design for selected-account deployments.
-- **Excluded accounts** — Optional 12-digit exclusion list. Coverage claims
-  never include excluded accounts, even when the organization path is chosen.
+  (`ou-1234-abcd5678`). Root IDs (`r-...`) are **not accepted here**; pick the
+  AWS Organization path if you want whole-organization coverage. Auto-onboard
+  applies to accounts moved into the covered OUs later.
+- **Selected accounts** — Comma or space separated 12-digit AWS account IDs
+  plus the Organizations root ID. Service-managed StackSet needs the root ID
+  to scope the account filter, but the effective coverage is still limited to
+  the account IDs you pick. Auto-onboard is disabled by design for
+  selected-account deployments.
+- **Excluded accounts** — Optional 12-digit exclusion list. Available on the
+  AWS Organization and Selected OUs paths; the Selected accounts path uses the
+  account list itself as the authoritative filter and drops any exclusion
+  entries at submission. Coverage claims never include excluded accounts.
 - **Target regions** — Region codes for StackSet instance deployment. The role
   itself is deployed to a single home region even when multiple scan regions
   are selected.
+- **Resume**: clicking "Prepare StackSet again" on an existing connector sends
+  the current connector ID, so the backend resumes the same setup lifecycle
+  instead of minting a fresh external ID.
 
 The wizard blocks launch when target inputs are missing or malformed
 (unknown region code, non-12-digit account ID, invalid OU ID) and surfaces

--- a/docs/aws-stackset-onboarding.md
+++ b/docs/aws-stackset-onboarding.md
@@ -207,6 +207,53 @@ operator can re-run a focused recovery.
    per-instance state, cursors, and recovery actions reflect the latest
    checkpoints.
 
+## Connect AWS wizard: organization and selected paths
+
+The scope-first **Connect AWS** wizard exposes the organization and
+selected-scope paths so operators can drive the flow without hand-editing API
+calls. The wizard is available at `AWS → Connect` inside a workspace and
+supports:
+
+- **AWS Organization** — Recommended for teams. Uses a service-managed
+  StackSet across the whole organization; exclusions and auto-onboard for new
+  accounts are exposed as first-class controls. Identrail never claims
+  organization-wide coverage while exclusions or missing trusted access are
+  present.
+- **Selected OUs** — Comma or space separated Organizations OU IDs
+  (`ou-1234-abcd5678`). Root IDs (`r-...`) are also accepted for whole-org
+  intent. Auto-onboard applies to accounts moved into the covered OUs later.
+- **Selected accounts** — Comma or space separated 12-digit AWS account IDs.
+  Auto-onboard is disabled by design for selected-account deployments.
+- **Excluded accounts** — Optional 12-digit exclusion list. Coverage claims
+  never include excluded accounts, even when the organization path is chosen.
+- **Target regions** — Region codes for StackSet instance deployment. The role
+  itself is deployed to a single home region even when multiple scan regions
+  are selected.
+
+The wizard blocks launch when target inputs are missing or malformed
+(unknown region code, non-12-digit account ID, invalid OU ID) and surfaces
+blocking prerequisites returned by the backend before enabling the launch
+button. The StackSet progress panel renders pending / active / degraded /
+failed / permission-denied / resumable counts, per-instance state, and any
+recovery actions produced by the planner.
+
+## Troubleshooting
+
+- **Trusted access is not enabled**: the launch button stays disabled with a
+  blocking prerequisite. Enable trusted access for CloudFormation in the
+  Organizations console, then reload the wizard.
+- **Delegated admin required**: register the delegated admin account for
+  CloudFormation StackSets in Organizations; the prerequisite clears on the
+  next reload.
+- **Missing targets**: the wizard rejects submissions that have no target
+  region, no OU IDs (selected OUs path), or no account IDs (selected accounts
+  path). The rejection is client-side and never sends the request.
+- **Partial StackSet failure**: the progress panel lists failed instances with
+  the reason and next action provided by the planner. Rerun the StackSet from
+  the AWS console using the recovery targets shown, then refresh status.
+- **Auto-onboard for selected accounts**: the toggle is intentionally hidden
+  because AWS blocks auto-deploy on selected-account deployments.
+
 ## Out of scope (next-wave issues)
 
 - Live execution of the StackSet operation from Identrail.

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -10132,9 +10132,226 @@ describe('Domain-first app routes', () => {
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
     await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
+    // On resume the wizard omits stack_set_name (and role_name) so the backend
+    // keeps whatever it stored for the connector; sending the wizard default
+    // would trip resumeAWSStackSetConnectorStart when the stored name differs.
     expect(startAWSConnector.mock.calls[0]?.[0]).toMatchObject({
       connector_id: 'aws-org-named',
-      stack_set_name: 'CustomerNamedStackSet'
+      stack_set_name: undefined,
+      role_name: undefined
+    });
+  });
+
+  it('resets the hidden StackSet name when switching to an environment without a connector', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging',
+          name: 'Staging',
+          slug: 'staging',
+          description: 'Staging AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
+    const getConnection = vi
+      .spyOn(api.apiClient, 'getAWSProjectConnection')
+      .mockImplementation((_workspaceID: string, projectID: string) => {
+        if (projectID === 'production') {
+          return Promise.resolve({
+            connection: {
+              ...connectedAWS,
+              connector_id: 'aws-prod-named',
+              scope_type: 'organization',
+              deployment_method: 'stackset_service_managed',
+              onboarding_status: 'connected',
+              target_regions: ['us-east-1'],
+              target_ou_ids: ['r-abcd'],
+              stack_set_name: 'ProdCustomStackSet'
+            }
+          });
+        }
+        return Promise.resolve({ connection: disconnectedAWS });
+      });
+    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({
+      onboarding: readyAWSStackSetOnboarding
+    });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-staging-new',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready'
+      },
+      connector_id: 'aws-staging-new',
+      external_id: 'staging-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'identrail-readonly-stackset',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'organization',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: ['r-abcd'],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'Fresh staging setup.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Wait for the production connector to hydrate the custom stack set name.
+    await screen.findByRole('region', { name: /StackSet onboarding progress/i });
+
+    // Switch to the staging environment (no connector yet).
+    fireEvent.change(screen.getByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('staging');
+    await waitFor(() => expect(getConnection).toHaveBeenCalledWith(
+      'workspace-a',
+      'staging',
+      expect.anything()
+    ));
+
+    // Kick off a fresh StackSet setup in staging — the hidden StackSet name
+    // must come from the wizard default, not leak from the production
+    // environment's custom name.
+    fireEvent.click(screen.getByRole('button', { name: /AWS Organization/i }));
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    await waitFor(() => expect(startAWSConnector).toHaveBeenCalled());
+    const stagingCall = startAWSConnector.mock.calls[startAWSConnector.mock.calls.length - 1]?.[0] as {
+      stack_set_name?: string;
+      connector_id?: string;
+    };
+    expect(stagingCall?.connector_id).toBeUndefined();
+    expect(stagingCall?.stack_set_name).toBe('identrail-readonly-stackset');
+    expect(stagingCall?.stack_set_name).not.toBe('ProdCustomStackSet');
+  });
+
+  it('omits role_name on resume for a pending StackSet connector with empty role_arn', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      // Pending API-created StackSet connector: no role_arn yet (StackSet
+      // hasn't deployed the role), so role_name cannot be derived from the
+      // ARN. AWSConnectionStatus doesn't currently expose role_name.
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-pending-role',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'waiting_for_aws',
+        target_regions: ['us-east-1'],
+        target_ou_ids: ['r-abcd'],
+        role_arn: undefined
+      }
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({
+      onboarding: readyAWSStackSetOnboarding
+    });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-pending-role',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready'
+      },
+      connector_id: 'aws-pending-role',
+      external_id: 'pending-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'CustomRoleFromBackend',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'CustomerNamedStackSet',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'organization',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: ['r-abcd'],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'Pending setup.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('region', { name: /StackSet onboarding progress/i });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
+    // Resume must not overwrite the stored custom role name with the wizard
+    // default — omit role_name entirely so the backend keeps its stored value.
+    expect(startAWSConnector.mock.calls[0]?.[0]).toMatchObject({
+      connector_id: 'aws-pending-role',
+      role_name: undefined
     });
   });
 
@@ -10626,10 +10843,13 @@ describe('Domain-first app routes', () => {
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
     await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
+    // The role name and StackSet name are hydrated in the form for display,
+    // but the resume payload omits them so the backend keeps the stored
+    // values rather than overwriting them with the wizard defaults.
     expect(startAWSConnector.mock.calls[0]?.[0]).toMatchObject({
       connector_id: 'aws-org-role',
-      role_name: 'CustomerReadOnlyIdentrail',
-      stack_set_name: 'CustomerNamedStackSet'
+      role_name: undefined,
+      stack_set_name: undefined
     });
   });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -9140,6 +9140,7 @@ describe('Domain-first app routes', () => {
     expect(screen.getByRole('heading', { level: 4, name: /Set the coverage scope/i })).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/Target regions/i), { target: { value: 'us-east-1, us-west-2' } });
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     const autoOnboard = screen.getByRole('checkbox', { name: /Auto-onboard new accounts/i });
     expect(autoOnboard).toBeChecked();
 
@@ -9153,6 +9154,7 @@ describe('Domain-first app routes', () => {
           scope_type: 'organization',
           deployment_method: 'stackset_service_managed',
           target_regions: ['us-east-1', 'us-west-2'],
+          target_ou_ids: ['r-abcd'],
           auto_onboard_new_accounts: true
         }),
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
@@ -9336,6 +9338,7 @@ describe('Domain-first app routes', () => {
     fireEvent.change(screen.getByLabelText(/Target account IDs/i), {
       target: { value: '111111111111, 222222222222' }
     });
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
     await waitFor(() =>
@@ -9343,11 +9346,15 @@ describe('Domain-first app routes', () => {
         expect.objectContaining({
           scope_type: 'selected_accounts',
           target_account_ids: ['111111111111', '222222222222'],
+          target_ou_ids: ['r-abcd'],
           auto_onboard_new_accounts: false
         }),
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
+    const calls = startAWSConnector.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect((lastCall?.[0] as { excluded_account_ids?: string[] } | undefined)?.excluded_account_ids).toBeUndefined();
   });
 
   it('blocks empty StackSet targets before calling the API', async () => {
@@ -9474,6 +9481,7 @@ describe('Domain-first app routes', () => {
     );
 
     fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
     await waitFor(() =>
@@ -9528,6 +9536,7 @@ describe('Domain-first app routes', () => {
     );
 
     fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
     fireEvent.change(screen.getByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
@@ -9571,6 +9580,274 @@ describe('Domain-first app routes', () => {
     expect(
       screen.queryByRole('link', { name: /Open StackSet in AWS/i })
     ).not.toBeInTheDocument();
+  });
+
+  it('rejects an Organizations root ID on the Selected OUs path', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector');
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
+    fireEvent.change(screen.getByLabelText(/Target OU IDs/i), { target: { value: 'r-abcd' } });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    expect(
+      await screen.findByText(/Root ID "r-abcd" is not accepted for Selected OUs/i)
+    ).toBeInTheDocument();
+    expect(startAWSConnector).not.toHaveBeenCalled();
+  });
+
+  it('sends connector_id on retry so the StackSet start resumes existing setup', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const startResponse: AWSConnectorStartResponse = {
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-org-retry',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready',
+        launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets'
+      },
+      connector_id: 'aws-org-retry',
+      external_id: 'org-retry-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'IdentrailReadOnlyCoverage',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'organization',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: ['r-abcd'],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'AWS Organization setup ready.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      target_summary: {
+        account_count: 0,
+        account_count_known: false,
+        ou_count: 0,
+        region_count: 1,
+        excluded_account_count: 0,
+        expected_stack_instances: 0,
+        expected_stack_instances_known: false,
+        all_accounts: true
+      },
+      prerequisites: [],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    };
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue(startResponse);
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
+    expect(startAWSConnector.mock.calls[0]?.[0]).toMatchObject({ connector_id: undefined });
+
+    fireEvent.click(await screen.findByRole('button', { name: /Prepare StackSet again/i }));
+
+    await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(2));
+    expect(startAWSConnector.mock.calls[1]?.[0]).toMatchObject({ connector_id: 'aws-org-retry' });
+  });
+
+  it('drops a pending StackSet start when the operator switches scope mode', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const pendingStart = deferred<AWSConnectorStartResponse>();
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockReturnValue(pendingStart.promise);
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
+
+    await act(async () => {
+      pendingStart.resolve({
+        connection: {
+          ...disconnectedAWS,
+          connector_id: 'aws-org-abandoned',
+          scope_type: 'organization',
+          deployment_method: 'stackset_service_managed',
+          onboarding_status: 'launch_ready'
+        },
+        connector_id: 'aws-org-abandoned',
+        external_id: 'org-abandoned-external',
+        launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets/abandoned',
+        template_url: 'https://example.com/template.yaml',
+        role_name: 'IdentrailReadOnly',
+        stack_name: 'identrail-readonly-connector',
+        stack_set_name: 'IdentrailReadOnlyCoverage',
+        policy_hash: 'sha256:example',
+        template_checksum: 'sha256:example',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready',
+        target_regions: ['us-east-1'],
+        target_account_ids: [],
+        target_ou_ids: ['r-abcd'],
+        excluded_account_ids: [],
+        auto_onboard_new_accounts: true,
+        setup_summary: 'Abandoned org start.',
+        next_actions: ['open_stackset', 'refresh_status'],
+        stackset_onboarding: readyAWSStackSetOnboarding,
+        permission_preview: [],
+        permission_tiers: []
+      });
+    });
+
+    expect(await screen.findByLabelText(/Target OU IDs/i)).toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: /StackSet onboarding progress/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /Open StackSet in AWS/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Launch StackSet setup/i })).not.toBeDisabled();
+  });
+
+  it('loads persisted StackSet onboarding for an existing organization connector', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-existing',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'connected',
+        target_regions: ['us-east-1', 'us-west-2'],
+        target_ou_ids: ['r-abcd'],
+        auto_onboard_new_accounts: true
+      }
+    });
+    const getStackSetOnboarding = vi
+      .spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding')
+      .mockResolvedValue({ onboarding: readyAWSStackSetOnboarding });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('region', { name: /StackSet onboarding progress/i })).toBeInTheDocument();
+    expect(getStackSetOnboarding).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      undefined,
+      undefined,
+      undefined,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(screen.getByRole('table', { name: /StackSet instance status/i })).toBeInTheDocument();
   });
 
   it('shows AWS operational panels when connector health is warning', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -10114,13 +10114,14 @@ describe('Domain-first app routes', () => {
     await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
     expect(startAWSConnector.mock.calls[0]?.[0]).toMatchObject({ connector_id: undefined });
 
-    // Edit a scope-target value after the connector has been prepared.
+    // Edit a scope-target value after the connector has been prepared. The
+    // edit clears the prepared response (so the button reverts to Launch), and
+    // the next click submits a fresh connector — not a resume of the old one.
     fireEvent.change(screen.getByLabelText(/Target regions/i), { target: { value: 'us-east-1, us-west-2' } });
-    fireEvent.click(screen.getByRole('button', { name: /Prepare StackSet again/i }));
+    expect(screen.queryByRole('button', { name: /Prepare StackSet again/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
     await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(2));
-    // Contract drift must not send the old connector_id — that would 400 on
-    // resumeAWSStackSetConnectorStart. A fresh connector must be minted.
     expect(startAWSConnector.mock.calls[1]?.[0]).toMatchObject({
       connector_id: undefined,
       target_regions: ['us-east-1', 'us-west-2']
@@ -10254,9 +10255,10 @@ describe('Domain-first app routes', () => {
     await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
 
     // Only swap region ordering — backend matcher is order-sensitive, and the
-    // first region becomes the StackSet home region.
+    // first region becomes the StackSet home region. The edit also invalidates
+    // the prepared launch, so the button label goes back to Launch.
     fireEvent.change(screen.getByLabelText(/Target regions/i), { target: { value: 'us-west-2, us-east-1' } });
-    fireEvent.click(screen.getByRole('button', { name: /Prepare StackSet again/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
     await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(2));
     expect(startAWSConnector.mock.calls[1]?.[0]).toMatchObject({
       connector_id: undefined,
@@ -10479,6 +10481,94 @@ describe('Domain-first app routes', () => {
       role_name: 'CustomerReadOnlyIdentrail',
       stack_set_name: 'CustomerNamedStackSet'
     });
+  });
+
+  it('preserves the last good StackSet onboarding when a refresh fails', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-refresh-err',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'connected',
+        target_regions: ['us-east-1'],
+        target_ou_ids: ['r-abcd']
+      }
+    });
+    vi.spyOn(api.apiClient, 'pollAWSConnector').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-refresh-err',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'connected',
+        target_regions: ['us-east-1'],
+        target_ou_ids: ['r-abcd']
+      }
+    });
+    const persisted: AWSStackSetOnboardingResult = {
+      ...readyAWSStackSetOnboarding,
+      recovery_actions: [
+        {
+          id: 'preserve-recovery',
+          title: 'Preserved recovery action',
+          description: 'Should remain visible after a transient refresh failure.',
+          targets: []
+        }
+      ]
+    };
+    let onboardingCallCount = 0;
+    const getStackSetOnboarding = vi
+      .spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding')
+      .mockImplementation(() => {
+        onboardingCallCount += 1;
+        if (onboardingCallCount === 1) {
+          return Promise.resolve({ onboarding: persisted });
+        }
+        return Promise.reject(new Error('temporary network error'));
+      });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Preserved recovery action/i)).toBeInTheDocument();
+    const priorCalls = getStackSetOnboarding.mock.calls.length;
+
+    fireEvent.click(screen.getByRole('button', { name: /Refresh StackSet status/i }));
+
+    // The refresh error surfaces, but the previous onboarding is retained so
+    // the panel keeps rendering with a retry action.
+    expect(await screen.findByText(/temporary network error/i)).toBeInTheDocument();
+    expect(screen.getByText(/Preserved recovery action/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText(/Retry StackSet status/i)).toBeInTheDocument()
+    );
+    expect(getStackSetOnboarding.mock.calls.length).toBeGreaterThan(priorCalls);
   });
 
   it('does not reuse an existing StackSet connector when the operator switches to a different scope', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -9153,6 +9153,7 @@ describe('Domain-first app routes', () => {
           project_id: 'production',
           scope_type: 'organization',
           deployment_method: 'stackset_service_managed',
+          region: 'us-east-1',
           target_regions: ['us-east-1', 'us-west-2'],
           target_ou_ids: ['r-abcd'],
           auto_onboard_new_accounts: true
@@ -9160,6 +9161,7 @@ describe('Domain-first app routes', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
+    expect(screen.queryByLabelText('Home region')).not.toBeInTheDocument();
     expect(await screen.findByRole('region', { name: /StackSet onboarding progress/i })).toBeInTheDocument();
     expect(screen.getByRole('table', { name: /StackSet instance status/i })).toBeInTheDocument();
     expect(screen.getByText(/Redeploy regional StackSet instance/i)).toBeInTheDocument();
@@ -9848,6 +9850,198 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(screen.getByRole('table', { name: /StackSet instance status/i })).toBeInTheDocument();
+  });
+
+  it('prefers refreshed StackSet onboarding over the launch snapshot in the progress panel', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const staleOnboarding: AWSStackSetOnboardingResult = {
+      ...readyAWSStackSetOnboarding,
+      recovery_actions: [
+        {
+          id: 'stale-recovery',
+          title: 'Stale snapshot recovery action',
+          description: 'This is the frozen snapshot from the start response.',
+          targets: []
+        }
+      ]
+    };
+    const freshOnboarding: AWSStackSetOnboardingResult = {
+      ...readyAWSStackSetOnboarding,
+      recovery_actions: [
+        {
+          id: 'fresh-recovery',
+          title: 'Fresh onboarding recovery action',
+          description: 'This came from a follow-up refresh call.',
+          targets: []
+        }
+      ]
+    };
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-org-refresh',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready'
+      },
+      connector_id: 'aws-org-refresh',
+      external_id: 'org-refresh-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'IdentrailReadOnlyCoverage',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'organization',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: ['r-abcd'],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'Organization setup.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      stackset_onboarding: staleOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+    vi.spyOn(api.apiClient, 'pollAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-org-refresh',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready'
+      }
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({ onboarding: freshOnboarding });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    // The panel prefers the freshly-refetched onboarding over the launch
+    // response snapshot, so the recovery action from the refresh mock wins.
+    expect(await screen.findByText(/Fresh onboarding recovery action/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Stale snapshot recovery action/i)).not.toBeInTheDocument();
+  });
+
+  it('hydrates the StackSet name from the existing connection so resume matches stored setup', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-named',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'connected',
+        target_regions: ['us-east-1'],
+        target_ou_ids: ['r-abcd'],
+        stack_set_name: 'CustomerNamedStackSet'
+      }
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({
+      onboarding: readyAWSStackSetOnboarding
+    });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-named',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready',
+        stack_set_name: 'CustomerNamedStackSet'
+      },
+      connector_id: 'aws-org-named',
+      external_id: 'named-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'CustomerNamedStackSet',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'organization',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: ['r-abcd'],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'Named organization setup.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Wait for the connection to hydrate.
+    await screen.findByRole('region', { name: /StackSet onboarding progress/i });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
+    expect(startAWSConnector.mock.calls[0]?.[0]).toMatchObject({
+      connector_id: 'aws-org-named',
+      stack_set_name: 'CustomerNamedStackSet'
+    });
   });
 
   it('does not reuse an existing StackSet connector when the operator switches to a different scope', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -10393,6 +10393,62 @@ describe('Domain-first app routes', () => {
     }
   });
 
+  it('hides a persisted organization StackSet launch URL when switching to Selected OUs', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-cross-scope',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'connected',
+        target_regions: ['us-east-1'],
+        target_ou_ids: ['r-abcd'],
+        launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets/org-persisted'
+      }
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({
+      onboarding: readyAWSStackSetOnboarding
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('region', { name: /StackSet onboarding progress/i });
+    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
+
+    // Selected OUs shares the stackset_ deployment method with organization,
+    // but the scope type differs — the persisted URL must not leak through.
+    const links = screen.queryAllByRole('link', { name: /Open AWS stack|Open StackSet in AWS/i });
+    for (const link of links) {
+      expect(link.getAttribute('href') ?? '').not.toContain('stacksets/org-persisted');
+    }
+  });
+
   it('hydrates the role name from the stored role ARN so StackSet resume matches', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -9049,6 +9049,529 @@ describe('Domain-first app routes', () => {
     expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
   });
 
+  it('launches the organization StackSet path with target regions and auto-onboard toggle', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-org-1',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready',
+        launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+        target_regions: ['us-east-1', 'us-west-2'],
+        auto_onboard_new_accounts: true
+      },
+      connector_id: 'aws-org-1',
+      external_id: 'org-external-id',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'IdentrailReadOnlyCoverage',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'organization',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1', 'us-west-2'],
+      target_account_ids: [],
+      target_ou_ids: [],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'AWS Organization service-managed StackSet setup.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      target_summary: {
+        account_count: 0,
+        account_count_known: false,
+        ou_count: 0,
+        region_count: 2,
+        excluded_account_count: 0,
+        expected_stack_instances: 0,
+        expected_stack_instances_known: false,
+        all_accounts: true
+      },
+      prerequisites: [
+        {
+          id: 'trusted-access',
+          title: 'Enable Organizations trusted access for CloudFormation',
+          severity: 'blocking',
+          satisfied: true,
+          reason: 'Organizations trusted access is enabled.'
+        }
+      ],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [
+        { service: 'IAM', actions: ['iam:GetRole'], resources: ['*'], reason: 'Inspect role metadata.' }
+      ],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    expect(screen.getByRole('heading', { level: 4, name: /Set the coverage scope/i })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Target regions/i), { target: { value: 'us-east-1, us-west-2' } });
+    const autoOnboard = screen.getByRole('checkbox', { name: /Auto-onboard new accounts/i });
+    expect(autoOnboard).toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    await waitFor(() =>
+      expect(startAWSConnector).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          scope_type: 'organization',
+          deployment_method: 'stackset_service_managed',
+          target_regions: ['us-east-1', 'us-west-2'],
+          auto_onboard_new_accounts: true
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(await screen.findByRole('region', { name: /StackSet onboarding progress/i })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: /StackSet instance status/i })).toBeInTheDocument();
+    expect(screen.getByText(/Redeploy regional StackSet instance/i)).toBeInTheDocument();
+  });
+
+  it('launches the selected-OUs StackSet path with OU targets', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-ou-1',
+        scope_type: 'selected_ous',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready',
+        launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+        target_regions: ['us-east-1'],
+        target_ou_ids: ['ou-1234-abcd5678']
+      },
+      connector_id: 'aws-ou-1',
+      external_id: 'selected-ou-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'IdentrailReadOnlyCoverage',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'selected_ous',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: ['ou-1234-abcd5678'],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'Selected OUs service-managed StackSet setup.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      target_summary: {
+        account_count: 0,
+        account_count_known: false,
+        ou_count: 1,
+        region_count: 1,
+        excluded_account_count: 0,
+        expected_stack_instances: 0,
+        expected_stack_instances_known: false,
+        all_accounts: false
+      },
+      prerequisites: [],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
+    fireEvent.change(screen.getByLabelText(/Target OU IDs/i), { target: { value: 'ou-1234-abcd5678' } });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    await waitFor(() =>
+      expect(startAWSConnector).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope_type: 'selected_ous',
+          deployment_method: 'stackset_service_managed',
+          target_ou_ids: ['ou-1234-abcd5678']
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(await screen.findByRole('region', { name: /StackSet onboarding progress/i })).toBeInTheDocument();
+  });
+
+  it('launches the selected-accounts StackSet path with account IDs', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-accts-1',
+        scope_type: 'selected_accounts',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready',
+        target_regions: ['us-east-1'],
+        target_account_ids: ['111111111111', '222222222222']
+      },
+      connector_id: 'aws-accts-1',
+      external_id: 'selected-accounts-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'IdentrailReadOnlyCoverage',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'selected_accounts',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1'],
+      target_account_ids: ['111111111111', '222222222222'],
+      target_ou_ids: [],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: false,
+      setup_summary: 'Selected accounts StackSet setup.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      target_summary: {
+        account_count: 2,
+        account_count_known: true,
+        ou_count: 0,
+        region_count: 1,
+        excluded_account_count: 0,
+        expected_stack_instances: 2,
+        expected_stack_instances_known: true,
+        all_accounts: false
+      },
+      prerequisites: [],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /Account IDs/i }));
+    fireEvent.change(screen.getByLabelText(/Target account IDs/i), {
+      target: { value: '111111111111, 222222222222' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    await waitFor(() =>
+      expect(startAWSConnector).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope_type: 'selected_accounts',
+          target_account_ids: ['111111111111', '222222222222'],
+          auto_onboard_new_accounts: false
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+  });
+
+  it('blocks empty StackSet targets before calling the API', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector');
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /Account IDs/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    expect(await screen.findByText(/Add at least one 12-digit target AWS account ID/i)).toBeInTheDocument();
+    expect(startAWSConnector).not.toHaveBeenCalled();
+  });
+
+  it('disables StackSet launch while a blocking prerequisite is unresolved', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-org-1',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'waiting_for_aws',
+        target_regions: ['us-east-1']
+      },
+      connector_id: 'aws-org-1',
+      external_id: 'org-external',
+      launch_url: '',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'IdentrailReadOnlyCoverage',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'organization',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'waiting_for_aws',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: [],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'Trusted access needs to be enabled before deployment.',
+      next_actions: ['enable_trusted_access'],
+      target_summary: {
+        account_count: 0,
+        account_count_known: false,
+        ou_count: 0,
+        region_count: 1,
+        excluded_account_count: 0,
+        expected_stack_instances: 0,
+        expected_stack_instances_known: false,
+        all_accounts: true
+      },
+      prerequisites: [
+        {
+          id: 'trusted-access',
+          title: 'Enable Organizations trusted access for CloudFormation',
+          severity: 'blocking',
+          satisfied: false,
+          reason: 'Trusted access is not enabled for CloudFormation StackSets.',
+          remediation: 'Enable trusted access in the Organizations console.'
+        }
+      ],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /Launch StackSet setup/i })
+      ).toBeDisabled()
+    );
+    expect(screen.getByText(/Enable trusted access in the Organizations console/i)).toBeInTheDocument();
+  });
+
+  it('ignores stale StackSet setup responses after switching environments', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging',
+          name: 'Staging',
+          slug: 'staging',
+          description: 'Staging AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const pendingStart = deferred<AWSConnectorStartResponse>();
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockReturnValue(pendingStart.promise);
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
+
+    await act(async () => {
+      pendingStart.resolve({
+        connection: {
+          ...disconnectedAWS,
+          connector_id: 'aws-org-stale',
+          scope_type: 'organization',
+          deployment_method: 'stackset_service_managed',
+          onboarding_status: 'launch_ready'
+        },
+        connector_id: 'aws-org-stale',
+        external_id: 'stale-external',
+        launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets/stale',
+        template_url: 'https://example.com/template.yaml',
+        role_name: 'IdentrailReadOnly',
+        stack_name: 'identrail-readonly-connector',
+        stack_set_name: 'IdentrailReadOnlyCoverage',
+        policy_hash: 'sha256:example',
+        template_checksum: 'sha256:example',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready',
+        target_regions: ['us-east-1'],
+        target_account_ids: [],
+        target_ou_ids: [],
+        excluded_account_ids: [],
+        auto_onboard_new_accounts: true,
+        setup_summary: 'Stale organization setup for a different environment.',
+        next_actions: ['open_stackset', 'refresh_status'],
+        stackset_onboarding: readyAWSStackSetOnboarding,
+        permission_preview: [],
+        permission_tiers: []
+      });
+    });
+
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('staging');
+    expect(screen.queryByRole('region', { name: /StackSet onboarding progress/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /Open StackSet in AWS/i })
+    ).not.toBeInTheDocument();
+  });
+
   it('shows AWS operational panels when connector health is warning', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3776,7 +3776,13 @@ describe('Domain-first app routes', () => {
         }
       ]
     });
-    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed'
+      }
+    });
     const {
       getCoveragePlan,
       getAccountRegionCoverage,
@@ -3849,6 +3855,50 @@ describe('Domain-first app routes', () => {
       undefined,
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
+  });
+
+  it('does not fetch StackSet onboarding for a single-account connector on the AWS Coverage page', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    // connectedAWS is a plain single_account / cloudformation connector.
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const { getStackSetOnboarding } = mockAWSCoverageDashboardAPIs(api);
+
+    const { ProductAWSCoveragePage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/coverage?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/coverage" element={<ProductAWSCoveragePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Wait for the page to render (coverage records still load).
+    await screen.findByRole('heading', { level: 2, name: 'Coverage' });
+
+    // Backend's GetAWSStackSetOnboarding defaults to a synthetic service-
+    // managed success fixture with fabricated OUs and accounts. It must not
+    // be called for a plain single_account connector, otherwise the fixture
+    // would render as fake organization StackSet progress under the
+    // "AWS Organization StackSet read-only deployment" panel.
+    expect(getStackSetOnboarding).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole('heading', { name: /AWS Organization StackSet read-only deployment/i })
+    ).not.toBeInTheDocument();
   });
 
   it('renders AWS machine identity inventory with current IAM, EC2, ECS, Lambda, CodeBuild, and EKS role rows', async () => {
@@ -9585,6 +9635,99 @@ describe('Domain-first app routes', () => {
     for (const link of links) {
       expect(link.getAttribute('href') ?? '').not.toContain('stacksets/blocked');
     }
+  });
+
+  it('cancels an in-flight StackSet start when the operator edits targets before it returns', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const pendingStart = deferred<AWSConnectorStartResponse>();
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockReturnValue(pendingStart.promise);
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    // While the start request is still pending, edit a scope-contract field.
+    fireEvent.change(screen.getByLabelText(/Target regions/i), {
+      target: { value: 'eu-west-1' }
+    });
+
+    // Now resolve the original start with the old targets and a launch URL.
+    // The invalidation should have bumped the start request ref so this
+    // response is treated as stale.
+    await act(async () => {
+      pendingStart.resolve({
+        connection: {
+          ...disconnectedAWS,
+          connector_id: 'aws-org-cancel',
+          scope_type: 'organization',
+          deployment_method: 'stackset_service_managed',
+          onboarding_status: 'launch_ready',
+          launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets/cancel'
+        },
+        connector_id: 'aws-org-cancel',
+        external_id: 'cancel-external',
+        launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets/cancel',
+        template_url: 'https://example.com/template.yaml',
+        role_name: 'IdentrailReadOnly',
+        stack_name: 'identrail-readonly-connector',
+        stack_set_name: 'IdentrailReadOnlyCoverage',
+        policy_hash: 'sha256:example',
+        template_checksum: 'sha256:example',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready',
+        target_regions: ['us-east-1'],
+        target_account_ids: [],
+        target_ou_ids: ['r-abcd'],
+        excluded_account_ids: [],
+        auto_onboard_new_accounts: true,
+        setup_summary: 'Cancelled start.',
+        next_actions: ['open_stackset', 'refresh_status'],
+        stackset_onboarding: readyAWSStackSetOnboarding,
+        permission_preview: [],
+        permission_tiers: []
+      });
+    });
+
+    // The stale start must not restore old targets, render the progress
+    // panel, or expose the launch URL for accounts / regions the operator
+    // just removed.
+    expect(screen.getByLabelText(/Target regions/i)).toHaveValue('eu-west-1');
+    expect(screen.queryByRole('region', { name: /StackSet onboarding progress/i })).not.toBeInTheDocument();
+    const links = screen.queryAllByRole('link', { name: /Open StackSet in AWS|Open AWS stack/i });
+    for (const link of links) {
+      expect(link.getAttribute('href') ?? '').not.toContain('stacksets/cancel');
+    }
+    // Launch button should be re-enabled (submitting flag was cleared).
+    expect(screen.getByRole('button', { name: /Launch StackSet setup/i })).not.toBeDisabled();
   });
 
   it('ignores stale StackSet setup responses after switching environments', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -10407,6 +10407,74 @@ describe('Domain-first app routes', () => {
     expect(stagingCall?.stack_set_name).not.toBe('ProdCustomStackSet');
   });
 
+  it('marks a persisted self-managed StackSet connector unsupported instead of resuming as service-managed', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-self-managed-1',
+        scope_type: 'selected_accounts',
+        deployment_method: 'stackset_self_managed',
+        onboarding_status: 'connected',
+        target_regions: ['us-east-1'],
+        target_account_ids: ['111111111111', '222222222222'],
+        target_ou_ids: [],
+        launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets/self-managed'
+      }
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({
+      onboarding: readyAWSStackSetOnboarding
+    });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector');
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Wait for the connector's scope to hydrate the wizard.
+    await screen.findByRole('heading', { level: 4, name: /Set the coverage scope/i });
+
+    // The wizard exposes an alert that says this setup is not relaunchable and
+    // disables the Launch button so we never send service-managed to a
+    // self-managed connector (which resumeAWSStackSetConnectorStart rejects
+    // via exact deployment_method match).
+    expect(await screen.findByText(/self-managed StackSet, which the wizard does not currently support/i)).toBeInTheDocument();
+    const launchButton = screen.getByRole('button', { name: /Launch StackSet setup|Prepare StackSet again/i });
+    expect(launchButton).toBeDisabled();
+    fireEvent.click(launchButton);
+    expect(startAWSConnector).not.toHaveBeenCalled();
+
+    // The persisted self-managed launch URL must not surface anywhere on the
+    // wizard, since the wizard cannot describe what it would open.
+    const links = screen.queryAllByRole('link', { name: /Open StackSet in AWS|Open AWS stack/i });
+    for (const link of links) {
+      expect(link.getAttribute('href') ?? '').not.toContain('stacksets/self-managed');
+    }
+  });
+
   it('keeps a persisted Terraform single-account connector reachable from the wizard', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -9494,6 +9494,99 @@ describe('Domain-first app routes', () => {
     expect(screen.getByText(/Enable trusted access in the Organizations console/i)).toBeInTheDocument();
   });
 
+  it('hides the StackSet launch link while a blocking prerequisite is unresolved', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    // The backend commonly returns a nonempty launch_url alongside a blocking
+    // stackset.trusted_access_enabled prerequisite: the URL exists but must
+    // not be opened until the prereq is satisfied.
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-org-blocked',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'waiting_for_aws',
+        launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets/blocked'
+      },
+      connector_id: 'aws-org-blocked',
+      external_id: 'org-blocked-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets/blocked',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'IdentrailReadOnlyCoverage',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'organization',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'waiting_for_aws',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: ['r-abcd'],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'Trusted access needs to be enabled before deployment.',
+      next_actions: ['enable_trusted_access'],
+      prerequisites: [
+        {
+          id: 'stackset.trusted_access_enabled',
+          title: 'Enable Organizations trusted access for CloudFormation',
+          severity: 'blocking',
+          satisfied: false,
+          reason: 'Trusted access is not enabled for CloudFormation StackSets.',
+          remediation: 'Enable trusted access in the Organizations console.'
+        }
+      ],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    // The launch button stays disabled and the link to the AWS console does
+    // not render, even though the response contains a launch URL.
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /Prepare StackSet again|Launch StackSet setup/i })
+      ).toBeDisabled()
+    );
+    const links = screen.queryAllByRole('link', { name: /Open StackSet in AWS|Open AWS stack/i });
+    for (const link of links) {
+      expect(link.getAttribute('href') ?? '').not.toContain('stacksets/blocked');
+    }
+  });
+
   it('ignores stale StackSet setup responses after switching environments', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
@@ -9852,7 +9945,7 @@ describe('Domain-first app routes', () => {
     expect(screen.getByRole('table', { name: /StackSet instance status/i })).toBeInTheDocument();
   });
 
-  it('prefers refreshed StackSet onboarding over the launch snapshot in the progress panel', async () => {
+  it('renders the launch-response onboarding rather than the fixture-backed refresh endpoint', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
     const api = await import('./api/client');
@@ -9872,24 +9965,24 @@ describe('Domain-first app routes', () => {
       ]
     });
     vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
-    const staleOnboarding: AWSStackSetOnboardingResult = {
+    const connectorOnboarding: AWSStackSetOnboardingResult = {
       ...readyAWSStackSetOnboarding,
       recovery_actions: [
         {
-          id: 'stale-recovery',
-          title: 'Stale snapshot recovery action',
-          description: 'This is the frozen snapshot from the start response.',
+          id: 'connector-recovery',
+          title: 'Connector-specific recovery action',
+          description: 'This came from the start response, tied to the connector.',
           targets: []
         }
       ]
     };
-    const freshOnboarding: AWSStackSetOnboardingResult = {
+    const fixtureOnboarding: AWSStackSetOnboardingResult = {
       ...readyAWSStackSetOnboarding,
       recovery_actions: [
         {
-          id: 'fresh-recovery',
-          title: 'Fresh onboarding recovery action',
-          description: 'This came from a follow-up refresh call.',
+          id: 'fixture-recovery',
+          title: 'Fixture recovery action',
+          description: 'This came from the synthetic refresh endpoint.',
           targets: []
         }
       ]
@@ -9921,7 +10014,7 @@ describe('Domain-first app routes', () => {
       auto_onboard_new_accounts: true,
       setup_summary: 'Organization setup.',
       next_actions: ['open_stackset', 'refresh_status'],
-      stackset_onboarding: staleOnboarding,
+      stackset_onboarding: connectorOnboarding,
       permission_preview: [],
       permission_tiers: []
     });
@@ -9934,7 +10027,7 @@ describe('Domain-first app routes', () => {
         onboarding_status: 'launch_ready'
       }
     });
-    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({ onboarding: freshOnboarding });
+    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({ onboarding: fixtureOnboarding });
 
     const { ProductAWSConnectPage } = await import('./productShell');
 
@@ -9950,10 +10043,11 @@ describe('Domain-first app routes', () => {
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
-    // The panel prefers the freshly-refetched onboarding over the launch
-    // response snapshot, so the recovery action from the refresh mock wins.
-    expect(await screen.findByText(/Fresh onboarding recovery action/i)).toBeInTheDocument();
-    expect(screen.queryByText(/Stale snapshot recovery action/i)).not.toBeInTheDocument();
+    // The panel prefers the connector-specific launch-response snapshot over
+    // the synthetic refresh endpoint, so the connector-tied recovery action
+    // wins even after refresh fetches the fixture payload.
+    expect(await screen.findByText(/Connector-specific recovery action/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Fixture recovery action/i)).not.toBeInTheDocument();
   });
 
   it('hydrates the StackSet name from the existing connection so resume matches stored setup', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -10264,6 +10264,76 @@ describe('Domain-first app routes', () => {
     expect(stagingCall?.stack_set_name).not.toBe('ProdCustomStackSet');
   });
 
+  it('keeps a persisted Terraform single-account connector reachable from the wizard', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-terraform-single',
+        scope_type: 'single_account',
+        deployment_method: 'terraform',
+        onboarding_status: 'connected'
+      }
+    });
+    const pollAWSConnector = vi.spyOn(api.apiClient, 'pollAWSConnector').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-terraform-single',
+        scope_type: 'single_account',
+        deployment_method: 'terraform',
+        onboarding_status: 'connected'
+      }
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Single-account mode covers both CloudFormation and Terraform deployment
+    // methods. The verify step (Refresh status / Validate connection) must
+    // still be reachable for a Terraform-provisioned connector — the wizard
+    // step's Refresh button clicks into pollAWSConnector, not the sidebar
+    // Permission health refresh action.
+    const wizardStep = await screen.findByRole('heading', { level: 4, name: /Verify the connection/i });
+    const wizardStepBody = wizardStep.closest('.idt-aws-wizard-step') as HTMLElement | null;
+    expect(wizardStepBody).not.toBeNull();
+    const refreshButton = within(wizardStepBody!).getByRole('button', { name: /Refresh status/i });
+    expect(refreshButton).not.toBeDisabled();
+
+    fireEvent.click(refreshButton);
+    await waitFor(() =>
+      expect(pollAWSConnector).toHaveBeenCalledWith(
+        'aws-terraform-single',
+        'workspace-a',
+        'production',
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+  });
+
   it('omits role_name on resume for a pending StackSet connector with empty role_arn', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -9842,12 +9842,102 @@ describe('Domain-first app routes', () => {
     expect(getStackSetOnboarding).toHaveBeenCalledWith(
       'workspace-a',
       'production',
-      undefined,
+      'aws-org-existing',
       undefined,
       undefined,
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(screen.getByRole('table', { name: /StackSet instance status/i })).toBeInTheDocument();
+  });
+
+  it('does not reuse an existing StackSet connector when the operator switches to a different scope', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-existing',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'connected',
+        target_regions: ['us-east-1'],
+        target_ou_ids: ['r-abcd']
+      }
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({
+      onboarding: readyAWSStackSetOnboarding
+    });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-ou-new',
+        scope_type: 'selected_ous',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready'
+      },
+      connector_id: 'aws-ou-new',
+      external_id: 'selected-ou-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'IdentrailReadOnlyCoverage',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'selected_ous',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: ['ou-1234-abcd5678'],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'Selected OUs setup.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Wait for the existing organization connector to hydrate.
+    await screen.findByRole('region', { name: /StackSet onboarding progress/i });
+
+    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
+    fireEvent.change(await screen.findByLabelText(/Target OU IDs/i), {
+      target: { value: 'ou-1234-abcd5678' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
+    const startPayload = startAWSConnector.mock.calls[0]?.[0] as { connector_id?: string; scope_type?: string };
+    expect(startPayload?.scope_type).toBe('selected_ous');
+    expect(startPayload?.connector_id).toBeUndefined();
   });
 
   it('shows AWS operational panels when connector health is warning', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -10044,6 +10044,147 @@ describe('Domain-first app routes', () => {
     });
   });
 
+  it('drops connector_id from the retry payload when scope-target values are edited', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-org-drift',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready',
+        launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets'
+      },
+      connector_id: 'aws-org-drift',
+      external_id: 'org-drift-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'IdentrailReadOnlyCoverage',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'organization',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: ['r-abcd'],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'Organization setup.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
+    expect(startAWSConnector.mock.calls[0]?.[0]).toMatchObject({ connector_id: undefined });
+
+    // Edit a scope-target value after the connector has been prepared.
+    fireEvent.change(screen.getByLabelText(/Target regions/i), { target: { value: 'us-east-1, us-west-2' } });
+    fireEvent.click(screen.getByRole('button', { name: /Prepare StackSet again/i }));
+
+    await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(2));
+    // Contract drift must not send the old connector_id — that would 400 on
+    // resumeAWSStackSetConnectorStart. A fresh connector must be minted.
+    expect(startAWSConnector.mock.calls[1]?.[0]).toMatchObject({
+      connector_id: undefined,
+      target_regions: ['us-east-1', 'us-west-2']
+    });
+  });
+
+  it('clears persisted StackSet progress when switching mode on an existing StackSet connection', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-existing',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'connected',
+        target_regions: ['us-east-1'],
+        target_ou_ids: ['r-abcd']
+      }
+    });
+    const persistedOnboarding: AWSStackSetOnboardingResult = {
+      ...readyAWSStackSetOnboarding,
+      recovery_actions: [
+        {
+          id: 'org-persist-recovery',
+          title: 'Persisted organization recovery action',
+          description: 'Should not linger after switching modes.',
+          targets: []
+        }
+      ]
+    };
+    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({ onboarding: persistedOnboarding });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Persisted organization recovery action/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
+    expect(screen.queryByText(/Persisted organization recovery action/i)).not.toBeInTheDocument();
+  });
+
   it('does not reuse an existing StackSet connector when the operator switches to a different scope', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -10185,6 +10185,302 @@ describe('Domain-first app routes', () => {
     expect(screen.queryByText(/Persisted organization recovery action/i)).not.toBeInTheDocument();
   });
 
+  it('drops connector_id when only the target region ordering changes', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-org-order',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready'
+      },
+      connector_id: 'aws-org-order',
+      external_id: 'org-order-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'IdentrailReadOnly',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'IdentrailReadOnlyCoverage',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'organization',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1', 'us-west-2'],
+      target_account_ids: [],
+      target_ou_ids: ['r-abcd'],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'Organization setup.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
+    fireEvent.change(screen.getByLabelText(/Target regions/i), { target: { value: 'us-east-1, us-west-2' } });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+    await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
+
+    // Only swap region ordering — backend matcher is order-sensitive, and the
+    // first region becomes the StackSet home region.
+    fireEvent.change(screen.getByLabelText(/Target regions/i), { target: { value: 'us-west-2, us-east-1' } });
+    fireEvent.click(screen.getByRole('button', { name: /Prepare StackSet again/i }));
+    await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(2));
+    expect(startAWSConnector.mock.calls[1]?.[0]).toMatchObject({
+      connector_id: undefined,
+      target_regions: ['us-west-2', 'us-east-1'],
+      region: 'us-west-2'
+    });
+  });
+
+  it('restores persisted StackSet progress when switching back to the connectors scope', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-return',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'connected',
+        target_regions: ['us-east-1'],
+        target_ou_ids: ['r-abcd']
+      }
+    });
+    const persisted: AWSStackSetOnboardingResult = {
+      ...readyAWSStackSetOnboarding,
+      recovery_actions: [
+        {
+          id: 'return-recovery',
+          title: 'Persisted recovery action to restore',
+          description: 'Should reappear when returning to the organization scope.',
+          targets: []
+        }
+      ]
+    };
+    const getStackSetOnboarding = vi
+      .spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding')
+      .mockResolvedValue({ onboarding: persisted });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Initial hydrate.
+    expect(await screen.findByText(/Persisted recovery action to restore/i)).toBeInTheDocument();
+    const initialCallCount = getStackSetOnboarding.mock.calls.length;
+
+    // Switch away from the connector's scope.
+    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
+    expect(screen.queryByText(/Persisted recovery action to restore/i)).not.toBeInTheDocument();
+
+    // Switch back to the connector's scope — panel should reappear via a fresh refetch.
+    fireEvent.click(screen.getByRole('button', { name: /AWS Organization/i }));
+    expect(await screen.findByText(/Persisted recovery action to restore/i)).toBeInTheDocument();
+    expect(getStackSetOnboarding.mock.calls.length).toBeGreaterThan(initialCallCount);
+  });
+
+  it('hides a persisted StackSet launch URL when the operator switches to Single account', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-launch',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'connected',
+        target_regions: ['us-east-1'],
+        target_ou_ids: ['r-abcd'],
+        launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets/persisted'
+      }
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({
+      onboarding: readyAWSStackSetOnboarding
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Panel shows a StackSet link initially.
+    await screen.findByRole('region', { name: /StackSet onboarding progress/i });
+
+    fireEvent.click(screen.getByRole('button', { name: /This AWS account/i }));
+
+    // Under Single account, the persisted StackSet launch URL must not surface.
+    const links = screen.queryAllByRole('link', { name: /Open AWS stack|Open StackSet in AWS/i });
+    for (const link of links) {
+      expect(link.getAttribute('href') ?? '').not.toContain('stacksets/persisted');
+    }
+  });
+
+  it('hydrates the role name from the stored role ARN so StackSet resume matches', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-role',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'connected',
+        target_regions: ['us-east-1'],
+        target_ou_ids: ['r-abcd'],
+        role_arn: 'arn:aws:iam::123456789012:role/CustomerReadOnlyIdentrail',
+        stack_set_name: 'CustomerNamedStackSet'
+      }
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding').mockResolvedValue({
+      onboarding: readyAWSStackSetOnboarding
+    });
+    const startAWSConnector = vi.spyOn(api.apiClient, 'startAWSConnector').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connector_id: 'aws-org-role',
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        onboarding_status: 'launch_ready',
+        role_arn: 'arn:aws:iam::123456789012:role/CustomerReadOnlyIdentrail',
+        stack_set_name: 'CustomerNamedStackSet'
+      },
+      connector_id: 'aws-org-role',
+      external_id: 'role-hydrate-external',
+      launch_url: 'https://console.aws.amazon.com/cloudformation/home#/stacksets',
+      template_url: 'https://example.com/template.yaml',
+      role_name: 'CustomerReadOnlyIdentrail',
+      stack_name: 'identrail-readonly-connector',
+      stack_set_name: 'CustomerNamedStackSet',
+      policy_hash: 'sha256:example',
+      template_checksum: 'sha256:example',
+      scope_type: 'organization',
+      deployment_method: 'stackset_service_managed',
+      onboarding_status: 'launch_ready',
+      target_regions: ['us-east-1'],
+      target_account_ids: [],
+      target_ou_ids: ['r-abcd'],
+      excluded_account_ids: [],
+      auto_onboard_new_accounts: true,
+      setup_summary: 'Organization setup.',
+      next_actions: ['open_stackset', 'refresh_status'],
+      stackset_onboarding: readyAWSStackSetOnboarding,
+      permission_preview: [],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('region', { name: /StackSet onboarding progress/i });
+    fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
+
+    await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
+    expect(startAWSConnector.mock.calls[0]?.[0]).toMatchObject({
+      connector_id: 'aws-org-role',
+      role_name: 'CustomerReadOnlyIdentrail',
+      stack_set_name: 'CustomerNamedStackSet'
+    });
+  });
+
   it('does not reuse an existing StackSet connector when the operator switches to a different scope', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20983,7 +20983,7 @@ function AWSStackSetScopeStep(props: AWSStackSetScopeStepProps) {
           >
             {launchLabel}
           </button>
-          {start?.launch_url ? (
+          {start?.launch_url && blockingCount === 0 ? (
             <a className="idt-btn idt-btn-dark" href={start.launch_url} target="_blank" rel="noreferrer">
               <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
               <span>Open StackSet in AWS</span>
@@ -21047,8 +21047,13 @@ function AWSStackSetProgressPanel({
   onRefresh,
   refreshing
 }: AWSStackSetProgressPanelProps) {
+  // Prefer the start-response snapshot: it is derived from the connector's
+  // own targets and checkpoints. getAWSProjectStackSetOnboarding today uses
+  // a synthetic fixture that does not reflect this connector's OUs, accounts,
+  // or instances, so we only fall back to it when no start is available (an
+  // existing persisted connector on page load).
   const onboarding: AWSStackSetOnboardingResult | undefined | null =
-    persistedOnboarding ?? start?.stackset_onboarding ?? null;
+    start?.stackset_onboarding ?? persistedOnboarding ?? null;
   const summary: AWSStackSetOnboardingSummary | undefined = onboarding?.summary;
   const coverage: AWSStackSetOnboardingCoverageExpectation | undefined = onboarding?.coverage_expectation;
   const recoveryActions: AWSStackSetOnboardingRecoveryAction[] = onboarding?.recovery_actions ?? [];
@@ -22068,13 +22073,26 @@ export function ProductAWSConnectPage() {
       awsSetupModeTouchedRef.current = true;
       awsSetupModeRef.current = mode;
       setAWSSetupMode(mode);
-      setSuccessMessage('AWS StackSet setup is ready. Open the StackSet in AWS, then refresh status.');
+      const responsePrereqs = response.prerequisites ?? [];
+      const responseBlockingCount = responsePrereqs.filter(
+        (prereq) => !prereq.satisfied && prereq.severity === 'blocking'
+      ).length;
+      if (responseBlockingCount > 0) {
+        setSuccessMessage('AWS StackSet setup is prepared. Resolve blocking prerequisites before launching the StackSet.');
+      } else {
+        setSuccessMessage('AWS StackSet setup is ready. Open the StackSet in AWS, then refresh status.');
+      }
       if (response.stackset_onboarding) {
         setAWSStackSetOnboarding(response.stackset_onboarding);
       } else if (response.connector_id) {
         void refreshStackSetOnboarding(response.connector_id);
       }
-      if (response.launch_url && typeof window !== 'undefined' && !/jsdom/i.test(window.navigator.userAgent)) {
+      if (
+        responseBlockingCount === 0 &&
+        response.launch_url &&
+        typeof window !== 'undefined' &&
+        !/jsdom/i.test(window.navigator.userAgent)
+      ) {
         window.open(response.launch_url, '_blank', 'noopener,noreferrer');
       }
     } catch (error) {
@@ -22247,6 +22265,10 @@ export function ProductAWSConnectPage() {
     }
     return bits.join(' · ');
   })();
+  const stackSetBlockingPrereqCount = (() => {
+    const preferred = stackSetAWSStart?.prerequisites ?? connection?.prerequisites ?? [];
+    return preferred.filter((prereq) => !prereq.satisfied && prereq.severity === 'blocking').length;
+  })();
   // Only surface the persisted connection's launch URL when both the
   // deployment method and the scope type match the currently selected setup
   // mode. Otherwise a leftover StackSet console link can render under a
@@ -22308,8 +22330,11 @@ export function ProductAWSConnectPage() {
     if (isManualSetup && manualExternalID && !connectedNow) {
       return 'Add the trust policy in AWS, paste the role ARN, then validate the role.';
     }
-    if (isStackSetSetup && stackSetAWSStart?.launch_url) {
+    if (isStackSetSetup && stackSetAWSStart?.launch_url && stackSetBlockingPrereqCount === 0) {
       return 'Open the StackSet in AWS to deploy the read-only role, then refresh status.';
+    }
+    if (isStackSetSetup && stackSetAWSStart?.launch_url && stackSetBlockingPrereqCount > 0) {
+      return 'Resolve the blocking StackSet prerequisites, then open the StackSet in AWS.';
     }
     if (isStackSetSetup && !stackSetAWSStart) {
       return 'Pick target regions and accounts or OUs, then launch the StackSet setup.';
@@ -22760,7 +22785,7 @@ export function ProductAWSConnectPage() {
               </dl>
               <p>{setupSummaryBody}</p>
               <div className="idt-source-actions idt-aws-summary-actions">
-                {isStackSetSetup && stackSetAWSStart?.launch_url ? (
+                {isStackSetSetup && stackSetAWSStart?.launch_url && stackSetBlockingPrereqCount === 0 ? (
                   <a
                     className="idt-btn idt-btn-primary"
                     href={stackSetAWSStart.launch_url}
@@ -22770,7 +22795,7 @@ export function ProductAWSConnectPage() {
                     <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
                     <span>Open StackSet in AWS</span>
                   </a>
-                ) : launchURL ? (
+                ) : isStackSetSetup ? null : launchURL ? (
                   <a className="idt-btn idt-btn-primary" href={launchURL} target="_blank" rel="noreferrer">
                     <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
                     <span>Open AWS stack</span>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20900,7 +20900,7 @@ function AWSStackSetProgressPanel({
   refreshing
 }: AWSStackSetProgressPanelProps) {
   const onboarding: AWSStackSetOnboardingResult | undefined | null =
-    start?.stackset_onboarding ?? persistedOnboarding ?? null;
+    persistedOnboarding ?? start?.stackset_onboarding ?? null;
   const summary: AWSStackSetOnboardingSummary | undefined = onboarding?.summary;
   const coverage: AWSStackSetOnboardingCoverageExpectation | undefined = onboarding?.coverage_expectation;
   const recoveryActions: AWSStackSetOnboardingRecoveryAction[] = onboarding?.recovery_actions ?? [];
@@ -21092,7 +21092,8 @@ export function ProductAWSConnectPage() {
     targetOUIDs: false,
     targetAccountIDs: false,
     excludedAccountIDs: false,
-    autoOnboardNewAccounts: false
+    autoOnboardNewAccounts: false,
+    stackSetName: false
   });
   const [awsCloudFormationStart, setAWSCloudFormationStart] = useState<AWSConnectorStartResponse | null>(null);
   const [awsPermissionPreview, setAWSPermissionPreview] = useState<AWSPermissionPreviewItem[]>([]);
@@ -21195,7 +21196,10 @@ export function ProductAWSConnectPage() {
             : response.connection.connector_id &&
               typeof response.connection.auto_onboard_new_accounts === 'boolean'
             ? response.connection.auto_onboard_new_accounts
-            : current.autoOnboardNewAccounts
+            : current.autoOnboardNewAccounts,
+          stackSetName: dirty.stackSetName
+            ? current.stackSetName
+            : response.connection.stack_set_name || current.stackSetName
         }));
       } catch (error) {
         if (isStale()) {
@@ -21378,7 +21382,8 @@ export function ProductAWSConnectPage() {
       targetOUIDs: false,
       targetAccountIDs: false,
       excludedAccountIDs: false,
-      autoOnboardNewAccounts: false
+      autoOnboardNewAccounts: false,
+      stackSetName: false
     };
     void refreshConnection('initial');
     void refreshBaseline();
@@ -21755,7 +21760,11 @@ export function ProductAWSConnectPage() {
     const requestID = ++awsStartRequestRef.current;
     const requestEnvironmentID = selectedEnvironmentID;
     const requestScopeKey = scopeKeyRef.current;
-    const region = normalizeValue(awsForm.region) || parsedTargetRegions[0] || 'us-east-1';
+    // Backend derives the StackSet home region from the first target region
+    // (internal/api/aws_connect.go), so anchor `region` to that entry rather
+    // than the Home region field, which is only meaningful for CloudFormation
+    // single-account setup.
+    const region = parsedTargetRegions[0] || normalizeValue(awsForm.region) || 'us-east-1';
     const isStale = () =>
       requestID !== awsStartRequestRef.current ||
       selectedEnvironmentIDRef.current !== requestEnvironmentID ||
@@ -21807,6 +21816,7 @@ export function ProductAWSConnectPage() {
         externalID: response.external_id,
         region: current.region || response.connection.region || 'us-east-1',
         displayName: current.displayName || response.connection.display_name || '',
+        stackSetName: response.stack_set_name || current.stackSetName,
         organizationRootID: responseRoot ?? current.organizationRootID,
         targetRegions:
           response.target_regions && response.target_regions.length > 0
@@ -22198,15 +22208,19 @@ export function ProductAWSConnectPage() {
                         placeholder="Production AWS"
                       />
                     </label>
-                    <label>
-                      Home region
-                      <input
-                        value={awsForm.region}
-                        onChange={(event) => setAWSForm((current) => ({ ...current, region: event.target.value }))}
-                        placeholder="us-east-1"
-                        pattern="[a-z]{2}(-gov)?-[a-z]+-[0-9]"
-                      />
-                    </label>
+                    {!isStackSetSetup ? (
+                      <label>
+                        Home region
+                        <input
+                          value={awsForm.region}
+                          onChange={(event) =>
+                            setAWSForm((current) => ({ ...current, region: event.target.value }))
+                          }
+                          placeholder="us-east-1"
+                          pattern="[a-z]{2}(-gov)?-[a-z]+-[0-9]"
+                        />
+                      </label>
+                    ) : null}
                   </div>
                 </div>
               </div>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -10197,7 +10197,24 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     const requestID = ++stackSetOnboardingRequestRef.current;
     setStackSetOnboarding(null);
     setStackSetOnboardingError('');
-    if (!isAWSCoverageInventoryRoute(routeID) || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+    // Only fetch when the connector is actually a StackSet setup. Otherwise
+    // the backend defaults to a synthetic service-managed success fixture
+    // with fabricated OUs and accounts, which would render as fake
+    // organization progress under a plain single_account/cloudformation
+    // connector on the AWS Accounts and Coverage routes.
+    const isStackSetConnector =
+      connection?.scope_type === 'organization' ||
+      connection?.scope_type === 'selected_ous' ||
+      connection?.scope_type === 'selected_accounts' ||
+      connection?.deployment_method === 'stackset_service_managed' ||
+      connection?.deployment_method === 'stackset_self_managed';
+    if (
+      !isAWSCoverageInventoryRoute(routeID) ||
+      !scope ||
+      !selectedEnvironmentID ||
+      !connection?.connector_id ||
+      !isStackSetConnector
+    ) {
       setStackSetOnboardingLoading(false);
       return;
     }
@@ -10236,6 +10253,8 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     connection?.region,
     connection?.status,
     connection?.health_status,
+    connection?.scope_type,
+    connection?.deployment_method,
   ]);
 
   useEffect(() => {
@@ -21728,7 +21747,11 @@ export function ProductAWSConnectPage() {
     // Once the operator edits any scope-contract field, the prepared start
     // response no longer describes what the wizard would launch. Drop it so
     // neither the launch button nor the sidebar can send them to the AWS
-    // console with the old targets baked into the launch URL.
+    // console with the old targets baked into the launch URL. Also bump the
+    // start request ref so an in-flight StackSet start (targets typed while
+    // Preparing StackSet... is still spinning) can no longer restore its
+    // previous targets, launch URL, or auto-open the AWS console for an
+    // account or OU the operator just removed.
     setAWSCloudFormationStart((current) => {
       if (
         current &&
@@ -21740,7 +21763,9 @@ export function ProductAWSConnectPage() {
       return current;
     });
     setAWSStackSetOnboarding(null);
+    awsStartRequestRef.current += 1;
     awsStackSetOnboardingRequestRef.current += 1;
+    setSubmitting(false);
     setAWSStackSetOnboardingLoading(false);
     setAWSStackSetOnboardingError('');
   };

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -429,7 +429,8 @@ const AWS_REGION_PATTERN = /^[a-z]{2}(-gov)?-[a-z]+-[0-9]$/;
 type AWSSetupMode = 'cloudformation' | 'organization' | 'selected_ous' | 'selected_accounts' | 'manual';
 type AWSPartition = 'aws' | 'aws-us-gov' | 'aws-cn';
 
-const AWS_OU_ID_PATTERN = /^(ou-[a-z0-9]{4,32}-[a-z0-9]{8,32}|r-[a-z0-9]{4,32})$/;
+const AWS_OU_ID_PATTERN = /^ou-[a-z0-9]{4,32}-[a-z0-9]{8,32}$/;
+const AWS_ORG_ROOT_ID_PATTERN = /^r-[a-z0-9]{4,32}$/;
 const AWS_ACCOUNT_ID_PATTERN = /^[0-9]{12}$/;
 
 function splitScopeTokens(value: string): string[] {
@@ -20566,11 +20567,13 @@ function awsScopeSummaryLabel(mode: AWSSetupMode, start: AWSConnectorStartRespon
 type AWSStackSetScopeStepProps = {
   mode: AWSSetupMode;
   onChooseMode: (mode: AWSSetupMode) => void;
+  organizationRootID: string;
   targetRegions: string;
   targetOUIDs: string;
   targetAccountIDs: string;
   excludedAccountIDs: string;
   autoOnboardNewAccounts: boolean;
+  onChangeOrganizationRootID: (value: string) => void;
   onChangeRegions: (value: string) => void;
   onChangeOUIDs: (value: string) => void;
   onChangeAccountIDs: (value: string) => void;
@@ -20592,11 +20595,13 @@ function AWSStackSetScopeStep(props: AWSStackSetScopeStepProps) {
   const {
     mode,
     onChooseMode,
+    organizationRootID,
     targetRegions,
     targetOUIDs,
     targetAccountIDs,
     excludedAccountIDs,
     autoOnboardNewAccounts,
+    onChangeOrganizationRootID,
     onChangeRegions,
     onChangeOUIDs,
     onChangeAccountIDs,
@@ -20696,6 +20701,22 @@ function AWSStackSetScopeStep(props: AWSStackSetScopeStepProps) {
             </small>
           </label>
 
+          {(isOrganization || isSelectedAccounts) ? (
+            <label>
+              Organization root ID
+              <input
+                value={organizationRootID}
+                onChange={(event) => onChangeOrganizationRootID(event.target.value)}
+                placeholder="r-abcd"
+                aria-describedby="idt-aws-scope-root-hint"
+              />
+              <small id="idt-aws-scope-root-hint" className="idt-aws-scope-hint">
+                Starts with r-. Find it in the AWS Organizations console. Required by
+                service-managed StackSet even when picking specific accounts.
+              </small>
+            </label>
+          ) : null}
+
           {isSelectedOUs ? (
             <label>
               Target OU IDs
@@ -20707,7 +20728,8 @@ function AWSStackSetScopeStep(props: AWSStackSetScopeStepProps) {
                 aria-describedby="idt-aws-scope-ous-hint"
               />
               <small id="idt-aws-scope-ous-hint" className="idt-aws-scope-hint">
-                Organizations OU IDs. Root IDs (r-...) also allowed for the whole organization.
+                Organizations OU IDs (ou-...). Root IDs (r-...) are not accepted here —
+                use the AWS Organization path for whole-organization coverage.
               </small>
             </label>
           ) : null}
@@ -20865,18 +20887,26 @@ function stackSetOnboardingStatusTone(status: string): 'success' | 'warning' | '
 }
 
 type AWSStackSetProgressPanelProps = {
-  start: AWSConnectorStartResponse;
+  start: AWSConnectorStartResponse | null;
+  persistedOnboarding: AWSStackSetOnboardingResult | null;
   onRefresh?: () => void;
   refreshing: boolean;
 };
 
-function AWSStackSetProgressPanel({ start, onRefresh, refreshing }: AWSStackSetProgressPanelProps) {
-  const onboarding = start.stackset_onboarding;
+function AWSStackSetProgressPanel({
+  start,
+  persistedOnboarding,
+  onRefresh,
+  refreshing
+}: AWSStackSetProgressPanelProps) {
+  const onboarding: AWSStackSetOnboardingResult | undefined | null =
+    start?.stackset_onboarding ?? persistedOnboarding ?? null;
   const summary: AWSStackSetOnboardingSummary | undefined = onboarding?.summary;
   const coverage: AWSStackSetOnboardingCoverageExpectation | undefined = onboarding?.coverage_expectation;
   const recoveryActions: AWSStackSetOnboardingRecoveryAction[] = onboarding?.recovery_actions ?? [];
   const instances: AWSStackSetOnboardingInstance[] = onboarding?.instances ?? [];
-  const prereqs: AWSStackSetOnboardingPrerequisite[] = onboarding?.validation?.prerequisites ?? start.prerequisites ?? [];
+  const prereqs: AWSStackSetOnboardingPrerequisite[] =
+    onboarding?.validation?.prerequisites ?? start?.prerequisites ?? [];
   const status = onboarding?.status ?? 'blocked';
   const tone = stackSetOnboardingStatusTone(status);
   const statusLabel = stackSetOnboardingStatusLabel(status);
@@ -21049,21 +21079,33 @@ export function ProductAWSConnectPage() {
     roleName: 'IdentrailReadOnly',
     stackName: 'identrail-readonly-connector',
     stackSetName: 'identrail-readonly-stackset',
+    organizationRootID: '',
     targetRegions: 'us-east-1',
     targetOUIDs: '',
     targetAccountIDs: '',
     excludedAccountIDs: '',
     autoOnboardNewAccounts: true
   });
+  const awsScopeDirtyRef = useRef({
+    organizationRootID: false,
+    targetRegions: false,
+    targetOUIDs: false,
+    targetAccountIDs: false,
+    excludedAccountIDs: false,
+    autoOnboardNewAccounts: false
+  });
   const [awsCloudFormationStart, setAWSCloudFormationStart] = useState<AWSConnectorStartResponse | null>(null);
   const [awsPermissionPreview, setAWSPermissionPreview] = useState<AWSPermissionPreviewItem[]>([]);
   const [awsPermissionTiers, setAWSPermissionTiers] = useState<AWSCapabilityPermissionTier[]>([]);
   const [awsPreviewOpen, setAWSPreviewOpen] = useState(false);
+  const [awsStackSetOnboarding, setAWSStackSetOnboarding] = useState<AWSStackSetOnboardingResult | null>(null);
+  const [awsStackSetOnboardingLoading, setAWSStackSetOnboardingLoading] = useState(false);
   const connectionRequestRef = useRef(0);
   const baselineRequestRef = useRef(0);
   const awsStartRequestRef = useRef(0);
   const awsPollRequestRef = useRef(0);
   const awsValidationRequestRef = useRef(0);
+  const awsStackSetOnboardingRequestRef = useRef(0);
   const awsSetupModeTouchedRef = useRef(false);
   const awsSetupModeRef = useRef<AWSSetupMode>('cloudformation');
   const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
@@ -21113,6 +21155,10 @@ export function ProductAWSConnectPage() {
           awsSetupModeRef.current = next;
           return next;
         });
+        const dirty = awsScopeDirtyRef.current;
+        const responseOUIDs = response.connection.target_ou_ids ?? [];
+        const rootFromOUIDs = responseOUIDs.find((id) => AWS_ORG_ROOT_ID_PATTERN.test(id));
+        const ouOnlyIDs = responseOUIDs.filter((id) => AWS_OU_ID_PATTERN.test(id));
         setAWSForm((current) => ({
           ...current,
           roleARN: response.connection.role_arn ?? (preserveManualDraft ? current.roleARN : ''),
@@ -21120,27 +21166,35 @@ export function ProductAWSConnectPage() {
           region: response.connection.region ?? 'us-east-1',
           displayName: response.connection.display_name ?? '',
           sessionName: preserveManualDraft ? current.sessionName : 'identrail-connector-validation',
-          targetRegions:
-            response.connection.target_regions && response.connection.target_regions.length > 0
-              ? response.connection.target_regions.join(', ')
-              : current.targetRegions,
-          targetOUIDs:
-            response.connection.target_ou_ids && response.connection.target_ou_ids.length > 0
-              ? response.connection.target_ou_ids.join(', ')
-              : current.targetOUIDs,
-          targetAccountIDs:
-            response.connection.target_account_ids && response.connection.target_account_ids.length > 0
-              ? response.connection.target_account_ids.join(', ')
-              : current.targetAccountIDs,
-          excludedAccountIDs:
-            response.connection.excluded_account_ids && response.connection.excluded_account_ids.length > 0
-              ? response.connection.excluded_account_ids.join(', ')
-              : current.excludedAccountIDs,
-          autoOnboardNewAccounts:
-            response.connection.connector_id &&
-            typeof response.connection.auto_onboard_new_accounts === 'boolean'
-              ? response.connection.auto_onboard_new_accounts
-              : current.autoOnboardNewAccounts
+          organizationRootID: dirty.organizationRootID
+            ? current.organizationRootID
+            : rootFromOUIDs ?? current.organizationRootID,
+          targetRegions: dirty.targetRegions
+            ? current.targetRegions
+            : response.connection.target_regions && response.connection.target_regions.length > 0
+            ? response.connection.target_regions.join(', ')
+            : current.targetRegions,
+          targetOUIDs: dirty.targetOUIDs
+            ? current.targetOUIDs
+            : ouOnlyIDs.length > 0
+            ? ouOnlyIDs.join(', ')
+            : current.targetOUIDs,
+          targetAccountIDs: dirty.targetAccountIDs
+            ? current.targetAccountIDs
+            : response.connection.target_account_ids && response.connection.target_account_ids.length > 0
+            ? response.connection.target_account_ids.join(', ')
+            : current.targetAccountIDs,
+          excludedAccountIDs: dirty.excludedAccountIDs
+            ? current.excludedAccountIDs
+            : response.connection.excluded_account_ids && response.connection.excluded_account_ids.length > 0
+            ? response.connection.excluded_account_ids.join(', ')
+            : current.excludedAccountIDs,
+          autoOnboardNewAccounts: dirty.autoOnboardNewAccounts
+            ? current.autoOnboardNewAccounts
+            : response.connection.connector_id &&
+              typeof response.connection.auto_onboard_new_accounts === 'boolean'
+            ? response.connection.auto_onboard_new_accounts
+            : current.autoOnboardNewAccounts
         }));
       } catch (error) {
         if (isStale()) {
@@ -21236,6 +21290,45 @@ export function ProductAWSConnectPage() {
     }
   }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, awsCloudFormationStart?.connector_id, connection?.connector_id]);
 
+  const refreshStackSetOnboarding = useCallback(async () => {
+    const requestID = ++awsStackSetOnboardingRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const requestScopeKey = scopeKeyRef.current;
+    if (!scope || !requestEnvironmentID) {
+      setAWSStackSetOnboarding(null);
+      setAWSStackSetOnboardingLoading(false);
+      return;
+    }
+    const isStale = () =>
+      requestID !== awsStackSetOnboardingRequestRef.current ||
+      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+      scopeKeyRef.current !== requestScopeKey;
+    setAWSStackSetOnboardingLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectStackSetOnboarding(
+        scope.workspaceID,
+        requestEnvironmentID,
+        undefined,
+        undefined,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (isStale()) {
+        return;
+      }
+      setAWSStackSetOnboarding(response.onboarding);
+    } catch {
+      if (isStale()) {
+        return;
+      }
+      setAWSStackSetOnboarding(null);
+    } finally {
+      if (!isStale()) {
+        setAWSStackSetOnboardingLoading(false);
+      }
+    }
+  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+
 
   useEffect(() => {
     connectionRequestRef.current += 1;
@@ -21243,6 +21336,7 @@ export function ProductAWSConnectPage() {
     awsStartRequestRef.current += 1;
     awsPollRequestRef.current += 1;
     awsValidationRequestRef.current += 1;
+    awsStackSetOnboardingRequestRef.current += 1;
     setSuccessMessage('');
     setErrorMessage('');
     setAWSSetupMessage('');
@@ -21257,6 +21351,8 @@ export function ProductAWSConnectPage() {
     setAWSPermissionPreview([]);
     setAWSPermissionTiers([]);
     setAWSPreviewOpen(false);
+    setAWSStackSetOnboarding(null);
+    setAWSStackSetOnboardingLoading(false);
     setAWSForm((current) => ({
       ...current,
       roleARN: '',
@@ -21264,12 +21360,21 @@ export function ProductAWSConnectPage() {
       region: 'us-east-1',
       displayName: '',
       sessionName: 'identrail-connector-validation',
+      organizationRootID: '',
       targetRegions: 'us-east-1',
       targetOUIDs: '',
       targetAccountIDs: '',
       excludedAccountIDs: '',
       autoOnboardNewAccounts: true
     }));
+    awsScopeDirtyRef.current = {
+      organizationRootID: false,
+      targetRegions: false,
+      targetOUIDs: false,
+      targetAccountIDs: false,
+      excludedAccountIDs: false,
+      autoOnboardNewAccounts: false
+    };
     void refreshConnection('initial');
     void refreshBaseline();
     return () => {
@@ -21278,8 +21383,20 @@ export function ProductAWSConnectPage() {
       awsStartRequestRef.current += 1;
       awsPollRequestRef.current += 1;
       awsValidationRequestRef.current += 1;
+      awsStackSetOnboardingRequestRef.current += 1;
     };
   }, [refreshConnection, refreshBaseline]);
+
+  useEffect(() => {
+    const connectorScope = connection?.scope_type;
+    const isStackSetConnector =
+      connectorScope === 'organization' ||
+      connectorScope === 'selected_ous' ||
+      connectorScope === 'selected_accounts';
+    if (isStackSetConnector && connection?.connector_id) {
+      void refreshStackSetOnboarding();
+    }
+  }, [connection?.connector_id, connection?.scope_type, refreshStackSetOnboarding]);
 
   if (!scope) {
     return (
@@ -21361,12 +21478,17 @@ export function ProductAWSConnectPage() {
   };
 
   const chooseAWSSetupMode = (mode: AWSSetupMode) => {
+    const previousMode = awsSetupModeRef.current;
     awsSetupModeTouchedRef.current = true;
     awsSetupModeRef.current = mode;
     setAWSSetupMode(mode);
     const preparedScopeType = awsCloudFormationStart?.scope_type;
     const preparedMode: AWSSetupMode | null = preparedScopeType ? awsSetupModeFromResponse(preparedScopeType) : null;
     const switchingAcrossPreparedSetup = preparedMode !== null && preparedMode !== mode;
+    if (previousMode !== mode) {
+      awsStartRequestRef.current += 1;
+      setSubmitting(false);
+    }
     if (switchingAcrossPreparedSetup) {
       setAWSCloudFormationStart(null);
       setAWSPermissionPreview([]);
@@ -21519,6 +21641,7 @@ export function ProductAWSConnectPage() {
     }
   };
 
+  const parsedOrganizationRootID = normalizeValue(awsForm.organizationRootID);
   const parsedTargetRegions = uniqueTokens(splitScopeTokens(awsForm.targetRegions));
   const parsedTargetOUIDs = uniqueTokens(splitScopeTokens(awsForm.targetOUIDs));
   const parsedTargetAccountIDs = uniqueTokens(splitScopeTokens(awsForm.targetAccountIDs));
@@ -21533,13 +21656,24 @@ export function ProductAWSConnectPage() {
         return `Region "${region}" is not a valid AWS region. Use lowercase codes like us-east-1.`;
       }
     }
+    if (mode === 'organization') {
+      if (!parsedOrganizationRootID) {
+        return 'Add your AWS Organizations root ID (starts with r-). Find it in the AWS Organizations console.';
+      }
+      if (!AWS_ORG_ROOT_ID_PATTERN.test(parsedOrganizationRootID)) {
+        return `Root ID "${parsedOrganizationRootID}" is not valid. It must start with r-, for example r-abcd.`;
+      }
+    }
     if (mode === 'selected_ous') {
       if (parsedTargetOUIDs.length === 0) {
         return 'Add at least one target OU ID, for example ou-1234-abcd5678.';
       }
       for (const ou of parsedTargetOUIDs) {
         if (!AWS_OU_ID_PATTERN.test(ou)) {
-          return `OU "${ou}" is not a valid Organizations OU or root ID.`;
+          if (AWS_ORG_ROOT_ID_PATTERN.test(ou)) {
+            return `Root ID "${ou}" is not accepted for Selected OUs. Pick the AWS Organization path for whole-organization coverage.`;
+          }
+          return `OU "${ou}" is not a valid Organizations OU ID (expected ou-...).`;
         }
       }
     }
@@ -21552,10 +21686,18 @@ export function ProductAWSConnectPage() {
           return `Account ID "${account}" must be exactly 12 digits.`;
         }
       }
+      if (!parsedOrganizationRootID) {
+        return 'Add your AWS Organizations root ID (starts with r-). Service-managed StackSet needs it to scope the account filter.';
+      }
+      if (!AWS_ORG_ROOT_ID_PATTERN.test(parsedOrganizationRootID)) {
+        return `Root ID "${parsedOrganizationRootID}" is not valid. It must start with r-, for example r-abcd.`;
+      }
     }
-    for (const account of parsedExcludedAccountIDs) {
-      if (!AWS_ACCOUNT_ID_PATTERN.test(account)) {
-        return `Excluded account "${account}" must be exactly 12 digits.`;
+    if (mode !== 'selected_accounts') {
+      for (const account of parsedExcludedAccountIDs) {
+        if (!AWS_ACCOUNT_ID_PATTERN.test(account)) {
+          return `Excluded account "${account}" must be exactly 12 digits.`;
+        }
       }
     }
     return '';
@@ -21590,9 +21732,19 @@ export function ProductAWSConnectPage() {
     try {
       const scopeType = awsScopeTypeFromMode(mode);
       const deploymentMethod: AWSConnectorDeploymentMethod = 'stackset_service_managed';
+      const targetOUIDs = (() => {
+        if (mode === 'selected_ous') {
+          return parsedTargetOUIDs;
+        }
+        if (mode === 'organization' || mode === 'selected_accounts') {
+          return parsedOrganizationRootID ? [parsedOrganizationRootID] : undefined;
+        }
+        return undefined;
+      })();
       const payload = {
         workspace_id: scope.workspaceID,
         project_id: requestEnvironmentID,
+        connector_id: activeConnectorID || undefined,
         display_name: normalizeValue(awsForm.displayName) || undefined,
         region,
         role_name: normalizeValue(awsForm.roleName) || undefined,
@@ -21600,9 +21752,12 @@ export function ProductAWSConnectPage() {
         scope_type: scopeType,
         deployment_method: deploymentMethod,
         target_regions: parsedTargetRegions,
-        target_ou_ids: mode === 'selected_ous' ? parsedTargetOUIDs : undefined,
+        target_ou_ids: targetOUIDs,
         target_account_ids: mode === 'selected_accounts' ? parsedTargetAccountIDs : undefined,
-        excluded_account_ids: parsedExcludedAccountIDs.length > 0 ? parsedExcludedAccountIDs : undefined,
+        excluded_account_ids:
+          mode !== 'selected_accounts' && parsedExcludedAccountIDs.length > 0
+            ? parsedExcludedAccountIDs
+            : undefined,
         auto_onboard_new_accounts:
           mode === 'organization' || mode === 'selected_ous' ? Boolean(awsForm.autoOnboardNewAccounts) : false
       };
@@ -21613,19 +21768,21 @@ export function ProductAWSConnectPage() {
       setAWSCloudFormationStart(response);
       setAWSPermissionPreview(response.permission_preview);
       setAWSPermissionTiers(response.permission_tiers ?? []);
+      const responseOUIDs = response.target_ou_ids ?? [];
+      const responseRoot = responseOUIDs.find((id) => AWS_ORG_ROOT_ID_PATTERN.test(id));
+      const responseOnlyOUs = responseOUIDs.filter((id) => AWS_OU_ID_PATTERN.test(id));
       setAWSForm((current) => ({
         ...current,
         externalID: response.external_id,
         region: current.region || response.connection.region || 'us-east-1',
         displayName: current.displayName || response.connection.display_name || '',
+        organizationRootID: responseRoot ?? current.organizationRootID,
         targetRegions:
           response.target_regions && response.target_regions.length > 0
             ? response.target_regions.join(', ')
             : current.targetRegions,
         targetOUIDs:
-          response.target_ou_ids && response.target_ou_ids.length > 0
-            ? response.target_ou_ids.join(', ')
-            : current.targetOUIDs,
+          responseOnlyOUs.length > 0 ? responseOnlyOUs.join(', ') : current.targetOUIDs,
         targetAccountIDs:
           response.target_account_ids && response.target_account_ids.length > 0
             ? response.target_account_ids.join(', ')
@@ -21644,6 +21801,11 @@ export function ProductAWSConnectPage() {
       awsSetupModeRef.current = mode;
       setAWSSetupMode(mode);
       setSuccessMessage('AWS StackSet setup is ready. Open the StackSet in AWS, then refresh status.');
+      if (response.stackset_onboarding) {
+        setAWSStackSetOnboarding(response.stackset_onboarding);
+      } else {
+        void refreshStackSetOnboarding();
+      }
       if (response.launch_url && typeof window !== 'undefined' && !/jsdom/i.test(window.navigator.userAgent)) {
         window.open(response.launch_url, '_blank', 'noopener,noreferrer');
       }
@@ -22022,20 +22184,36 @@ export function ProductAWSConnectPage() {
                 <AWSStackSetScopeStep
                   mode={awsSetupMode}
                   onChooseMode={chooseAWSSetupMode}
+                  organizationRootID={awsForm.organizationRootID}
                   targetRegions={awsForm.targetRegions}
                   targetOUIDs={awsForm.targetOUIDs}
                   targetAccountIDs={awsForm.targetAccountIDs}
                   excludedAccountIDs={awsForm.excludedAccountIDs}
                   autoOnboardNewAccounts={awsForm.autoOnboardNewAccounts}
-                  onChangeRegions={(value) => setAWSForm((current) => ({ ...current, targetRegions: value }))}
-                  onChangeOUIDs={(value) => setAWSForm((current) => ({ ...current, targetOUIDs: value }))}
-                  onChangeAccountIDs={(value) => setAWSForm((current) => ({ ...current, targetAccountIDs: value }))}
-                  onChangeExcludedAccountIDs={(value) =>
-                    setAWSForm((current) => ({ ...current, excludedAccountIDs: value }))
-                  }
-                  onToggleAutoOnboard={(value) =>
-                    setAWSForm((current) => ({ ...current, autoOnboardNewAccounts: value }))
-                  }
+                  onChangeOrganizationRootID={(value) => {
+                    awsScopeDirtyRef.current.organizationRootID = true;
+                    setAWSForm((current) => ({ ...current, organizationRootID: value }));
+                  }}
+                  onChangeRegions={(value) => {
+                    awsScopeDirtyRef.current.targetRegions = true;
+                    setAWSForm((current) => ({ ...current, targetRegions: value }));
+                  }}
+                  onChangeOUIDs={(value) => {
+                    awsScopeDirtyRef.current.targetOUIDs = true;
+                    setAWSForm((current) => ({ ...current, targetOUIDs: value }));
+                  }}
+                  onChangeAccountIDs={(value) => {
+                    awsScopeDirtyRef.current.targetAccountIDs = true;
+                    setAWSForm((current) => ({ ...current, targetAccountIDs: value }));
+                  }}
+                  onChangeExcludedAccountIDs={(value) => {
+                    awsScopeDirtyRef.current.excludedAccountIDs = true;
+                    setAWSForm((current) => ({ ...current, excludedAccountIDs: value }));
+                  }}
+                  onToggleAutoOnboard={(value) => {
+                    awsScopeDirtyRef.current.autoOnboardNewAccounts = true;
+                    setAWSForm((current) => ({ ...current, autoOnboardNewAccounts: value }));
+                  }}
                   onLaunch={handleAWSStackSetStart}
                   onPreviewPermissions={
                     awsPermissionPreview.length > 0 ? () => setAWSPreviewOpen(true) : undefined
@@ -22243,11 +22421,19 @@ export function ProductAWSConnectPage() {
                 </div>
               ) : null}
             </form>
-            {isStackSetSetup && stackSetAWSStart ? (
+            {isStackSetSetup && (stackSetAWSStart || awsStackSetOnboarding) ? (
               <AWSStackSetProgressPanel
                 start={stackSetAWSStart}
-                onRefresh={activeConnectorID ? () => void handleAWSPoll() : undefined}
-                refreshing={submitting}
+                persistedOnboarding={awsStackSetOnboarding}
+                onRefresh={
+                  activeConnectorID
+                    ? () => {
+                        void handleAWSPoll();
+                        void refreshStackSetOnboarding();
+                      }
+                    : undefined
+                }
+                refreshing={submitting || awsStackSetOnboardingLoading}
               />
             ) : null}
           </section>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -35,6 +35,8 @@ import {
   type AuthConfigResponse,
   type AWSCapabilityPermissionTier,
   type AWSConnectorStartResponse,
+  type AWSConnectorScopeType,
+  type AWSConnectorDeploymentMethod,
   type AWSConnectionStatus,
   type AWSCodeBuildServiceRoleInventoryResult,
   type AWSCodeBuildServiceRoleRecord,
@@ -166,6 +168,10 @@ import {
   type AWSOrganizationsTopologyResult,
   type AWSStackSetOnboardingResult,
   type AWSStackSetOnboardingInstance,
+  type AWSStackSetOnboardingPrerequisite,
+  type AWSStackSetOnboardingSummary,
+  type AWSStackSetOnboardingCoverageExpectation,
+  type AWSStackSetOnboardingRecoveryAction,
   type AWSSecretsManagerMetadataInventoryResult,
   type AWSSecretsManagerMetadataRecord,
   type AWSSQSSNSReachabilityInventoryResult,
@@ -416,8 +422,90 @@ const GITHUB_REPOSITORY_SPLIT_PATTERN = /[\n,]+/;
 const AWS_ROLE_ARN_PATTERN = /^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role\/[A-Za-z0-9+=,.@_/-]{1,512}$/;
 const AWS_REGION_PATTERN = /^[a-z]{2}(-gov)?-[a-z]+-[0-9]$/;
 
-type AWSSetupMode = 'cloudformation' | 'manual';
+type AWSSetupMode = 'cloudformation' | 'organization' | 'selected_ous' | 'selected_accounts' | 'manual';
 type AWSPartition = 'aws' | 'aws-us-gov' | 'aws-cn';
+
+const AWS_OU_ID_PATTERN = /^(ou-[a-z0-9]{4,32}-[a-z0-9]{8,32}|r-[a-z0-9]{4,32})$/;
+const AWS_ACCOUNT_ID_PATTERN = /^[0-9]{12}$/;
+
+function splitScopeTokens(value: string): string[] {
+  return value
+    .split(/[\s,]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function uniqueTokens(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      out.push(value);
+    }
+  }
+  return out;
+}
+
+function awsSetupModeFromResponse(scopeType: AWSConnectorScopeType): AWSSetupMode {
+  switch (scopeType) {
+    case 'organization':
+      return 'organization';
+    case 'selected_ous':
+      return 'selected_ous';
+    case 'selected_accounts':
+      return 'selected_accounts';
+    case 'manual_role':
+      return 'manual';
+    case 'single_account':
+    default:
+      return 'cloudformation';
+  }
+}
+
+function awsScopeTypeFromMode(mode: AWSSetupMode): AWSConnectorScopeType {
+  switch (mode) {
+    case 'organization':
+      return 'organization';
+    case 'selected_ous':
+      return 'selected_ous';
+    case 'selected_accounts':
+      return 'selected_accounts';
+    case 'manual':
+      return 'manual_role';
+    case 'cloudformation':
+    default:
+      return 'single_account';
+  }
+}
+
+const AWS_SCOPE_OPTION_LABELS: Record<AWSSetupMode, { title: string; kicker: string; blurb: string }> = {
+  cloudformation: {
+    kicker: 'Single account',
+    title: 'This AWS account',
+    blurb: 'One-click CloudFormation'
+  },
+  organization: {
+    kicker: 'AWS Organization',
+    title: 'All accounts',
+    blurb: 'Recommended for teams'
+  },
+  selected_ous: {
+    kicker: 'Selected OUs',
+    title: 'Chosen OUs',
+    blurb: 'Pick OUs to onboard'
+  },
+  selected_accounts: {
+    kicker: 'Selected accounts',
+    title: 'Chosen accounts',
+    blurb: 'Pick accounts to onboard'
+  },
+  manual: {
+    kicker: 'Advanced',
+    title: 'Existing IAM role',
+    blurb: 'Use your change process'
+  }
+};
 
 function awsPartitionForManualTrustPolicy(roleARN: string, region: string): AWSPartition {
   const arnPartition = normalizeValue(roleARN).match(/^arn:(aws|aws-us-gov|aws-cn):iam::/)?.[1] as AWSPartition | undefined;
@@ -20409,6 +20497,494 @@ function ProductConnectorConnectPage({ provider, providerLabel }: ConnectorConne
   );
 }
 
+function awsScopeSummaryLabel(mode: AWSSetupMode, start: AWSConnectorStartResponse | null): string {
+  if (start?.target_summary) {
+    const summary = start.target_summary;
+    if (start.scope_type === 'organization') {
+      const accountCount = summary.account_count_known
+        ? `${summary.account_count} account${summary.account_count === 1 ? '' : 's'}`
+        : 'organization accounts';
+      return `Organization · ${accountCount}`;
+    }
+    if (start.scope_type === 'selected_ous') {
+      return `Selected OUs · ${summary.ou_count} OU${summary.ou_count === 1 ? '' : 's'}`;
+    }
+    if (start.scope_type === 'selected_accounts') {
+      return `Selected accounts · ${summary.account_count} account${summary.account_count === 1 ? '' : 's'}`;
+    }
+  }
+  switch (mode) {
+    case 'organization':
+      return 'AWS Organization';
+    case 'selected_ous':
+      return 'Selected OUs';
+    case 'selected_accounts':
+      return 'Selected accounts';
+    case 'manual':
+      return 'Existing IAM role';
+    case 'cloudformation':
+    default:
+      return 'Single account';
+  }
+}
+
+type AWSStackSetScopeStepProps = {
+  mode: AWSSetupMode;
+  onChooseMode: (mode: AWSSetupMode) => void;
+  targetRegions: string;
+  targetOUIDs: string;
+  targetAccountIDs: string;
+  excludedAccountIDs: string;
+  autoOnboardNewAccounts: boolean;
+  onChangeRegions: (value: string) => void;
+  onChangeOUIDs: (value: string) => void;
+  onChangeAccountIDs: (value: string) => void;
+  onChangeExcludedAccountIDs: (value: string) => void;
+  onToggleAutoOnboard: (value: boolean) => void;
+  onLaunch: () => void;
+  onPreviewPermissions?: () => void;
+  submitting: boolean;
+  canSubmit: boolean;
+  start: AWSConnectorStartResponse | null;
+  parsedRegions: string[];
+  parsedOUs: string[];
+  parsedAccounts: string[];
+  parsedExcludedAccounts: string[];
+  setupMessage: string;
+};
+
+function AWSStackSetScopeStep(props: AWSStackSetScopeStepProps) {
+  const {
+    mode,
+    onChooseMode,
+    targetRegions,
+    targetOUIDs,
+    targetAccountIDs,
+    excludedAccountIDs,
+    autoOnboardNewAccounts,
+    onChangeRegions,
+    onChangeOUIDs,
+    onChangeAccountIDs,
+    onChangeExcludedAccountIDs,
+    onToggleAutoOnboard,
+    onLaunch,
+    onPreviewPermissions,
+    submitting,
+    canSubmit,
+    start,
+    parsedRegions,
+    parsedOUs,
+    parsedAccounts,
+    parsedExcludedAccounts,
+    setupMessage
+  } = props;
+  const isOrganization = mode === 'organization';
+  const isSelectedOUs = mode === 'selected_ous';
+  const isSelectedAccounts = mode === 'selected_accounts';
+  const summaryLine = (() => {
+    if (isOrganization) {
+      return 'Read-only coverage across every active account in this AWS Organization.';
+    }
+    if (isSelectedOUs) {
+      return 'Read-only coverage across the OUs you pick. Auto-onboard covers accounts moved into those OUs later.';
+    }
+    return 'Read-only coverage across the AWS account IDs you pick. Excluded IDs are skipped.';
+  })();
+  const targetCountLabel = (() => {
+    if (isOrganization) {
+      return parsedExcludedAccounts.length > 0
+        ? `All active accounts, minus ${parsedExcludedAccounts.length} excluded`
+        : 'All active accounts';
+    }
+    if (isSelectedOUs) {
+      return `${parsedOUs.length} OU${parsedOUs.length === 1 ? '' : 's'} · ${parsedRegions.length} region${parsedRegions.length === 1 ? '' : 's'}`;
+    }
+    return `${parsedAccounts.length} account${parsedAccounts.length === 1 ? '' : 's'} · ${parsedRegions.length} region${parsedRegions.length === 1 ? '' : 's'}`;
+  })();
+  const prerequisites = start?.prerequisites ?? [];
+  const blockingCount = prerequisites.filter((prereq) => !prereq.satisfied && prereq.severity === 'blocking').length;
+  const launchLabel = (() => {
+    if (submitting) {
+      return 'Preparing StackSet...';
+    }
+    if (start?.launch_url) {
+      return 'Prepare StackSet again';
+    }
+    return 'Launch StackSet setup';
+  })();
+  return (
+    <div className="idt-aws-wizard-step">
+      <div className="idt-aws-step-index" aria-hidden="true">2</div>
+      <div className="idt-aws-step-body">
+        <div className="idt-aws-step-heading">
+          <div>
+            <h4>Set the coverage scope</h4>
+            <p>{summaryLine}</p>
+          </div>
+          <span>{targetCountLabel}</span>
+        </div>
+
+        {(isSelectedOUs || isSelectedAccounts) ? (
+          <div className="idt-aws-scope-subtoggle" role="tablist" aria-label="Selected scope type">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={isSelectedOUs}
+              className={`idt-aws-scope-subtoggle-option ${isSelectedOUs ? 'is-selected' : ''}`}
+              onClick={() => onChooseMode('selected_ous')}
+            >
+              OU IDs
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={isSelectedAccounts}
+              className={`idt-aws-scope-subtoggle-option ${isSelectedAccounts ? 'is-selected' : ''}`}
+              onClick={() => onChooseMode('selected_accounts')}
+            >
+              Account IDs
+            </button>
+          </div>
+        ) : null}
+
+        <div className="idt-aws-scope-fields">
+          <label>
+            Target regions
+            <input
+              value={targetRegions}
+              onChange={(event) => onChangeRegions(event.target.value)}
+              placeholder="us-east-1, us-west-2"
+              aria-describedby="idt-aws-scope-regions-hint"
+            />
+            <small id="idt-aws-scope-regions-hint" className="idt-aws-scope-hint">
+              Comma or space separated AWS region codes.
+            </small>
+          </label>
+
+          {isSelectedOUs ? (
+            <label>
+              Target OU IDs
+              <textarea
+                value={targetOUIDs}
+                onChange={(event) => onChangeOUIDs(event.target.value)}
+                placeholder="ou-1234-abcd5678, ou-1234-efgh9012"
+                rows={2}
+                aria-describedby="idt-aws-scope-ous-hint"
+              />
+              <small id="idt-aws-scope-ous-hint" className="idt-aws-scope-hint">
+                Organizations OU IDs. Root IDs (r-...) also allowed for the whole organization.
+              </small>
+            </label>
+          ) : null}
+
+          {isSelectedAccounts ? (
+            <label>
+              Target account IDs
+              <textarea
+                value={targetAccountIDs}
+                onChange={(event) => onChangeAccountIDs(event.target.value)}
+                placeholder="111111111111, 222222222222"
+                rows={2}
+                aria-describedby="idt-aws-scope-accounts-hint"
+              />
+              <small id="idt-aws-scope-accounts-hint" className="idt-aws-scope-hint">
+                12-digit AWS account IDs to onboard.
+              </small>
+            </label>
+          ) : null}
+
+          {(isOrganization || isSelectedOUs) ? (
+            <label>
+              Excluded account IDs
+              <textarea
+                value={excludedAccountIDs}
+                onChange={(event) => onChangeExcludedAccountIDs(event.target.value)}
+                placeholder="Optional. 333333333333"
+                rows={2}
+                aria-describedby="idt-aws-scope-exclusions-hint"
+              />
+              <small id="idt-aws-scope-exclusions-hint" className="idt-aws-scope-hint">
+                Accounts to skip. Coverage claims never include excluded accounts.
+              </small>
+            </label>
+          ) : null}
+        </div>
+
+        {(isOrganization || isSelectedOUs) ? (
+          <label className="idt-aws-scope-toggle">
+            <input
+              type="checkbox"
+              checked={autoOnboardNewAccounts}
+              onChange={(event) => onToggleAutoOnboard(event.target.checked)}
+            />
+            <span>
+              <strong>Auto-onboard new accounts</strong>
+              <small>Service-managed StackSet enrolls accounts added to the covered OUs later.</small>
+            </span>
+          </label>
+        ) : null}
+
+        {parsedRegions.length > 0 || parsedOUs.length > 0 || parsedAccounts.length > 0 ? (
+          <div className="idt-aws-scope-chips" aria-label="Selected target summary">
+            {parsedOUs.map((ou) => (
+              <span key={`ou-${ou}`} className="idt-aws-scope-chip">{ou}</span>
+            ))}
+            {parsedAccounts.map((account) => (
+              <span key={`account-${account}`} className="idt-aws-scope-chip">{account}</span>
+            ))}
+            {parsedExcludedAccounts.map((account) => (
+              <span key={`excluded-${account}`} className="idt-aws-scope-chip is-excluded">
+                Exclude {account}
+              </span>
+            ))}
+            {parsedRegions.map((region) => (
+              <span key={`region-${region}`} className="idt-aws-scope-chip is-region">{region}</span>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="idt-aws-permission-summary" aria-label="AWS StackSet permission summary">
+          <span>Service-managed StackSet with a read-only role in every target account.</span>
+          <span>No write, delete, or remediation permissions.</span>
+          <span>Coverage is only claimed once AWS reports each StackSet instance active.</span>
+        </div>
+
+        {prerequisites.length > 0 ? (
+          <ul className="idt-aws-prereq-list" aria-label="StackSet prerequisites">
+            {prerequisites.map((prereq) => (
+              <li
+                key={prereq.id}
+                className={`idt-aws-prereq ${prereq.satisfied ? 'is-ok' : `is-${prereq.severity}`}`}
+              >
+                <strong>{prereq.title}</strong>
+                <span>{prereq.satisfied ? 'Satisfied' : formatTokenLabel(prereq.severity)}</span>
+                <p>{prereq.reason}</p>
+                {prereq.remediation && !prereq.satisfied ? <p>{prereq.remediation}</p> : null}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        {setupMessage ? (
+          <p role="status" className="idt-aws-setup-note">
+            {setupMessage}
+          </p>
+        ) : null}
+
+        <div className="idt-source-actions">
+          <button
+            className="idt-btn idt-btn-primary"
+            type="button"
+            onClick={onLaunch}
+            disabled={!canSubmit || blockingCount > 0}
+          >
+            {launchLabel}
+          </button>
+          {start?.launch_url ? (
+            <a className="idt-btn idt-btn-dark" href={start.launch_url} target="_blank" rel="noreferrer">
+              <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
+              <span>Open StackSet in AWS</span>
+            </a>
+          ) : null}
+          {onPreviewPermissions ? (
+            <button className="idt-btn idt-btn-ghost" type="button" onClick={onPreviewPermissions}>
+              Preview permissions
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function stackSetOnboardingStatusLabel(status: string): string {
+  switch (status) {
+    case 'ready':
+      return 'Ready';
+    case 'degraded':
+      return 'Degraded';
+    case 'blocked':
+      return 'Blocked';
+    case 'permission_denied':
+      return 'Permission denied';
+    case 'partial_failure':
+      return 'Partial failure';
+    default:
+      return formatTokenLabel(status);
+  }
+}
+
+function stackSetOnboardingStatusTone(status: string): 'success' | 'warning' | 'danger' | 'neutral' {
+  switch (status) {
+    case 'ready':
+      return 'success';
+    case 'degraded':
+    case 'partial_failure':
+      return 'warning';
+    case 'blocked':
+    case 'permission_denied':
+      return 'danger';
+    default:
+      return 'neutral';
+  }
+}
+
+type AWSStackSetProgressPanelProps = {
+  start: AWSConnectorStartResponse;
+  onRefresh?: () => void;
+  refreshing: boolean;
+};
+
+function AWSStackSetProgressPanel({ start, onRefresh, refreshing }: AWSStackSetProgressPanelProps) {
+  const onboarding = start.stackset_onboarding;
+  const summary: AWSStackSetOnboardingSummary | undefined = onboarding?.summary;
+  const coverage: AWSStackSetOnboardingCoverageExpectation | undefined = onboarding?.coverage_expectation;
+  const recoveryActions: AWSStackSetOnboardingRecoveryAction[] = onboarding?.recovery_actions ?? [];
+  const instances: AWSStackSetOnboardingInstance[] = onboarding?.instances ?? [];
+  const prereqs: AWSStackSetOnboardingPrerequisite[] = onboarding?.validation?.prerequisites ?? start.prerequisites ?? [];
+  const status = onboarding?.status ?? 'blocked';
+  const tone = stackSetOnboardingStatusTone(status);
+  const statusLabel = stackSetOnboardingStatusLabel(status);
+  const resumableCount = summary?.resumable_instances ?? 0;
+  const pendingCount = summary?.pending_instances ?? 0;
+  const activeCount = summary?.active_instances ?? 0;
+  const failedCount = summary?.failed_instances ?? 0;
+  const degradedCount = summary?.degraded_instances ?? 0;
+  const permissionDeniedCount = summary?.permission_denied_instances ?? 0;
+  const totalInstances = summary?.total_instances ?? instances.length;
+  return (
+    <section className="idt-aws-stackset-progress" aria-label="StackSet onboarding progress">
+      <header className="idt-aws-stackset-progress-header">
+        <div>
+          <p className="idt-app-kicker">StackSet progress</p>
+          <h3>{stackSetOnboardingStatusLabel(status)} · {totalInstances} instance{totalInstances === 1 ? '' : 's'}</h3>
+          <p>
+            {summary?.deployed_percent_known
+              ? `${summary.deployed_percent}% of StackSet instances are active.`
+              : 'Waiting for AWS to report StackSet instance status.'}
+          </p>
+        </div>
+        <span className={`idt-domain-status-badge is-${tone}`}>{statusLabel}</span>
+      </header>
+      <dl className="idt-aws-stackset-progress-grid">
+        <div>
+          <dt>Pending</dt>
+          <dd>{pendingCount}</dd>
+        </div>
+        <div>
+          <dt>Active</dt>
+          <dd>{activeCount}</dd>
+        </div>
+        <div>
+          <dt>Degraded</dt>
+          <dd>{degradedCount}</dd>
+        </div>
+        <div>
+          <dt>Failed</dt>
+          <dd>{failedCount}</dd>
+        </div>
+        <div>
+          <dt>Permission denied</dt>
+          <dd>{permissionDeniedCount}</dd>
+        </div>
+        <div>
+          <dt>Resumable</dt>
+          <dd>{resumableCount}</dd>
+        </div>
+      </dl>
+      {coverage ? (
+        <p className="idt-aws-stackset-coverage-line">
+          Planned coverage:
+          {' '}
+          {coverage.expected_accounts_known
+            ? `${coverage.expected_accounts} account${coverage.expected_accounts === 1 ? '' : 's'}`
+            : 'account count unknown until validation'}
+          {' · '}
+          {coverage.expected_regions_known
+            ? `${coverage.expected_regions} region${coverage.expected_regions === 1 ? '' : 's'}`
+            : 'region count unknown'}
+          .
+          {' '}
+          Identrail will not claim coverage until AWS reports instances active.
+        </p>
+      ) : null}
+      {prereqs.length > 0 ? (
+        <ul className="idt-aws-prereq-list" aria-label="StackSet onboarding prerequisites">
+          {prereqs.map((prereq) => (
+            <li
+              key={`prereq-${prereq.id}`}
+              className={`idt-aws-prereq ${prereq.satisfied ? 'is-ok' : `is-${prereq.severity}`}`}
+            >
+              <strong>{prereq.title}</strong>
+              <span>{prereq.satisfied ? 'Satisfied' : formatTokenLabel(prereq.severity)}</span>
+              <p>{prereq.reason}</p>
+              {prereq.remediation && !prereq.satisfied ? <p>{prereq.remediation}</p> : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {instances.length > 0 ? (
+        <div className="idt-aws-stackset-instances-wrap">
+          <table className="idt-aws-stackset-instances" aria-label="StackSet instance status">
+            <thead>
+              <tr>
+                <th>Account</th>
+                <th>Region</th>
+                <th>State</th>
+                <th>Next action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {instances.map((instance) => (
+                <tr key={instance.key}>
+                  <td>
+                    <strong>{instance.account_id}</strong>
+                    {instance.account_name ? <small>{instance.account_name}</small> : null}
+                  </td>
+                  <td>{instance.region}</td>
+                  <td>
+                    <span className={`idt-source-status-pill is-${stackSetOnboardingStatusTone(instance.state)}`}>
+                      {formatTokenLabel(instance.state)}
+                    </span>
+                  </td>
+                  <td>
+                    <p>{instance.next_action || 'No action required.'}</p>
+                    {instance.failure_reason ? <p className="idt-aws-stackset-failure">{instance.failure_reason}</p> : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="idt-aws-stackset-empty">
+          No StackSet instances yet. AWS reports instances once the StackSet deploys.
+        </p>
+      )}
+      {recoveryActions.length > 0 ? (
+        <ul className="idt-domain-charter-list" aria-label="StackSet recovery actions">
+          {recoveryActions.map((action) => (
+            <li key={action.id}>
+              <strong>{action.title}</strong>
+              <p>{action.description}</p>
+              {action.targets.length > 0 ? (
+                <p className="idt-aws-stackset-recovery-targets">Targets: {action.targets.join(', ')}</p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {onRefresh ? (
+        <div className="idt-source-actions">
+          <button className="idt-btn idt-btn-secondary" type="button" onClick={onRefresh} disabled={refreshing}>
+            {refreshing ? 'Refreshing...' : 'Refresh StackSet status'}
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 export function ProductAWSConnectPage() {
   const params = useParams<ScopeRouteParams>();
   const location = useLocation();
@@ -20436,7 +21012,13 @@ export function ProductAWSConnectPage() {
     displayName: '',
     sessionName: 'identrail-connector-validation',
     roleName: 'IdentrailReadOnly',
-    stackName: 'identrail-readonly-connector'
+    stackName: 'identrail-readonly-connector',
+    stackSetName: 'identrail-readonly-stackset',
+    targetRegions: 'us-east-1',
+    targetOUIDs: '',
+    targetAccountIDs: '',
+    excludedAccountIDs: '',
+    autoOnboardNewAccounts: true
   });
   const [awsCloudFormationStart, setAWSCloudFormationStart] = useState<AWSConnectorStartResponse | null>(null);
   const [awsPermissionPreview, setAWSPermissionPreview] = useState<AWSPermissionPreviewItem[]>([]);
@@ -20487,7 +21069,7 @@ export function ProductAWSConnectPage() {
           return;
         }
         setConnection(response.connection);
-        const responseSetupMode = response.connection.deployment_method === 'manual' ? 'manual' : 'cloudformation';
+        const responseSetupMode = awsSetupModeFromResponse(response.connection.scope_type);
         const preserveManualDraft = awsSetupModeTouchedRef.current
           ? awsSetupModeRef.current === 'manual'
           : responseSetupMode === 'manual';
@@ -20502,7 +21084,28 @@ export function ProductAWSConnectPage() {
           externalID: preserveManualDraft ? current.externalID : '',
           region: response.connection.region ?? 'us-east-1',
           displayName: response.connection.display_name ?? '',
-          sessionName: preserveManualDraft ? current.sessionName : 'identrail-connector-validation'
+          sessionName: preserveManualDraft ? current.sessionName : 'identrail-connector-validation',
+          targetRegions:
+            response.connection.target_regions && response.connection.target_regions.length > 0
+              ? response.connection.target_regions.join(', ')
+              : current.targetRegions,
+          targetOUIDs:
+            response.connection.target_ou_ids && response.connection.target_ou_ids.length > 0
+              ? response.connection.target_ou_ids.join(', ')
+              : current.targetOUIDs,
+          targetAccountIDs:
+            response.connection.target_account_ids && response.connection.target_account_ids.length > 0
+              ? response.connection.target_account_ids.join(', ')
+              : current.targetAccountIDs,
+          excludedAccountIDs:
+            response.connection.excluded_account_ids && response.connection.excluded_account_ids.length > 0
+              ? response.connection.excluded_account_ids.join(', ')
+              : current.excludedAccountIDs,
+          autoOnboardNewAccounts:
+            response.connection.connector_id &&
+            typeof response.connection.auto_onboard_new_accounts === 'boolean'
+              ? response.connection.auto_onboard_new_accounts
+              : current.autoOnboardNewAccounts
         }));
       } catch (error) {
         if (isStale()) {
@@ -20625,7 +21228,12 @@ export function ProductAWSConnectPage() {
       externalID: '',
       region: 'us-east-1',
       displayName: '',
-      sessionName: 'identrail-connector-validation'
+      sessionName: 'identrail-connector-validation',
+      targetRegions: 'us-east-1',
+      targetOUIDs: '',
+      targetAccountIDs: '',
+      excludedAccountIDs: '',
+      autoOnboardNewAccounts: true
     }));
     void refreshConnection('initial');
     void refreshBaseline();
@@ -20674,13 +21282,30 @@ export function ProductAWSConnectPage() {
   const canSubmit = !submitting && !loadingConnection && Boolean(selectedEnvironmentID);
   const manualAWSStart = awsCloudFormationStart?.deployment_method === 'manual' ? awsCloudFormationStart : null;
   const cloudFormationAWSStart =
-    awsCloudFormationStart && awsCloudFormationStart.deployment_method !== 'manual' ? awsCloudFormationStart : null;
+    awsCloudFormationStart && awsCloudFormationStart.deployment_method === 'cloudformation' ? awsCloudFormationStart : null;
+  const stackSetAWSStart =
+    awsCloudFormationStart &&
+    (awsCloudFormationStart.deployment_method === 'stackset_service_managed' ||
+      awsCloudFormationStart.deployment_method === 'stackset_self_managed')
+      ? awsCloudFormationStart
+      : null;
   const isManualSetup =
     awsSetupMode === 'manual' ||
     Boolean(manualAWSStart);
+  const isStackSetSetup =
+    awsSetupMode === 'organization' ||
+    awsSetupMode === 'selected_ous' ||
+    awsSetupMode === 'selected_accounts' ||
+    Boolean(stackSetAWSStart);
   const activeConnectorID = isManualSetup
     ? manualAWSStart?.connector_id ?? (connection?.deployment_method === 'manual' ? connection.connector_id : '') ?? ''
-    : cloudFormationAWSStart?.connector_id ?? (connection?.deployment_method !== 'manual' ? connection?.connector_id : '') ?? '';
+    : isStackSetSetup
+    ? stackSetAWSStart?.connector_id ??
+      (connection?.deployment_method?.startsWith('stackset_') ? connection.connector_id : '') ??
+      ''
+    : cloudFormationAWSStart?.connector_id ??
+      (connection?.deployment_method === 'cloudformation' ? connection?.connector_id : '') ??
+      '';
   const canValidateRole = Boolean(normalizeValue(awsForm.roleARN)) && (!isManualSetup || Boolean(activeConnectorID));
   const selectedAWSRegion = normalizeValue(awsForm.region) || 'us-east-1';
   const manualExternalID = normalizeValue(awsForm.externalID);
@@ -20704,9 +21329,9 @@ export function ProductAWSConnectPage() {
     awsSetupModeTouchedRef.current = true;
     awsSetupModeRef.current = mode;
     setAWSSetupMode(mode);
-    const switchingAcrossPreparedSetup =
-      (mode === 'cloudformation' && Boolean(manualAWSStart)) ||
-      (mode === 'manual' && Boolean(cloudFormationAWSStart));
+    const preparedScopeType = awsCloudFormationStart?.scope_type;
+    const preparedMode: AWSSetupMode | null = preparedScopeType ? awsSetupModeFromResponse(preparedScopeType) : null;
+    const switchingAcrossPreparedSetup = preparedMode !== null && preparedMode !== mode;
     if (switchingAcrossPreparedSetup) {
       setAWSCloudFormationStart(null);
       setAWSPermissionPreview([]);
@@ -20847,6 +21472,146 @@ export function ProductAWSConnectPage() {
       awsSetupModeRef.current = 'manual';
       setAWSSetupMode('manual');
       setSuccessMessage('Manual setup is ready. Add the trust policy in AWS, then validate the role.');
+    } catch (error) {
+      if (isStale()) {
+        return;
+      }
+      setAWSSetupMessage(formatAWSConnectorSetupError(error));
+    } finally {
+      if (!isStale()) {
+        setSubmitting(false);
+      }
+    }
+  };
+
+  const parsedTargetRegions = uniqueTokens(splitScopeTokens(awsForm.targetRegions));
+  const parsedTargetOUIDs = uniqueTokens(splitScopeTokens(awsForm.targetOUIDs));
+  const parsedTargetAccountIDs = uniqueTokens(splitScopeTokens(awsForm.targetAccountIDs));
+  const parsedExcludedAccountIDs = uniqueTokens(splitScopeTokens(awsForm.excludedAccountIDs));
+
+  const validateStackSetTargets = (mode: AWSSetupMode): string => {
+    if (parsedTargetRegions.length === 0) {
+      return 'Add at least one target region, for example us-east-1.';
+    }
+    for (const region of parsedTargetRegions) {
+      if (!AWS_REGION_PATTERN.test(region)) {
+        return `Region "${region}" is not a valid AWS region. Use lowercase codes like us-east-1.`;
+      }
+    }
+    if (mode === 'selected_ous') {
+      if (parsedTargetOUIDs.length === 0) {
+        return 'Add at least one target OU ID, for example ou-1234-abcd5678.';
+      }
+      for (const ou of parsedTargetOUIDs) {
+        if (!AWS_OU_ID_PATTERN.test(ou)) {
+          return `OU "${ou}" is not a valid Organizations OU or root ID.`;
+        }
+      }
+    }
+    if (mode === 'selected_accounts') {
+      if (parsedTargetAccountIDs.length === 0) {
+        return 'Add at least one 12-digit target AWS account ID.';
+      }
+      for (const account of parsedTargetAccountIDs) {
+        if (!AWS_ACCOUNT_ID_PATTERN.test(account)) {
+          return `Account ID "${account}" must be exactly 12 digits.`;
+        }
+      }
+    }
+    for (const account of parsedExcludedAccountIDs) {
+      if (!AWS_ACCOUNT_ID_PATTERN.test(account)) {
+        return `Excluded account "${account}" must be exactly 12 digits.`;
+      }
+    }
+    return '';
+  };
+
+  const handleAWSStackSetStart = async () => {
+    if (!selectedEnvironmentID) {
+      setErrorMessage('Choose an environment before launching the StackSet.');
+      return;
+    }
+    const mode = awsSetupMode;
+    if (mode !== 'organization' && mode !== 'selected_ous' && mode !== 'selected_accounts') {
+      return;
+    }
+    const targetError = validateStackSetTargets(mode);
+    if (targetError) {
+      setAWSSetupMessage(targetError);
+      return;
+    }
+    setSubmitting(true);
+    setSuccessMessage('');
+    setErrorMessage('');
+    setAWSSetupMessage('');
+    const requestID = ++awsStartRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const requestScopeKey = scopeKeyRef.current;
+    const region = normalizeValue(awsForm.region) || parsedTargetRegions[0] || 'us-east-1';
+    const isStale = () =>
+      requestID !== awsStartRequestRef.current ||
+      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+      scopeKeyRef.current !== requestScopeKey;
+    try {
+      const scopeType = awsScopeTypeFromMode(mode);
+      const deploymentMethod: AWSConnectorDeploymentMethod = 'stackset_service_managed';
+      const payload = {
+        workspace_id: scope.workspaceID,
+        project_id: requestEnvironmentID,
+        display_name: normalizeValue(awsForm.displayName) || undefined,
+        region,
+        role_name: normalizeValue(awsForm.roleName) || undefined,
+        stack_set_name: normalizeValue(awsForm.stackSetName) || undefined,
+        scope_type: scopeType,
+        deployment_method: deploymentMethod,
+        target_regions: parsedTargetRegions,
+        target_ou_ids: mode === 'selected_ous' ? parsedTargetOUIDs : undefined,
+        target_account_ids: mode === 'selected_accounts' ? parsedTargetAccountIDs : undefined,
+        excluded_account_ids: parsedExcludedAccountIDs.length > 0 ? parsedExcludedAccountIDs : undefined,
+        auto_onboard_new_accounts:
+          mode === 'organization' || mode === 'selected_ous' ? Boolean(awsForm.autoOnboardNewAccounts) : false
+      };
+      const response = await apiClient.startAWSConnector(payload, buildProductAuthContext(scope));
+      if (isStale()) {
+        return;
+      }
+      setAWSCloudFormationStart(response);
+      setAWSPermissionPreview(response.permission_preview);
+      setAWSPermissionTiers(response.permission_tiers ?? []);
+      setAWSForm((current) => ({
+        ...current,
+        externalID: response.external_id,
+        region: current.region || response.connection.region || 'us-east-1',
+        displayName: current.displayName || response.connection.display_name || '',
+        targetRegions:
+          response.target_regions && response.target_regions.length > 0
+            ? response.target_regions.join(', ')
+            : current.targetRegions,
+        targetOUIDs:
+          response.target_ou_ids && response.target_ou_ids.length > 0
+            ? response.target_ou_ids.join(', ')
+            : current.targetOUIDs,
+        targetAccountIDs:
+          response.target_account_ids && response.target_account_ids.length > 0
+            ? response.target_account_ids.join(', ')
+            : current.targetAccountIDs,
+        excludedAccountIDs:
+          response.excluded_account_ids && response.excluded_account_ids.length > 0
+            ? response.excluded_account_ids.join(', ')
+            : current.excludedAccountIDs,
+        autoOnboardNewAccounts:
+          typeof response.auto_onboard_new_accounts === 'boolean'
+            ? response.auto_onboard_new_accounts
+            : current.autoOnboardNewAccounts
+      }));
+      setConnection(response.connection);
+      awsSetupModeTouchedRef.current = true;
+      awsSetupModeRef.current = mode;
+      setAWSSetupMode(mode);
+      setSuccessMessage('AWS StackSet setup is ready. Open the StackSet in AWS, then refresh status.');
+      if (response.launch_url && typeof window !== 'undefined' && !/jsdom/i.test(window.navigator.userAgent)) {
+        window.open(response.launch_url, '_blank', 'noopener,noreferrer');
+      }
     } catch (error) {
       if (isStale()) {
         return;
@@ -21055,6 +21820,12 @@ export function ProductAWSConnectPage() {
     if (isManualSetup && manualExternalID && !connectedNow) {
       return 'Add the trust policy in AWS, paste the role ARN, then validate the role.';
     }
+    if (isStackSetSetup && stackSetAWSStart?.launch_url) {
+      return 'Open the StackSet in AWS to deploy the read-only role, then refresh status.';
+    }
+    if (isStackSetSetup && !stackSetAWSStart) {
+      return 'Pick target regions and accounts or OUs, then launch the StackSet setup.';
+    }
     if ((connectedNow || hasConnectorSetup) && connection?.setup_summary) {
       return connection.setup_summary;
     }
@@ -21121,38 +21892,60 @@ export function ProductAWSConnectPage() {
             </div>
 
             <div className="idt-aws-scope-options" role="list" aria-label="AWS setup scope options">
-              <div className="idt-aws-scope-option is-planned" role="listitem" aria-disabled="true">
-                <span>AWS Organization</span>
-                <strong>All accounts</strong>
-                <small>Coming later</small>
-              </div>
               <div className="idt-aws-scope-option-shell" role="listitem">
                 <button
-                  className={`idt-aws-scope-option ${!isManualSetup ? 'is-selected' : ''}`}
+                  className={`idt-aws-scope-option ${awsSetupMode === 'organization' ? 'is-selected' : ''}`}
                   type="button"
-                  aria-current={!isManualSetup ? 'true' : undefined}
-                  onClick={() => chooseAWSSetupMode('cloudformation')}
+                  aria-current={awsSetupMode === 'organization' ? 'true' : undefined}
+                  onClick={() => chooseAWSSetupMode('organization')}
                 >
-                  <span>Single account</span>
-                  <strong>This AWS account</strong>
-                  <small>Available now</small>
+                  <span>{AWS_SCOPE_OPTION_LABELS.organization.kicker}</span>
+                  <strong>{AWS_SCOPE_OPTION_LABELS.organization.title}</strong>
+                  <small>{AWS_SCOPE_OPTION_LABELS.organization.blurb}</small>
                 </button>
               </div>
-              <div className="idt-aws-scope-option is-planned" role="listitem" aria-disabled="true">
-                <span>Selected scope</span>
-                <strong>OUs or accounts</strong>
-                <small>Coming later</small>
+              <div className="idt-aws-scope-option-shell" role="listitem">
+                <button
+                  className={`idt-aws-scope-option ${awsSetupMode === 'cloudformation' ? 'is-selected' : ''}`}
+                  type="button"
+                  aria-current={awsSetupMode === 'cloudformation' ? 'true' : undefined}
+                  onClick={() => chooseAWSSetupMode('cloudformation')}
+                >
+                  <span>{AWS_SCOPE_OPTION_LABELS.cloudformation.kicker}</span>
+                  <strong>{AWS_SCOPE_OPTION_LABELS.cloudformation.title}</strong>
+                  <small>{AWS_SCOPE_OPTION_LABELS.cloudformation.blurb}</small>
+                </button>
               </div>
               <div className="idt-aws-scope-option-shell" role="listitem">
                 <button
-                  className={`idt-aws-scope-option ${isManualSetup ? 'is-selected' : ''}`}
+                  className={`idt-aws-scope-option ${
+                    awsSetupMode === 'selected_ous' || awsSetupMode === 'selected_accounts' ? 'is-selected' : ''
+                  }`}
                   type="button"
-                  aria-current={isManualSetup ? 'true' : undefined}
+                  aria-current={
+                    awsSetupMode === 'selected_ous' || awsSetupMode === 'selected_accounts' ? 'true' : undefined
+                  }
+                  onClick={() =>
+                    chooseAWSSetupMode(
+                      awsSetupMode === 'selected_accounts' ? 'selected_accounts' : 'selected_ous'
+                    )
+                  }
+                >
+                  <span>Selected scope</span>
+                  <strong>OUs or accounts</strong>
+                  <small>Pick a subset</small>
+                </button>
+              </div>
+              <div className="idt-aws-scope-option-shell" role="listitem">
+                <button
+                  className={`idt-aws-scope-option ${awsSetupMode === 'manual' ? 'is-selected' : ''}`}
+                  type="button"
+                  aria-current={awsSetupMode === 'manual' ? 'true' : undefined}
                   onClick={() => chooseAWSSetupMode('manual')}
                 >
-                  <span>Advanced</span>
-                  <strong>Existing IAM role</strong>
-                  <small>Use your change process</small>
+                  <span>{AWS_SCOPE_OPTION_LABELS.manual.kicker}</span>
+                  <strong>{AWS_SCOPE_OPTION_LABELS.manual.title}</strong>
+                  <small>{AWS_SCOPE_OPTION_LABELS.manual.blurb}</small>
                 </button>
               </div>
             </div>
@@ -21190,7 +21983,38 @@ export function ProductAWSConnectPage() {
                 </div>
               </div>
 
-              {!isManualSetup ? (
+              {isStackSetSetup ? (
+                <AWSStackSetScopeStep
+                  mode={awsSetupMode}
+                  onChooseMode={chooseAWSSetupMode}
+                  targetRegions={awsForm.targetRegions}
+                  targetOUIDs={awsForm.targetOUIDs}
+                  targetAccountIDs={awsForm.targetAccountIDs}
+                  excludedAccountIDs={awsForm.excludedAccountIDs}
+                  autoOnboardNewAccounts={awsForm.autoOnboardNewAccounts}
+                  onChangeRegions={(value) => setAWSForm((current) => ({ ...current, targetRegions: value }))}
+                  onChangeOUIDs={(value) => setAWSForm((current) => ({ ...current, targetOUIDs: value }))}
+                  onChangeAccountIDs={(value) => setAWSForm((current) => ({ ...current, targetAccountIDs: value }))}
+                  onChangeExcludedAccountIDs={(value) =>
+                    setAWSForm((current) => ({ ...current, excludedAccountIDs: value }))
+                  }
+                  onToggleAutoOnboard={(value) =>
+                    setAWSForm((current) => ({ ...current, autoOnboardNewAccounts: value }))
+                  }
+                  onLaunch={handleAWSStackSetStart}
+                  onPreviewPermissions={
+                    awsPermissionPreview.length > 0 ? () => setAWSPreviewOpen(true) : undefined
+                  }
+                  submitting={submitting}
+                  canSubmit={canSubmit}
+                  start={stackSetAWSStart}
+                  parsedRegions={parsedTargetRegions}
+                  parsedOUs={parsedTargetOUIDs}
+                  parsedAccounts={parsedTargetAccountIDs}
+                  parsedExcludedAccounts={parsedExcludedAccountIDs}
+                  setupMessage={awsSetupMessage}
+                />
+              ) : !isManualSetup ? (
                 <div className="idt-aws-wizard-step">
                   <div className="idt-aws-step-index" aria-hidden="true">2</div>
                   <div className="idt-aws-step-body">
@@ -21305,7 +22129,7 @@ export function ProductAWSConnectPage() {
                 </div>
               )}
 
-              {hasConnectorSetup && !isManualSetup ? (
+              {hasConnectorSetup && !isManualSetup && !isStackSetSetup ? (
                 <div className="idt-aws-wizard-step">
                   <div className="idt-aws-step-index" aria-hidden="true">3</div>
                   <div className="idt-aws-step-body">
@@ -21384,6 +22208,13 @@ export function ProductAWSConnectPage() {
                 </div>
               ) : null}
             </form>
+            {isStackSetSetup && stackSetAWSStart ? (
+              <AWSStackSetProgressPanel
+                start={stackSetAWSStart}
+                onRefresh={activeConnectorID ? () => void handleAWSPoll() : undefined}
+                refreshing={submitting}
+              />
+            ) : null}
           </section>
 
           <div className="idt-aws-connect-side">
@@ -21393,7 +22224,7 @@ export function ProductAWSConnectPage() {
               <dl className="idt-source-meta">
                 <div>
                   <dt>Scope</dt>
-                  <dd>{isManualSetup ? 'Existing IAM role' : 'Single account'}</dd>
+                  <dd>{awsScopeSummaryLabel(awsSetupMode, stackSetAWSStart ?? cloudFormationAWSStart ?? manualAWSStart)}</dd>
                 </div>
                 <div>
                   <dt>Health</dt>
@@ -21406,7 +22237,17 @@ export function ProductAWSConnectPage() {
               </dl>
               <p>{setupSummaryBody}</p>
               <div className="idt-source-actions idt-aws-summary-actions">
-                {launchURL ? (
+                {isStackSetSetup && stackSetAWSStart?.launch_url ? (
+                  <a
+                    className="idt-btn idt-btn-primary"
+                    href={stackSetAWSStart.launch_url}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
+                    <span>Open StackSet in AWS</span>
+                  </a>
+                ) : launchURL ? (
                   <a className="idt-btn idt-btn-primary" href={launchURL} target="_blank" rel="noreferrer">
                     <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
                     <span>Open AWS stack</span>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -21540,6 +21540,8 @@ export function ProductAWSConnectPage() {
       region: 'us-east-1',
       displayName: '',
       sessionName: 'identrail-connector-validation',
+      roleName: 'IdentrailReadOnly',
+      stackSetName: 'identrail-readonly-stackset',
       organizationRootID: '',
       targetRegions: 'us-east-1',
       targetOUIDs: '',
@@ -22012,14 +22014,26 @@ export function ProductAWSConnectPage() {
         }
         return undefined;
       })();
+      const resumingExisting = Boolean(activeConnectorID);
+      // On resume, omit role_name / stack_set_name when the operator hasn't
+      // touched them. AWSConnectionStatus doesn't currently expose the stored
+      // role_name (and role_arn is empty for a not-yet-deployed connector),
+      // so we can't hydrate the form with the stored value in every case.
+      // Sending the hardcoded default would trip resumeAWSStackSetConnectorStart
+      // when the stored name differs. Omitting them lets the backend keep the
+      // stored values.
+      const shouldSendRoleName =
+        !resumingExisting || awsScopeDirtyRef.current.roleName;
+      const shouldSendStackSetName =
+        !resumingExisting || awsScopeDirtyRef.current.stackSetName;
       const payload = {
         workspace_id: scope.workspaceID,
         project_id: requestEnvironmentID,
         connector_id: activeConnectorID || undefined,
         display_name: normalizeValue(awsForm.displayName) || undefined,
         region,
-        role_name: normalizeValue(awsForm.roleName) || undefined,
-        stack_set_name: normalizeValue(awsForm.stackSetName) || undefined,
+        role_name: shouldSendRoleName ? normalizeValue(awsForm.roleName) || undefined : undefined,
+        stack_set_name: shouldSendStackSetName ? normalizeValue(awsForm.stackSetName) || undefined : undefined,
         scope_type: scopeType,
         deployment_method: deploymentMethod,
         target_regions: parsedTargetRegions,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -599,19 +599,29 @@ function stackSetContractsMatch(a: AWSStackSetContractSnapshot, b: AWSStackSetCo
   if (a.stackSetName && b.stackSetName && a.stackSetName !== b.stackSetName) {
     return false;
   }
-  // Backend awsConnectorSetupContractsMatch uses order-sensitive slices.Equal;
-  // reordering regions in particular changes the StackSet home region.
-  const stringListsEqual = (left: string[], right: string[]) => {
+  const positionalListsEqual = (left: string[], right: string[]) => {
     if (left.length !== right.length) {
       return false;
     }
     return left.every((value, index) => value === right[index]);
   };
+  const unorderedListsEqual = (left: string[], right: string[]) => {
+    if (left.length !== right.length) {
+      return false;
+    }
+    const l = [...left].sort();
+    const r = [...right].sort();
+    return l.every((value, index) => value === r[index]);
+  };
   return (
-    stringListsEqual(a.targetRegions, b.targetRegions) &&
-    stringListsEqual(a.targetOUIDs, b.targetOUIDs) &&
-    stringListsEqual(a.targetAccountIDs, b.targetAccountIDs) &&
-    stringListsEqual(a.excludedAccountIDs, b.excludedAccountIDs)
+    // target_regions is order-sensitive: the first entry is the StackSet home
+    // region, matching the backend's derivation.
+    positionalListsEqual(a.targetRegions, b.targetRegions) &&
+    // Backend normalizeAWSOUIDs/normalizeAWSAccountIDs sort these lists before
+    // awsConnectorSetupContractsMatch, so ordering doesn't count as drift.
+    unorderedListsEqual(a.targetOUIDs, b.targetOUIDs) &&
+    unorderedListsEqual(a.targetAccountIDs, b.targetAccountIDs) &&
+    unorderedListsEqual(a.excludedAccountIDs, b.excludedAccountIDs)
   );
 }
 
@@ -21025,6 +21035,7 @@ function stackSetOnboardingStatusTone(status: string): 'success' | 'warning' | '
 type AWSStackSetProgressPanelProps = {
   start: AWSConnectorStartResponse | null;
   persistedOnboarding: AWSStackSetOnboardingResult | null;
+  refreshError?: string;
   onRefresh?: () => void;
   refreshing: boolean;
 };
@@ -21032,6 +21043,7 @@ type AWSStackSetProgressPanelProps = {
 function AWSStackSetProgressPanel({
   start,
   persistedOnboarding,
+  refreshError,
   onRefresh,
   refreshing
 }: AWSStackSetProgressPanelProps) {
@@ -21175,10 +21187,19 @@ function AWSStackSetProgressPanel({
           ))}
         </ul>
       ) : null}
+      {refreshError ? (
+        <p role="alert" className="idt-aws-setup-note">
+          {refreshError}
+        </p>
+      ) : null}
       {onRefresh ? (
         <div className="idt-source-actions">
           <button className="idt-btn idt-btn-secondary" type="button" onClick={onRefresh} disabled={refreshing}>
-            {refreshing ? 'Refreshing...' : 'Refresh StackSet status'}
+            {refreshing
+              ? 'Refreshing...'
+              : refreshError
+              ? 'Retry StackSet status'
+              : 'Refresh StackSet status'}
           </button>
         </div>
       ) : null}
@@ -21238,6 +21259,7 @@ export function ProductAWSConnectPage() {
   const [awsPreviewOpen, setAWSPreviewOpen] = useState(false);
   const [awsStackSetOnboarding, setAWSStackSetOnboarding] = useState<AWSStackSetOnboardingResult | null>(null);
   const [awsStackSetOnboardingLoading, setAWSStackSetOnboardingLoading] = useState(false);
+  const [awsStackSetOnboardingError, setAWSStackSetOnboardingError] = useState('');
   const connectionRequestRef = useRef(0);
   const baselineRequestRef = useRef(0);
   const awsStartRequestRef = useRef(0);
@@ -21451,6 +21473,7 @@ export function ProductAWSConnectPage() {
         scopeKeyRef.current !== requestScopeKey;
       const connectorID = normalizeValue(connectorIDOverride ?? activeConnectorIDRef.current);
       setAWSStackSetOnboardingLoading(true);
+      setAWSStackSetOnboardingError('');
       try {
         const response = await apiClient.getAWSProjectStackSetOnboarding(
           scope.workspaceID,
@@ -21464,11 +21487,13 @@ export function ProductAWSConnectPage() {
           return;
         }
         setAWSStackSetOnboarding(response.onboarding);
-      } catch {
+      } catch (error) {
         if (isStale()) {
           return;
         }
-        setAWSStackSetOnboarding(null);
+        // Preserve the last good payload so the panel keeps rendering; surface
+        // the failure inline so the operator can retry.
+        setAWSStackSetOnboardingError(formatAPIError(error, 'Unable to refresh StackSet onboarding.'));
       } finally {
         if (!isStale()) {
           setAWSStackSetOnboardingLoading(false);
@@ -21502,6 +21527,7 @@ export function ProductAWSConnectPage() {
     setAWSPreviewOpen(false);
     setAWSStackSetOnboarding(null);
     setAWSStackSetOnboardingLoading(false);
+    setAWSStackSetOnboardingError('');
     setAWSForm((current) => ({
       ...current,
       roleARN: '',
@@ -21685,6 +21711,27 @@ export function ProductAWSConnectPage() {
     setAWSCopiedField(field);
   };
 
+  const invalidatePreparedStackSet = () => {
+    // Once the operator edits any scope-contract field, the prepared start
+    // response no longer describes what the wizard would launch. Drop it so
+    // neither the launch button nor the sidebar can send them to the AWS
+    // console with the old targets baked into the launch URL.
+    setAWSCloudFormationStart((current) => {
+      if (
+        current &&
+        (current.deployment_method === 'stackset_service_managed' ||
+          current.deployment_method === 'stackset_self_managed')
+      ) {
+        return null;
+      }
+      return current;
+    });
+    setAWSStackSetOnboarding(null);
+    awsStackSetOnboardingRequestRef.current += 1;
+    setAWSStackSetOnboardingLoading(false);
+    setAWSStackSetOnboardingError('');
+  };
+
   const chooseAWSSetupMode = (mode: AWSSetupMode) => {
     const previousMode = awsSetupModeRef.current;
     awsSetupModeTouchedRef.current = true;
@@ -21720,6 +21767,7 @@ export function ProductAWSConnectPage() {
       awsStackSetOnboardingRequestRef.current += 1;
       setAWSStackSetOnboarding(null);
       setAWSStackSetOnboardingLoading(false);
+      setAWSStackSetOnboardingError('');
     }
     setAWSSetupMessage('');
     setErrorMessage('');
@@ -22435,26 +22483,32 @@ export function ProductAWSConnectPage() {
                   autoOnboardNewAccounts={awsForm.autoOnboardNewAccounts}
                   onChangeOrganizationRootID={(value) => {
                     awsScopeDirtyRef.current.organizationRootID = true;
+                    invalidatePreparedStackSet();
                     setAWSForm((current) => ({ ...current, organizationRootID: value }));
                   }}
                   onChangeRegions={(value) => {
                     awsScopeDirtyRef.current.targetRegions = true;
+                    invalidatePreparedStackSet();
                     setAWSForm((current) => ({ ...current, targetRegions: value }));
                   }}
                   onChangeOUIDs={(value) => {
                     awsScopeDirtyRef.current.targetOUIDs = true;
+                    invalidatePreparedStackSet();
                     setAWSForm((current) => ({ ...current, targetOUIDs: value }));
                   }}
                   onChangeAccountIDs={(value) => {
                     awsScopeDirtyRef.current.targetAccountIDs = true;
+                    invalidatePreparedStackSet();
                     setAWSForm((current) => ({ ...current, targetAccountIDs: value }));
                   }}
                   onChangeExcludedAccountIDs={(value) => {
                     awsScopeDirtyRef.current.excludedAccountIDs = true;
+                    invalidatePreparedStackSet();
                     setAWSForm((current) => ({ ...current, excludedAccountIDs: value }));
                   }}
                   onToggleAutoOnboard={(value) => {
                     awsScopeDirtyRef.current.autoOnboardNewAccounts = true;
+                    invalidatePreparedStackSet();
                     setAWSForm((current) => ({ ...current, autoOnboardNewAccounts: value }));
                   }}
                   onLaunch={handleAWSStackSetStart}
@@ -22668,6 +22722,7 @@ export function ProductAWSConnectPage() {
               <AWSStackSetProgressPanel
                 start={stackSetAWSStart}
                 persistedOnboarding={awsStackSetOnboarding}
+                refreshError={awsStackSetOnboardingError}
                 onRefresh={
                   activeConnectorID
                     ? () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -484,6 +484,141 @@ function awsScopeTypeFromMode(mode: AWSSetupMode): AWSConnectorScopeType {
   }
 }
 
+type AWSStackSetContractSnapshot = {
+  scopeType: AWSConnectorScopeType;
+  targetRegions: string[];
+  targetOUIDs: string[];
+  targetAccountIDs: string[];
+  excludedAccountIDs: string[];
+  autoOnboardNewAccounts: boolean;
+  stackSetName: string;
+};
+
+function buildStackSetContractSnapshot(
+  mode: AWSSetupMode,
+  values: {
+    organizationRootID: string;
+    targetRegions: string[];
+    targetOUIDs: string[];
+    targetAccountIDs: string[];
+    excludedAccountIDs: string[];
+    autoOnboardNewAccounts: boolean;
+    stackSetName: string;
+  }
+): AWSStackSetContractSnapshot {
+  const targetOUIDs = (() => {
+    if (mode === 'selected_ous') {
+      return values.targetOUIDs;
+    }
+    if (mode === 'organization' || mode === 'selected_accounts') {
+      return values.organizationRootID ? [values.organizationRootID] : [];
+    }
+    return [];
+  })();
+  const targetAccountIDs = mode === 'selected_accounts' ? values.targetAccountIDs : [];
+  const excludedAccountIDs = mode !== 'selected_accounts' ? values.excludedAccountIDs : [];
+  const autoOnboard = mode === 'organization' || mode === 'selected_ous' ? values.autoOnboardNewAccounts : false;
+  return {
+    scopeType: awsScopeTypeFromMode(mode),
+    targetRegions: [...values.targetRegions],
+    targetOUIDs: [...targetOUIDs],
+    targetAccountIDs: [...targetAccountIDs],
+    excludedAccountIDs: [...excludedAccountIDs],
+    autoOnboardNewAccounts: autoOnboard,
+    stackSetName: values.stackSetName
+  };
+}
+
+function normalizeContractForScope(
+  scopeType: AWSConnectorScopeType,
+  raw: {
+    targetRegions?: string[];
+    targetOUIDs?: string[];
+    targetAccountIDs?: string[];
+    excludedAccountIDs?: string[];
+    autoOnboardNewAccounts?: boolean;
+    stackSetName?: string;
+  }
+): AWSStackSetContractSnapshot {
+  const mode = awsSetupModeFromResponse(scopeType);
+  const rootIDs = (raw.targetOUIDs ?? []).filter((id) => AWS_ORG_ROOT_ID_PATTERN.test(id));
+  const ouIDs = (raw.targetOUIDs ?? []).filter((id) => AWS_OU_ID_PATTERN.test(id));
+  const targetOUIDs = (() => {
+    if (mode === 'selected_ous') {
+      return ouIDs;
+    }
+    if (mode === 'organization' || mode === 'selected_accounts') {
+      return rootIDs.length > 0 ? [rootIDs[0]] : [];
+    }
+    return [];
+  })();
+  const targetAccountIDs = mode === 'selected_accounts' ? [...(raw.targetAccountIDs ?? [])] : [];
+  const excludedAccountIDs = mode !== 'selected_accounts' ? [...(raw.excludedAccountIDs ?? [])] : [];
+  const autoOnboard =
+    mode === 'organization' || mode === 'selected_ous' ? Boolean(raw.autoOnboardNewAccounts) : false;
+  return {
+    scopeType,
+    targetRegions: [...(raw.targetRegions ?? [])],
+    targetOUIDs,
+    targetAccountIDs,
+    excludedAccountIDs,
+    autoOnboardNewAccounts: autoOnboard,
+    stackSetName: raw.stackSetName ?? ''
+  };
+}
+
+function contractFromStartResponse(start: AWSConnectorStartResponse): AWSStackSetContractSnapshot {
+  return normalizeContractForScope(start.scope_type, {
+    targetRegions: start.target_regions,
+    targetOUIDs: start.target_ou_ids,
+    targetAccountIDs: start.target_account_ids,
+    excludedAccountIDs: start.excluded_account_ids,
+    autoOnboardNewAccounts: start.auto_onboard_new_accounts,
+    stackSetName: start.stack_set_name
+  });
+}
+
+function contractFromConnection(connection: AWSConnectionStatus): AWSStackSetContractSnapshot {
+  return normalizeContractForScope(connection.scope_type ?? 'single_account', {
+    targetRegions: connection.target_regions,
+    targetOUIDs: connection.target_ou_ids,
+    targetAccountIDs: connection.target_account_ids,
+    excludedAccountIDs: connection.excluded_account_ids,
+    autoOnboardNewAccounts: connection.auto_onboard_new_accounts,
+    stackSetName: connection.stack_set_name
+  });
+}
+
+function sortedCopy(values: string[]): string[] {
+  return [...values].sort();
+}
+
+function stackSetContractsMatch(a: AWSStackSetContractSnapshot, b: AWSStackSetContractSnapshot): boolean {
+  if (a.scopeType !== b.scopeType) {
+    return false;
+  }
+  if (a.autoOnboardNewAccounts !== b.autoOnboardNewAccounts) {
+    return false;
+  }
+  if (a.stackSetName && b.stackSetName && a.stackSetName !== b.stackSetName) {
+    return false;
+  }
+  const stringSetsEqual = (left: string[], right: string[]) => {
+    if (left.length !== right.length) {
+      return false;
+    }
+    const l = sortedCopy(left);
+    const r = sortedCopy(right);
+    return l.every((value, index) => value === r[index]);
+  };
+  return (
+    stringSetsEqual(a.targetRegions, b.targetRegions) &&
+    stringSetsEqual(a.targetOUIDs, b.targetOUIDs) &&
+    stringSetsEqual(a.targetAccountIDs, b.targetAccountIDs) &&
+    stringSetsEqual(a.excludedAccountIDs, b.excludedAccountIDs)
+  );
+}
+
 const AWS_SCOPE_OPTION_LABELS: Record<AWSSetupMode, { title: string; kicker: string; blurb: string }> = {
   cloudformation: {
     kicker: 'Single account',
@@ -21462,6 +21597,23 @@ export function ProductAWSConnectPage() {
   const connectionScopeMode = connection?.scope_type
     ? awsSetupModeFromResponse(connection.scope_type)
     : null;
+  const parsedOrganizationRootID = normalizeValue(awsForm.organizationRootID);
+  const parsedTargetRegions = uniqueTokens(splitScopeTokens(awsForm.targetRegions));
+  const parsedTargetOUIDs = uniqueTokens(splitScopeTokens(awsForm.targetOUIDs));
+  const parsedTargetAccountIDs = uniqueTokens(splitScopeTokens(awsForm.targetAccountIDs));
+  const parsedExcludedAccountIDs = uniqueTokens(splitScopeTokens(awsForm.excludedAccountIDs));
+  const parsedStackSetName = normalizeValue(awsForm.stackSetName);
+  const desiredContract = isStackSetSetup
+    ? buildStackSetContractSnapshot(awsSetupMode, {
+        organizationRootID: parsedOrganizationRootID,
+        targetRegions: parsedTargetRegions,
+        targetOUIDs: parsedTargetOUIDs,
+        targetAccountIDs: parsedTargetAccountIDs,
+        excludedAccountIDs: parsedExcludedAccountIDs,
+        autoOnboardNewAccounts: awsForm.autoOnboardNewAccounts,
+        stackSetName: parsedStackSetName
+      })
+    : null;
   const activeConnectorID = (() => {
     if (isManualSetup) {
       return (
@@ -21470,17 +21622,19 @@ export function ProductAWSConnectPage() {
         ''
       );
     }
-    if (isStackSetSetup) {
+    if (isStackSetSetup && desiredContract) {
       if (
         stackSetAWSStart?.connector_id &&
-        awsSetupModeFromResponse(stackSetAWSStart.scope_type) === awsSetupMode
+        awsSetupModeFromResponse(stackSetAWSStart.scope_type) === awsSetupMode &&
+        stackSetContractsMatch(desiredContract, contractFromStartResponse(stackSetAWSStart))
       ) {
         return stackSetAWSStart.connector_id;
       }
       if (
         connection?.deployment_method?.startsWith('stackset_') &&
         connectionScopeMode === awsSetupMode &&
-        connection.connector_id
+        connection.connector_id &&
+        stackSetContractsMatch(desiredContract, contractFromConnection(connection))
       ) {
         return connection.connector_id;
       }
@@ -21519,7 +21673,14 @@ export function ProductAWSConnectPage() {
     setAWSSetupMode(mode);
     const preparedScopeType = awsCloudFormationStart?.scope_type;
     const preparedMode: AWSSetupMode | null = preparedScopeType ? awsSetupModeFromResponse(preparedScopeType) : null;
+    const connectionMode: AWSSetupMode | null = connection?.scope_type
+      ? awsSetupModeFromResponse(connection.scope_type)
+      : null;
     const switchingAcrossPreparedSetup = preparedMode !== null && preparedMode !== mode;
+    const switchingAcrossPersistedStackSet =
+      Boolean(connection?.deployment_method?.startsWith('stackset_')) &&
+      connectionMode !== null &&
+      connectionMode !== mode;
     if (previousMode !== mode) {
       awsStartRequestRef.current += 1;
       setSubmitting(false);
@@ -21529,13 +21690,17 @@ export function ProductAWSConnectPage() {
       setAWSPermissionPreview([]);
       setAWSPermissionTiers([]);
       setAWSPreviewOpen(false);
-      setAWSStackSetOnboarding(null);
       setAWSForm((current) => ({
         ...current,
         roleARN: '',
         externalID: '',
         sessionName: 'identrail-connector-validation'
       }));
+    }
+    if (switchingAcrossPreparedSetup || switchingAcrossPersistedStackSet) {
+      awsStackSetOnboardingRequestRef.current += 1;
+      setAWSStackSetOnboarding(null);
+      setAWSStackSetOnboardingLoading(false);
     }
     setAWSSetupMessage('');
     setErrorMessage('');
@@ -21676,12 +21841,6 @@ export function ProductAWSConnectPage() {
       }
     }
   };
-
-  const parsedOrganizationRootID = normalizeValue(awsForm.organizationRootID);
-  const parsedTargetRegions = uniqueTokens(splitScopeTokens(awsForm.targetRegions));
-  const parsedTargetOUIDs = uniqueTokens(splitScopeTokens(awsForm.targetOUIDs));
-  const parsedTargetAccountIDs = uniqueTokens(splitScopeTokens(awsForm.targetAccountIDs));
-  const parsedExcludedAccountIDs = uniqueTokens(splitScopeTokens(awsForm.excludedAccountIDs));
 
   const validateStackSetTargets = (mode: AWSSetupMode): string => {
     if (parsedTargetRegions.length === 0) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -21108,6 +21108,7 @@ export function ProductAWSConnectPage() {
   const awsStackSetOnboardingRequestRef = useRef(0);
   const awsSetupModeTouchedRef = useRef(false);
   const awsSetupModeRef = useRef<AWSSetupMode>('cloudformation');
+  const activeConnectorIDRef = useRef('');
   const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
   const scopeKey = scope ? `${scope.tenantID}::${scope.workspaceID}` : '';
   const scopeKeyRef = useRef(scopeKey);
@@ -21290,44 +21291,48 @@ export function ProductAWSConnectPage() {
     }
   }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, awsCloudFormationStart?.connector_id, connection?.connector_id]);
 
-  const refreshStackSetOnboarding = useCallback(async () => {
-    const requestID = ++awsStackSetOnboardingRequestRef.current;
-    const requestEnvironmentID = selectedEnvironmentID;
-    const requestScopeKey = scopeKeyRef.current;
-    if (!scope || !requestEnvironmentID) {
-      setAWSStackSetOnboarding(null);
-      setAWSStackSetOnboardingLoading(false);
-      return;
-    }
-    const isStale = () =>
-      requestID !== awsStackSetOnboardingRequestRef.current ||
-      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
-      scopeKeyRef.current !== requestScopeKey;
-    setAWSStackSetOnboardingLoading(true);
-    try {
-      const response = await apiClient.getAWSProjectStackSetOnboarding(
-        scope.workspaceID,
-        requestEnvironmentID,
-        undefined,
-        undefined,
-        undefined,
-        buildProductAuthContext(scope)
-      );
-      if (isStale()) {
-        return;
-      }
-      setAWSStackSetOnboarding(response.onboarding);
-    } catch {
-      if (isStale()) {
-        return;
-      }
-      setAWSStackSetOnboarding(null);
-    } finally {
-      if (!isStale()) {
+  const refreshStackSetOnboarding = useCallback(
+    async (connectorIDOverride?: string) => {
+      const requestID = ++awsStackSetOnboardingRequestRef.current;
+      const requestEnvironmentID = selectedEnvironmentID;
+      const requestScopeKey = scopeKeyRef.current;
+      if (!scope || !requestEnvironmentID) {
+        setAWSStackSetOnboarding(null);
         setAWSStackSetOnboardingLoading(false);
+        return;
       }
-    }
-  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+      const isStale = () =>
+        requestID !== awsStackSetOnboardingRequestRef.current ||
+        selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+        scopeKeyRef.current !== requestScopeKey;
+      const connectorID = normalizeValue(connectorIDOverride ?? activeConnectorIDRef.current);
+      setAWSStackSetOnboardingLoading(true);
+      try {
+        const response = await apiClient.getAWSProjectStackSetOnboarding(
+          scope.workspaceID,
+          requestEnvironmentID,
+          connectorID || undefined,
+          undefined,
+          undefined,
+          buildProductAuthContext(scope)
+        );
+        if (isStale()) {
+          return;
+        }
+        setAWSStackSetOnboarding(response.onboarding);
+      } catch {
+        if (isStale()) {
+          return;
+        }
+        setAWSStackSetOnboarding(null);
+      } finally {
+        if (!isStale()) {
+          setAWSStackSetOnboardingLoading(false);
+        }
+      }
+    },
+    [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]
+  );
 
 
   useEffect(() => {
@@ -21394,7 +21399,7 @@ export function ProductAWSConnectPage() {
       connectorScope === 'selected_ous' ||
       connectorScope === 'selected_accounts';
     if (isStackSetConnector && connection?.connector_id) {
-      void refreshStackSetOnboarding();
+      void refreshStackSetOnboarding(connection.connector_id);
     }
   }, [connection?.connector_id, connection?.scope_type, refreshStackSetOnboarding]);
 
@@ -21449,15 +21454,40 @@ export function ProductAWSConnectPage() {
     awsSetupMode === 'selected_ous' ||
     awsSetupMode === 'selected_accounts' ||
     Boolean(stackSetAWSStart);
-  const activeConnectorID = isManualSetup
-    ? manualAWSStart?.connector_id ?? (connection?.deployment_method === 'manual' ? connection.connector_id : '') ?? ''
-    : isStackSetSetup
-    ? stackSetAWSStart?.connector_id ??
-      (connection?.deployment_method?.startsWith('stackset_') ? connection.connector_id : '') ??
-      ''
-    : cloudFormationAWSStart?.connector_id ??
+  const connectionScopeMode = connection?.scope_type
+    ? awsSetupModeFromResponse(connection.scope_type)
+    : null;
+  const activeConnectorID = (() => {
+    if (isManualSetup) {
+      return (
+        manualAWSStart?.connector_id ??
+        (connection?.deployment_method === 'manual' ? connection.connector_id : '') ??
+        ''
+      );
+    }
+    if (isStackSetSetup) {
+      if (
+        stackSetAWSStart?.connector_id &&
+        awsSetupModeFromResponse(stackSetAWSStart.scope_type) === awsSetupMode
+      ) {
+        return stackSetAWSStart.connector_id;
+      }
+      if (
+        connection?.deployment_method?.startsWith('stackset_') &&
+        connectionScopeMode === awsSetupMode &&
+        connection.connector_id
+      ) {
+        return connection.connector_id;
+      }
+      return '';
+    }
+    return (
+      cloudFormationAWSStart?.connector_id ??
       (connection?.deployment_method === 'cloudformation' ? connection?.connector_id : '') ??
-      '';
+      ''
+    );
+  })();
+  activeConnectorIDRef.current = activeConnectorID;
   const canValidateRole = Boolean(normalizeValue(awsForm.roleARN)) && (!isManualSetup || Boolean(activeConnectorID));
   const selectedAWSRegion = normalizeValue(awsForm.region) || 'us-east-1';
   const manualExternalID = normalizeValue(awsForm.externalID);
@@ -21494,6 +21524,7 @@ export function ProductAWSConnectPage() {
       setAWSPermissionPreview([]);
       setAWSPermissionTiers([]);
       setAWSPreviewOpen(false);
+      setAWSStackSetOnboarding(null);
       setAWSForm((current) => ({
         ...current,
         roleARN: '',
@@ -21803,8 +21834,8 @@ export function ProductAWSConnectPage() {
       setSuccessMessage('AWS StackSet setup is ready. Open the StackSet in AWS, then refresh status.');
       if (response.stackset_onboarding) {
         setAWSStackSetOnboarding(response.stackset_onboarding);
-      } else {
-        void refreshStackSetOnboarding();
+      } else if (response.connector_id) {
+        void refreshStackSetOnboarding(response.connector_id);
       }
       if (response.launch_url && typeof window !== 'undefined' && !/jsdom/i.test(window.navigator.userAgent)) {
         window.open(response.launch_url, '_blank', 'noopener,noreferrer');

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -22247,13 +22247,17 @@ export function ProductAWSConnectPage() {
     }
     return bits.join(' · ');
   })();
-  // Only surface the persisted connection's launch URL when its deployment
-  // method matches the currently selected setup mode; otherwise a leftover
-  // StackSet console link can render under Single account or Existing IAM role
-  // and send the operator back to the previous scope.
+  // Only surface the persisted connection's launch URL when both the
+  // deployment method and the scope type match the currently selected setup
+  // mode. Otherwise a leftover StackSet console link can render under a
+  // different scope (Single account, Existing IAM role, or another StackSet
+  // scope) and send the operator back to the previous scope's targets.
   const persistedLaunchURLMatchesMode = (() => {
     const method = connection?.deployment_method;
     if (!method || !connection?.launch_url) {
+      return false;
+    }
+    if (connectionScopeMode !== awsSetupMode) {
       return false;
     }
     if (isStackSetSetup) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -589,10 +589,6 @@ function contractFromConnection(connection: AWSConnectionStatus): AWSStackSetCon
   });
 }
 
-function sortedCopy(values: string[]): string[] {
-  return [...values].sort();
-}
-
 function stackSetContractsMatch(a: AWSStackSetContractSnapshot, b: AWSStackSetContractSnapshot): boolean {
   if (a.scopeType !== b.scopeType) {
     return false;
@@ -603,19 +599,19 @@ function stackSetContractsMatch(a: AWSStackSetContractSnapshot, b: AWSStackSetCo
   if (a.stackSetName && b.stackSetName && a.stackSetName !== b.stackSetName) {
     return false;
   }
-  const stringSetsEqual = (left: string[], right: string[]) => {
+  // Backend awsConnectorSetupContractsMatch uses order-sensitive slices.Equal;
+  // reordering regions in particular changes the StackSet home region.
+  const stringListsEqual = (left: string[], right: string[]) => {
     if (left.length !== right.length) {
       return false;
     }
-    const l = sortedCopy(left);
-    const r = sortedCopy(right);
-    return l.every((value, index) => value === r[index]);
+    return left.every((value, index) => value === right[index]);
   };
   return (
-    stringSetsEqual(a.targetRegions, b.targetRegions) &&
-    stringSetsEqual(a.targetOUIDs, b.targetOUIDs) &&
-    stringSetsEqual(a.targetAccountIDs, b.targetAccountIDs) &&
-    stringSetsEqual(a.excludedAccountIDs, b.excludedAccountIDs)
+    stringListsEqual(a.targetRegions, b.targetRegions) &&
+    stringListsEqual(a.targetOUIDs, b.targetOUIDs) &&
+    stringListsEqual(a.targetAccountIDs, b.targetAccountIDs) &&
+    stringListsEqual(a.excludedAccountIDs, b.excludedAccountIDs)
   );
 }
 
@@ -646,6 +642,11 @@ const AWS_SCOPE_OPTION_LABELS: Record<AWSSetupMode, { title: string; kicker: str
     blurb: 'Use your change process'
   }
 };
+
+function awsRoleNameFromARN(roleARN: string): string {
+  const match = normalizeValue(roleARN).match(/^arn:(?:aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role\/(.+)$/);
+  return match ? match[1] : '';
+}
 
 function awsPartitionForManualTrustPolicy(roleARN: string, region: string): AWSPartition {
   const arnPartition = normalizeValue(roleARN).match(/^arn:(aws|aws-us-gov|aws-cn):iam::/)?.[1] as AWSPartition | undefined;
@@ -21228,7 +21229,8 @@ export function ProductAWSConnectPage() {
     targetAccountIDs: false,
     excludedAccountIDs: false,
     autoOnboardNewAccounts: false,
-    stackSetName: false
+    stackSetName: false,
+    roleName: false
   });
   const [awsCloudFormationStart, setAWSCloudFormationStart] = useState<AWSConnectorStartResponse | null>(null);
   const [awsPermissionPreview, setAWSPermissionPreview] = useState<AWSPermissionPreviewItem[]>([]);
@@ -21334,7 +21336,10 @@ export function ProductAWSConnectPage() {
             : current.autoOnboardNewAccounts,
           stackSetName: dirty.stackSetName
             ? current.stackSetName
-            : response.connection.stack_set_name || current.stackSetName
+            : response.connection.stack_set_name || current.stackSetName,
+          roleName: dirty.roleName
+            ? current.roleName
+            : awsRoleNameFromARN(response.connection.role_arn ?? '') || current.roleName
         }));
       } catch (error) {
         if (isStale()) {
@@ -21518,7 +21523,8 @@ export function ProductAWSConnectPage() {
       targetAccountIDs: false,
       excludedAccountIDs: false,
       autoOnboardNewAccounts: false,
-      stackSetName: false
+      stackSetName: false,
+      roleName: false
     };
     void refreshConnection('initial');
     void refreshBaseline();
@@ -21538,10 +21544,23 @@ export function ProductAWSConnectPage() {
       connectorScope === 'organization' ||
       connectorScope === 'selected_ous' ||
       connectorScope === 'selected_accounts';
-    if (isStackSetConnector && connection?.connector_id) {
-      void refreshStackSetOnboarding(connection.connector_id);
+    if (!isStackSetConnector || !connection?.connector_id) {
+      return;
     }
-  }, [connection?.connector_id, connection?.scope_type, refreshStackSetOnboarding]);
+    // Only refetch when the currently-selected wizard mode matches the
+    // persisted connector's scope. That way switching away and back restores
+    // the panel instead of leaving it blank until a page reload.
+    const connectorMode = awsSetupModeFromResponse(connectorScope);
+    if (connectorMode !== awsSetupMode) {
+      return;
+    }
+    void refreshStackSetOnboarding(connection.connector_id);
+  }, [
+    connection?.connector_id,
+    connection?.scope_type,
+    awsSetupMode,
+    refreshStackSetOnboarding
+  ]);
 
   if (!scope) {
     return (
@@ -21976,6 +21995,7 @@ export function ProductAWSConnectPage() {
         region: current.region || response.connection.region || 'us-east-1',
         displayName: current.displayName || response.connection.display_name || '',
         stackSetName: response.stack_set_name || current.stackSetName,
+        roleName: response.role_name || current.roleName,
         organizationRootID: responseRoot ?? current.organizationRootID,
         targetRegions:
           response.target_regions && response.target_regions.length > 0
@@ -22179,7 +22199,26 @@ export function ProductAWSConnectPage() {
     }
     return bits.join(' · ');
   })();
-  const launchURL = cloudFormationAWSStart?.launch_url ?? connection?.launch_url ?? '';
+  // Only surface the persisted connection's launch URL when its deployment
+  // method matches the currently selected setup mode; otherwise a leftover
+  // StackSet console link can render under Single account or Existing IAM role
+  // and send the operator back to the previous scope.
+  const persistedLaunchURLMatchesMode = (() => {
+    const method = connection?.deployment_method;
+    if (!method || !connection?.launch_url) {
+      return false;
+    }
+    if (isStackSetSetup) {
+      return method.startsWith('stackset_');
+    }
+    if (isManualSetup) {
+      return method === 'manual';
+    }
+    return method === 'cloudformation';
+  })();
+  const launchURL =
+    cloudFormationAWSStart?.launch_url ??
+    (persistedLaunchURLMatchesMode ? connection?.launch_url ?? '' : '');
   const hasConnectorSetup = Boolean(awsCloudFormationStart || connection?.connector_id);
   const hasRoleOnlyConnection = Boolean(connection?.role_arn && !connection?.connector_id && !awsCloudFormationStart);
   const showOperationalPanels = Boolean(

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -486,6 +486,7 @@ function awsScopeTypeFromMode(mode: AWSSetupMode): AWSConnectorScopeType {
 
 type AWSStackSetContractSnapshot = {
   scopeType: AWSConnectorScopeType;
+  deploymentMethod: AWSConnectorDeploymentMethod;
   targetRegions: string[];
   targetOUIDs: string[];
   targetAccountIDs: string[];
@@ -520,6 +521,8 @@ function buildStackSetContractSnapshot(
   const autoOnboard = mode === 'organization' || mode === 'selected_ous' ? values.autoOnboardNewAccounts : false;
   return {
     scopeType: awsScopeTypeFromMode(mode),
+    // The wizard only issues service-managed StackSet starts today.
+    deploymentMethod: 'stackset_service_managed',
     targetRegions: [...values.targetRegions],
     targetOUIDs: [...targetOUIDs],
     targetAccountIDs: [...targetAccountIDs],
@@ -531,6 +534,7 @@ function buildStackSetContractSnapshot(
 
 function normalizeContractForScope(
   scopeType: AWSConnectorScopeType,
+  deploymentMethod: AWSConnectorDeploymentMethod,
   raw: {
     targetRegions?: string[];
     targetOUIDs?: string[];
@@ -558,6 +562,7 @@ function normalizeContractForScope(
     mode === 'organization' || mode === 'selected_ous' ? Boolean(raw.autoOnboardNewAccounts) : false;
   return {
     scopeType,
+    deploymentMethod,
     targetRegions: [...(raw.targetRegions ?? [])],
     targetOUIDs,
     targetAccountIDs,
@@ -568,7 +573,7 @@ function normalizeContractForScope(
 }
 
 function contractFromStartResponse(start: AWSConnectorStartResponse): AWSStackSetContractSnapshot {
-  return normalizeContractForScope(start.scope_type, {
+  return normalizeContractForScope(start.scope_type, start.deployment_method, {
     targetRegions: start.target_regions,
     targetOUIDs: start.target_ou_ids,
     targetAccountIDs: start.target_account_ids,
@@ -579,18 +584,28 @@ function contractFromStartResponse(start: AWSConnectorStartResponse): AWSStackSe
 }
 
 function contractFromConnection(connection: AWSConnectionStatus): AWSStackSetContractSnapshot {
-  return normalizeContractForScope(connection.scope_type ?? 'single_account', {
-    targetRegions: connection.target_regions,
-    targetOUIDs: connection.target_ou_ids,
-    targetAccountIDs: connection.target_account_ids,
-    excludedAccountIDs: connection.excluded_account_ids,
-    autoOnboardNewAccounts: connection.auto_onboard_new_accounts,
-    stackSetName: connection.stack_set_name
-  });
+  return normalizeContractForScope(
+    connection.scope_type ?? 'single_account',
+    connection.deployment_method ?? 'cloudformation',
+    {
+      targetRegions: connection.target_regions,
+      targetOUIDs: connection.target_ou_ids,
+      targetAccountIDs: connection.target_account_ids,
+      excludedAccountIDs: connection.excluded_account_ids,
+      autoOnboardNewAccounts: connection.auto_onboard_new_accounts,
+      stackSetName: connection.stack_set_name
+    }
+  );
 }
 
 function stackSetContractsMatch(a: AWSStackSetContractSnapshot, b: AWSStackSetContractSnapshot): boolean {
   if (a.scopeType !== b.scopeType) {
+    return false;
+  }
+  if (a.deploymentMethod !== b.deploymentMethod) {
+    // resumeAWSStackSetConnectorStart compares deployment_method exactly, so
+    // a self-managed persisted connector is not resumable from a
+    // service-managed wizard start (or vice versa).
     return false;
   }
   if (a.autoOnboardNewAccounts !== b.autoOnboardNewAccounts) {
@@ -20754,6 +20769,7 @@ type AWSStackSetScopeStepProps = {
   parsedAccounts: string[];
   parsedExcludedAccounts: string[];
   setupMessage: string;
+  persistedSelfManagedUnsupported: boolean;
 };
 
 function AWSStackSetScopeStep(props: AWSStackSetScopeStepProps) {
@@ -20781,7 +20797,8 @@ function AWSStackSetScopeStep(props: AWSStackSetScopeStepProps) {
     parsedOUs,
     parsedAccounts,
     parsedExcludedAccounts,
-    setupMessage
+    setupMessage,
+    persistedSelfManagedUnsupported
   } = props;
   const isOrganization = mode === 'organization';
   const isSelectedOUs = mode === 'selected_ous';
@@ -20993,16 +21010,26 @@ function AWSStackSetScopeStep(props: AWSStackSetScopeStepProps) {
           </p>
         ) : null}
 
+        {persistedSelfManagedUnsupported ? (
+          <p role="alert" className="idt-aws-setup-note">
+            This connector uses a self-managed StackSet, which the wizard does
+            not currently support relaunching. Update it through the API,
+            Terraform, or the AWS CloudFormation console. The wizard would
+            otherwise resubmit as service-managed and the backend would reject
+            the resume.
+          </p>
+        ) : null}
+
         <div className="idt-source-actions">
           <button
             className="idt-btn idt-btn-primary"
             type="button"
             onClick={onLaunch}
-            disabled={!canSubmit || blockingCount > 0}
+            disabled={!canSubmit || blockingCount > 0 || persistedSelfManagedUnsupported}
           >
             {launchLabel}
           </button>
-          {start?.launch_url && blockingCount === 0 ? (
+          {start?.launch_url && blockingCount === 0 && !persistedSelfManagedUnsupported ? (
             <a className="idt-btn idt-btn-dark" href={start.launch_url} target="_blank" rel="noreferrer">
               <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
               <span>Open StackSet in AWS</span>
@@ -22314,6 +22341,16 @@ export function ProductAWSConnectPage() {
     const preferred = stackSetAWSStart?.prerequisites ?? connection?.prerequisites ?? [];
     return preferred.filter((prereq) => !prereq.satisfied && prereq.severity === 'blocking').length;
   })();
+  // The wizard only issues service-managed StackSet starts. A persisted
+  // self-managed connector (created via API/Terraform) whose scope maps into
+  // the same wizard mode would otherwise be resumed as service-managed, which
+  // resumeAWSStackSetConnectorStart rejects (deployment_method must match
+  // exactly). Detect it and block the launch surface with a clear message.
+  const isPersistedSelfManagedStackSet =
+    isStackSetSetup &&
+    connectionScopeMode === awsSetupMode &&
+    connection?.deployment_method === 'stackset_self_managed' &&
+    !stackSetAWSStart;
   // Only surface the persisted connection's launch URL when both the
   // deployment method and the scope type match the currently selected setup
   // mode. Otherwise a leftover StackSet console link can render under a
@@ -22374,6 +22411,9 @@ export function ProductAWSConnectPage() {
     }
     if (isManualSetup && manualExternalID && !connectedNow) {
       return 'Add the trust policy in AWS, paste the role ARN, then validate the role.';
+    }
+    if (isPersistedSelfManagedStackSet) {
+      return 'This connector uses a self-managed StackSet. Manage it through the API, Terraform, or the AWS console — the wizard cannot relaunch self-managed setups.';
     }
     if (isStackSetSetup && stackSetAWSStart?.launch_url && stackSetBlockingPrereqCount === 0) {
       return 'Open the StackSet in AWS to deploy the read-only role, then refresh status.';
@@ -22597,6 +22637,7 @@ export function ProductAWSConnectPage() {
                   parsedAccounts={parsedTargetAccountIDs}
                   parsedExcludedAccounts={parsedExcludedAccountIDs}
                   setupMessage={awsSetupMessage}
+                  persistedSelfManagedUnsupported={isPersistedSelfManagedStackSet}
                 />
               ) : !isManualSetup ? (
                 <div className="idt-aws-wizard-step">

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -21692,11 +21692,17 @@ export function ProductAWSConnectPage() {
       }
       return '';
     }
-    return (
-      cloudFormationAWSStart?.connector_id ??
-      (connection?.deployment_method === 'cloudformation' ? connection?.connector_id : '') ??
-      ''
-    );
+    // Single-account mode covers CloudFormation and Terraform deployment
+    // methods (both map back to scope_type=single_account via
+    // awsSetupModeFromResponse). Restricting the fallback to
+    // deployment_method==='cloudformation' would hide the Refresh/Validate
+    // actions for a persisted Terraform connector.
+    const singleAccountConnectionID =
+      connection?.deployment_method === 'cloudformation' ||
+      connection?.deployment_method === 'terraform'
+        ? connection?.connector_id
+        : '';
+    return cloudFormationAWSStart?.connector_id ?? singleAccountConnectionID ?? '';
   })();
   activeConnectorIDRef.current = activeConnectorID;
   const canValidateRole = Boolean(normalizeValue(awsForm.roleARN)) && (!isManualSetup || Boolean(activeConnectorID));

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -24191,6 +24191,316 @@ html[data-theme='light'] .idt-app-shell-screen select {
   min-width: 0;
 }
 
+.idt-aws-scope-subtoggle {
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.2rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 999px;
+  background: #050505;
+}
+
+.idt-aws-scope-subtoggle-option {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  background: transparent;
+  color: var(--app-muted);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  font-size: 0.82rem;
+}
+
+.idt-aws-scope-subtoggle-option.is-selected {
+  background: rgba(126, 105, 255, 0.24);
+  color: #ffffff;
+}
+
+.idt-aws-scope-fields {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.idt-aws-scope-fields label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.idt-aws-scope-fields textarea,
+.idt-aws-scope-fields input {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.55rem 0.65rem;
+  background: #050505;
+  color: #ffffff;
+  font: inherit;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-scope-fields textarea {
+  min-height: 3rem;
+  resize: vertical;
+  font: 0.82rem/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.idt-aws-scope-hint {
+  color: var(--app-muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.idt-aws-scope-toggle {
+  display: grid;
+  grid-template-columns: 1.15rem minmax(0, 1fr);
+  align-items: start;
+  gap: 0.55rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.65rem 0.72rem;
+  background: #050505;
+}
+
+.idt-aws-scope-toggle input {
+  margin-top: 0.15rem;
+}
+
+.idt-aws-scope-toggle span {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.idt-aws-scope-toggle strong {
+  color: #ffffff;
+  font-size: 0.9rem;
+}
+
+.idt-aws-scope-toggle small {
+  color: var(--app-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.idt-aws-scope-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.idt-aws-scope-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 999px;
+  padding: 0.24rem 0.6rem;
+  background: #050505;
+  color: #ffffff;
+  font-size: 0.76rem;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-scope-chip.is-region {
+  color: #b6c3ff;
+}
+
+.idt-aws-scope-chip.is-excluded {
+  border-color: rgba(255, 90, 90, 0.5);
+  color: #ffb0b0;
+}
+
+.idt-aws-prereq-list {
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.idt-aws-prereq {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: baseline;
+  gap: 0.35rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.6rem 0.7rem;
+  background: #050505;
+}
+
+.idt-aws-prereq p {
+  grid-column: 1 / -1;
+  margin: 0.15rem 0 0;
+  color: var(--app-muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.idt-aws-prereq strong {
+  color: #ffffff;
+}
+
+.idt-aws-prereq > span {
+  color: var(--app-muted);
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.idt-aws-prereq.is-ok {
+  border-color: rgba(88, 214, 141, 0.36);
+}
+
+.idt-aws-prereq.is-ok > span {
+  color: #6ee7a0;
+}
+
+.idt-aws-prereq.is-blocking {
+  border-color: rgba(255, 90, 90, 0.4);
+}
+
+.idt-aws-prereq.is-blocking > span {
+  color: #ff9c9c;
+}
+
+.idt-aws-prereq.is-advisory {
+  border-color: rgba(255, 153, 0, 0.35);
+}
+
+.idt-aws-prereq.is-advisory > span {
+  color: #ffd08a;
+}
+
+.idt-aws-stackset-progress {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 10px;
+  padding: 0.9rem;
+  background: #050505;
+}
+
+.idt-aws-stackset-progress-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.idt-aws-stackset-progress-header h3 {
+  margin: 0.1rem 0 0;
+  color: #ffffff;
+}
+
+.idt-aws-stackset-progress-header p {
+  margin: 0.15rem 0 0;
+  color: var(--app-muted);
+  font-size: 0.85rem;
+}
+
+.idt-aws-stackset-progress-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.idt-aws-stackset-progress-grid div {
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.55rem 0.65rem;
+  background: #050505;
+}
+
+.idt-aws-stackset-progress-grid dt {
+  color: var(--app-dim);
+  font-size: 0.7rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-aws-stackset-progress-grid dd {
+  margin: 0.15rem 0 0;
+  color: #ffffff;
+  font-size: 0.98rem;
+  font-weight: 900;
+}
+
+.idt-aws-stackset-coverage-line {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.idt-aws-stackset-instances-wrap {
+  overflow-x: auto;
+}
+
+.idt-aws-stackset-instances {
+  width: 100%;
+  min-width: 30rem;
+  border-collapse: collapse;
+}
+
+.idt-aws-stackset-instances th,
+.idt-aws-stackset-instances td {
+  border-bottom: 1px solid var(--app-border-soft);
+  padding: 0.5rem 0.55rem;
+  text-align: left;
+  vertical-align: top;
+  font-size: 0.85rem;
+}
+
+.idt-aws-stackset-instances th {
+  color: var(--app-dim);
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-aws-stackset-instances td strong {
+  color: #ffffff;
+}
+
+.idt-aws-stackset-instances td small {
+  display: block;
+  color: var(--app-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.idt-aws-stackset-instances td p {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.idt-aws-stackset-failure {
+  margin-top: 0.25rem !important;
+  color: #ff9c9c !important;
+}
+
+.idt-aws-stackset-empty {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.85rem;
+}
+
+.idt-aws-stackset-recovery-targets {
+  margin: 0.25rem 0 0;
+  color: var(--app-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
 .idt-aws-summary-actions {
   align-items: stretch;
 }
@@ -24832,6 +25142,22 @@ html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge
     height: 1.8rem;
   }
 
+  .idt-aws-stackset-progress-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .idt-aws-prereq {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-aws-prereq > span {
+    justify-self: start;
+  }
+
+  .idt-aws-stackset-progress-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }
 
 .idt-visually-hidden {


### PR DESCRIPTION
Resolves #1753

## Summary

Extends the scope-first Connect AWS wizard (from #1750) with the AWS
Organization, Selected OUs, and Selected accounts paths powered by the
service-managed StackSet backend (from #1752). The wizard now covers every
scope the API supports without asking operators to hand-edit request
payloads.

## Why

Large teams cannot onboard by pasting one role ARN per account. This is
the UI companion of the backend added in #1768 (issue #1752): a
scope-first flow that lets operators pick target regions, OUs, accounts,
and exclusions, launch a service-managed StackSet, and see per-instance
progress without wading through backend diagnostics.

## Scope

- [x] Focused change (Connect AWS wizard only)
- [x] Backward compatibility considered (single-account and manual paths unchanged)
- [x] Risk level assessed (UI-only)

Implemented in `web/src/productShell.tsx` and `web/src/styles.css`:

- New scope options for `organization`, `selected_ous`, and
  `selected_accounts`; the Selected scope tile exposes an OUs / Accounts
  sub-toggle inside the step.
- Target region, OU, account, and exclusion inputs feed
  `POST /v1/connectors/aws`. `auto_onboard_new_accounts` is exposed for
  organization and selected-OU deployments and forced off for selected
  accounts (matching the backend guard).
- Prerequisite list shows blocking vs advisory items; blocking items
  disable the launch button.
- New `AWSStackSetProgressPanel` renders pending / active / degraded /
  failed / permission-denied / resumable counts, coverage expectation,
  per-instance state, failure reasons, and recovery actions returned in
  `stackset_onboarding`.
- Client-side validation rejects empty regions/targets and malformed
  region codes, OU IDs, or account IDs before the API call. Errors surface
  in the existing setup-note area.
- Stale start guard: switching environments while a StackSet start is in
  flight drops the response so it never bleeds into the new environment.
- Setup summary card and Open StackSet link reflect StackSet state
  alongside the existing CloudFormation flow.
- Docs (`docs/aws-stackset-onboarding.md`) get a Connect AWS wizard
  section with troubleshooting entries. `CHANGELOG.md` records the change.

## Validation

```bash
npx --prefix web vitest run web/src/productShell.test.tsx
npx --prefix web vitest run
npm --prefix web run build
```

Results:
- `productShell.test.tsx`: 238 passed (6 new tests cover the organization
  launch, selected OUs launch, selected accounts launch, empty-target
  validation, blocking prerequisite gating, and stale-environment guard).
- Full web vitest suite: 536 passed / 0 failed.
- Web build succeeded, prerendered 40 routes.

The dev server was launched but the app requires an authenticated
backend session for the Connect AWS page to render, so browser
verification was limited to test coverage above.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: reviewed issue scope and backend contract
  from #1768/#1752; ran `vitest` for the product shell tests, the full
  web vitest suite, and `npm --prefix web run build` to confirm the
  prerendered bundle still ships.

## Related Issues

Resolves #1753

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS Organization and Selected OUs/Accounts onboarding to the Connect AWS wizard using service‑managed StackSets so teams can target regions/OUs/accounts, auto‑onboard, and monitor per‑instance progress without hand‑editing requests (addresses #1753).

- **New Features**
  - Scope options: Organization, Selected OUs, Selected accounts with an OUs/Accounts sub‑toggle.
  - Inputs for regions, OU/root IDs, account IDs, and exclusions; auto‑onboard is on for org/selected‑OUs and off for selected accounts; client‑side validation blocks empty/malformed targets.
  - StackSet progress panel with counts, per‑instance state, coverage expectation, and recovery actions; launch region derives from the first target region; StackSet name hydrates and preserves edits; blocking prerequisites disable Launch and hide the console link/auto‑open.

- **Bug Fixes**
  - Safe resume and edits: in‑flight starts cancel on edits/scope switch; stale prepared launches are invalidated; a prepared/connected StackSet is reused only when the full contract matches (scope, regions order‑sensitive, OUs/accounts/exclusions sorted).
  - Correct progress/links: refresh and polling are pinned to the active connector and selected scope; prefer the connector start snapshot and keep the last good payload on refresh errors; console link only appears when deployment method and scope match; non‑StackSet connectors never fetch onboarding.
  - Field handling: role/StackSet names hydrate with dirty‑bit protection; resume omits names unless edited; Selected accounts never send `excluded_account_ids`; environment switch resets names; single‑account Terraform connectors keep `connector_id` for Refresh/Validate.
  - Self‑managed guard: detect persisted `stackset_self_managed` selected‑account connectors and block launch/resume; reject service‑vs‑self‑managed resume; hide the persisted launch URL and show an inline alert.

<sup>Written for commit 914cac14e1b563a458ba5cbf44d7b2d4b9bd6fdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

