### PR TITLE
Add AWS guided repair diagnostics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -151,6 +151,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS session policy recommendation path: `aws-session-policy-recommendation.md`
 - AWS SQS/SNS reachability: `aws-sqs-sns-reachability.md`
 - AWS SSM parameter metadata: `aws-ssm-parameter-metadata.md`
+- AWS Connect troubleshooting: `aws-connect-troubleshooting.md`
 - AWS StackSet onboarding: `aws-stackset-onboarding.md`
 - AWS Step Functions state machine roles: `aws-stepfunctions-state-machine-roles.md`
 - AWS approved trust-policy hardening executor: `aws-trust-policy-hardening-executor.md`

--- a/docs/aws-connect-troubleshooting.md
+++ b/docs/aws-connect-troubleshooting.md
@@ -1,0 +1,31 @@
+# AWS Connect Troubleshooting
+
+AWS Connect diagnostics describe setup coverage gaps, not runtime machine-identity findings. They are safe to show in the app because they use stable codes, scoped evidence references, and plain repair actions without serializing secrets.
+
+## Diagnostic Codes
+
+| Code | Meaning | Operator action | Tradeoff |
+| --- | --- | --- | --- |
+| `assume_role_failed` | Identrail could not assume the configured IAM role. | Update the role trust policy for the current Identrail account and External ID, then revalidate. | Restores read-only collection without adding write remediation permissions. |
+| `external_id_mismatch` | AWS trust policy and Identrail setup are using different External ID values. | Copy the current trust-policy guidance, update AWS, then revalidate. | The connector remains unavailable until both sides match. |
+| `role_arn_malformed` | The submitted role ARN is not a valid IAM role ARN. | Paste the full IAM role ARN from AWS, then revalidate. | No AWS calls are attempted until the ARN shape is valid. |
+| `missing_read_only_permission_tier` | The role or capability gate is missing the expected read-only permissions. | Refresh the expected policy, update the role, then revalidate. | Narrower permissions limit blast radius, but Identrail will not claim coverage for unreadable services. |
+| `connector_config_missing` | The Identrail deployment is missing CloudFormation setup configuration. | Configure the AWS template URL and checksum, then retry setup. | Operators can still use manual setup while one-click launch is unavailable. |
+| `cloudformation_stack_not_deployed` | AWS has not reported an active stack or StackSet instance yet. | Open the launch URL, complete AWS deployment, then refresh status. | Coverage is withheld until AWS reports active instances. |
+| `stackset_trusted_access_missing` | CloudFormation StackSets trusted access is not enabled in AWS Organizations. | Enable trusted access from the management account, then refresh status. | Required for service-managed StackSets. |
+| `delegated_admin_recommended` | StackSet administration is using or expecting the management account path. | Register a delegated administrator when possible. | Management-account operation can work, but delegated administration narrows blast radius. |
+| `selected_target_missing_stackset_instance` | A selected OU, account, or region does not have an active StackSet instance. | Review targets, launch or retry StackSet deployment, then refresh status. | Healthy targets remain visible, but coverage is partial. |
+| `member_account_permission_denied` | AWS denied StackSet deployment in a member account. | Fix member-account StackSet permissions and retry the instance. | The account is excluded from claimed coverage until repaired. |
+| `region_unsupported_or_not_opted_in` | The selected region is unsupported or not opted in for the member account. | Enable the region or remove it from the selected target set. | Removing it avoids failures, but coverage excludes workloads there. |
+| `partial_stackset_coverage` | Some StackSet instances failed while others remain usable. | Retry failed instances, then refresh status. | Identrail keeps successful targets visible but does not claim full coverage. |
+
+## Repair Actions
+
+- `refresh_status`: re-read connector and StackSet status without changing AWS.
+- `validate_role`: retry the read-only role validation.
+- `open_stackset` / `launch_stack`: open the AWS console launch URL returned by the backend.
+- `refresh_policy`: fetch the expected read-only policy preview.
+- `copy_trust_policy`: copy the current trust-policy guidance for manual role setup.
+- `open_docs`: open this runbook or the AWS connector guide.
+
+All actions require the operator to make the AWS-side change explicitly. This flow does not execute AWS write remediation.

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -1784,7 +1784,6 @@ func (s *Service) buildAWSConnectorStackSetOnboarding(
 			Retryable:   true,
 		})
 	}
-	diagnostics = awsStackSetRepairDiagnostics(plan, diagnostics)
 	status, confidence, failures, remediations := summarizeAWSStackSetOnboarding("success", plan, diagnostics)
 	return AWSStackSetOnboardingResult{
 		TenantID:            scope.TenantID,
@@ -2909,16 +2908,22 @@ func awsDiagnosticFromPermissionCheck(setup awsConnectorSetupContract, roleARN s
 
 func normalizeAWSSetupDiagnosticCode(code string, text string) string {
 	normalized := strings.ToLower(strings.TrimSpace(code))
+	switch normalized {
+	case "assume_role_failed", "external_id_mismatch", "role_arn_malformed", "missing_read_only_permission_tier", "connector_config_missing":
+		return normalized
+	case "aws_access_denied", "access_denied":
+		return "assume_role_failed"
+	}
 	search := strings.ToLower(text + " " + normalized)
 	switch {
-	case strings.Contains(normalized, "external_id") || strings.Contains(search, "external id") || strings.Contains(search, "externalid"):
-		return "external_id_mismatch"
+	case strings.Contains(normalized, "access_denied") || strings.Contains(normalized, "assume") || strings.Contains(search, "assume"):
+		return "assume_role_failed"
 	case strings.Contains(normalized, "malformed") || (strings.Contains(search, "role arn") && strings.Contains(search, "valid")):
 		return "role_arn_malformed"
 	case strings.Contains(normalized, "capability") || strings.Contains(normalized, "permission") || strings.Contains(search, "permission"):
 		return "missing_read_only_permission_tier"
-	case strings.Contains(normalized, "access_denied") || strings.Contains(normalized, "assume") || strings.Contains(search, "assume"):
-		return "assume_role_failed"
+	case strings.Contains(normalized, "external_id") || strings.Contains(search, "external id") || strings.Contains(search, "externalid"):
+		return "external_id_mismatch"
 	case normalized == "":
 		return "assume_role_failed"
 	default:
@@ -3043,6 +3048,7 @@ func scrubAWSConnectionDiagnostic(diagnostic AWSConnectionDiagnostic, externalID
 	diagnostic.Message = strings.ReplaceAll(diagnostic.Message, secret, "[redacted]")
 	diagnostic.OperatorAction = strings.ReplaceAll(diagnostic.OperatorAction, secret, "[redacted]")
 	diagnostic.Remediation = strings.ReplaceAll(diagnostic.Remediation, secret, "[redacted]")
+	diagnostic.EvidenceRef = strings.ReplaceAll(diagnostic.EvidenceRef, secret, "[redacted]")
 	diagnostic.Tradeoff = strings.ReplaceAll(diagnostic.Tradeoff, secret, "[redacted]")
 	return diagnostic
 }

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -104,6 +104,9 @@ const (
 	AWSConnectorNextActionValidateRole           AWSConnectorNextAction = "validate_role"
 	AWSConnectorNextActionRefreshStatus          AWSConnectorNextAction = "refresh_status"
 	AWSConnectorNextActionRepairPermissions      AWSConnectorNextAction = "repair_permissions"
+	AWSConnectorNextActionRefreshPolicy          AWSConnectorNextAction = "refresh_policy"
+	AWSConnectorNextActionCopyTrustPolicy        AWSConnectorNextAction = "copy_trust_policy"
+	AWSConnectorNextActionOpenDocs               AWSConnectorNextAction = "open_docs"
 	AWSConnectorNextActionStartIntelligence      AWSConnectorNextAction = "start_intelligence"
 )
 
@@ -237,9 +240,16 @@ type AWSConnectionValidationRequest struct {
 
 // AWSConnectionDiagnostic explains one validation outcome and how to remediate it.
 type AWSConnectionDiagnostic struct {
-	Code        string `json:"code"`
-	Message     string `json:"message"`
-	Remediation string `json:"remediation,omitempty"`
+	Code           string                   `json:"code"`
+	Severity       string                   `json:"severity,omitempty"`
+	AffectedScope  string                   `json:"affected_scope,omitempty"`
+	Message        string                   `json:"message"`
+	OperatorAction string                   `json:"operator_action,omitempty"`
+	Remediation    string                   `json:"remediation,omitempty"`
+	Retryable      bool                     `json:"retryable"`
+	EvidenceRef    string                   `json:"evidence_ref,omitempty"`
+	Tradeoff       string                   `json:"tradeoff,omitempty"`
+	Actions        []AWSConnectorNextAction `json:"actions,omitempty"`
 }
 
 // AWSConnectionPermissionCheck captures one connector permission sanity check.
@@ -1418,7 +1428,7 @@ func (s *Service) UpsertAWSConnection(ctx context.Context, workspaceID string, p
 		onboardingStatus = AWSConnectorOnboardingNeedsFix
 	}
 
-	checks := copyAWSPermissionChecks(validation.PermissionChecks)
+	checks := scrubAWSPermissionChecks(copyAWSPermissionChecks(validation.PermissionChecks), normalized.ExternalID)
 	if connected && len(checks) == 0 {
 		checks = []AWSConnectionPermissionCheck{{
 			Name:    "sts:AssumeRole",
@@ -1434,7 +1444,13 @@ func (s *Service) UpsertAWSConnection(ctx context.Context, workspaceID string, p
 	if err != nil {
 		return AWSConnectionStatus{}, err
 	}
-	diagnostics := append(copyAWSDiagnostics(validation.Diagnostics), capabilityDiagnostics...)
+	diagnostics := awsConnectorSetupDiagnostics(
+		setup,
+		normalized.RoleARN,
+		normalized.ExternalID,
+		append(copyAWSDiagnostics(validation.Diagnostics), capabilityDiagnostics...),
+		checks,
+	)
 
 	metadata := map[string]any{
 		"role_arn":               normalized.RoleARN,
@@ -1737,7 +1753,7 @@ func (s *Service) buildAWSConnectorStackSetOnboarding(
 		TargetRegions:         collectStackSetRegionCodes(plan.Targets.Regions),
 		AutoDeploymentEnabled: awsConnectorStackSetAutoDeploymentEnabled(mode, setup),
 	})
-	status, confidence, failures, remediations := summarizeAWSStackSetOnboarding("success", plan, nil)
+	diagnostics := []AWSStackSetOnboardingDiagnostic{}
 	instances := mapAWSStackSetInstances(plan.Instances)
 	coverageExpectation := mapAWSStackSetCoverageExpectation(plan.CoverageExpectation)
 	summary := mapAWSStackSetSummary(plan.Summary)
@@ -1749,7 +1765,6 @@ func (s *Service) buildAWSConnectorStackSetOnboarding(
 			Remediation: "Launch the StackSet in AWS, then refresh connector status to reconcile observed coverage.",
 		},
 	}
-	diagnostics := []AWSStackSetOnboardingDiagnostic{}
 	if !projectionKnown {
 		instances = []AWSStackSetOnboardingInstance{}
 		coverageExpectation = unknownAWSStackSetCoverageExpectation(len(plan.Targets.Regions), "Service-managed StackSet scopes are expanded by AWS during deployment; expected accounts, instances, and coverage targets are unknown until AWS resolves effective membership.")
@@ -1769,6 +1784,8 @@ func (s *Service) buildAWSConnectorStackSetOnboarding(
 			Retryable:   true,
 		})
 	}
+	diagnostics = awsStackSetRepairDiagnostics(plan, diagnostics)
+	status, confidence, failures, remediations := summarizeAWSStackSetOnboarding("success", plan, diagnostics)
 	return AWSStackSetOnboardingResult{
 		TenantID:            scope.TenantID,
 		WorkspaceID:         project.WorkspaceID,
@@ -2499,6 +2516,9 @@ func failedAWSChecks(checks []AWSConnectionPermissionCheck) []AWSConnectionPermi
 
 func firstAWSRemediation(diagnostics []AWSConnectionDiagnostic, checks []AWSConnectionPermissionCheck) string {
 	for _, diagnostic := range diagnostics {
+		if strings.TrimSpace(diagnostic.OperatorAction) != "" {
+			return diagnostic.OperatorAction
+		}
 		if strings.TrimSpace(diagnostic.Remediation) != "" {
 			return diagnostic.Remediation
 		}
@@ -2689,6 +2709,9 @@ func awsMetadataNextActions(metadata map[string]any, key string, fallback []AWSC
 			AWSConnectorNextActionValidateRole,
 			AWSConnectorNextActionRefreshStatus,
 			AWSConnectorNextActionRepairPermissions,
+			AWSConnectorNextActionRefreshPolicy,
+			AWSConnectorNextActionCopyTrustPolicy,
+			AWSConnectorNextActionOpenDocs,
 			AWSConnectorNextActionStartIntelligence:
 			actions = append(actions, action)
 		}
@@ -2813,12 +2836,227 @@ func (s *Service) resolveAWSConnectorCapabilities(requested []domain.ConnectorCa
 			Reason:     unavailable.Reason,
 		})
 		diagnostics = append(diagnostics, AWSConnectionDiagnostic{
-			Code:        fmt.Sprintf("aws_capability_unavailable_%s", unavailable.Capability),
-			Message:     fmt.Sprintf("requested capability %q is unavailable: %s", unavailable.Capability, unavailable.Reason),
-			Remediation: fmt.Sprintf("Enable the %q capability gate for this deployment before requesting it; write-capable tiers also require a dedicated write role.", unavailable.Capability),
+			Code:           "missing_read_only_permission_tier",
+			Severity:       "blocking",
+			AffectedScope:  string(unavailable.Capability),
+			Message:        fmt.Sprintf("requested capability %q is unavailable: %s", unavailable.Capability, unavailable.Reason),
+			OperatorAction: fmt.Sprintf("Enable the %q capability gate for this deployment before requesting it; write-capable tiers also require a dedicated write role.", unavailable.Capability),
+			Remediation:    fmt.Sprintf("Enable the %q capability gate for this deployment before requesting it; write-capable tiers also require a dedicated write role.", unavailable.Capability),
+			Retryable:      true,
+			EvidenceRef:    fmt.Sprintf("aws-capability:%s/%s", unavailable.Capability, unavailable.Tier),
+			Actions:        []AWSConnectorNextAction{AWSConnectorNextActionRefreshPolicy, AWSConnectorNextActionOpenDocs, AWSConnectorNextActionValidateRole},
 		})
 	}
 	return capabilities, diagnostics, nil
+}
+
+func awsConnectorSetupDiagnostics(setup awsConnectorSetupContract, roleARN string, externalID string, diagnostics []AWSConnectionDiagnostic, checks []AWSConnectionPermissionCheck) []AWSConnectionDiagnostic {
+	out := make([]AWSConnectionDiagnostic, 0, len(diagnostics)+len(checks))
+	for _, diagnostic := range diagnostics {
+		out = append(out, scrubAWSConnectionDiagnostic(enrichAWSConnectionDiagnostic(setup, roleARN, diagnostic), externalID))
+	}
+	for _, check := range checks {
+		if check.Passed {
+			continue
+		}
+		out = append(out, scrubAWSConnectionDiagnostic(awsDiagnosticFromPermissionCheck(setup, roleARN, check), externalID))
+	}
+	return dedupeAWSConnectionDiagnostics(out)
+}
+
+func enrichAWSConnectionDiagnostic(setup awsConnectorSetupContract, roleARN string, diagnostic AWSConnectionDiagnostic) AWSConnectionDiagnostic {
+	code := normalizeAWSSetupDiagnosticCode(diagnostic.Code, diagnostic.Message+" "+diagnostic.Remediation)
+	diagnostic.Code = code
+	if strings.TrimSpace(diagnostic.Severity) == "" {
+		diagnostic.Severity = awsSetupDiagnosticSeverity(code)
+	}
+	if strings.TrimSpace(diagnostic.AffectedScope) == "" {
+		diagnostic.AffectedScope = awsDiagnosticAffectedScope(setup, roleARN)
+	}
+	if strings.TrimSpace(diagnostic.OperatorAction) == "" {
+		diagnostic.OperatorAction = firstNonEmptyAWSValue(strings.TrimSpace(diagnostic.Remediation), awsSetupDiagnosticAction(code, setup))
+	}
+	if strings.TrimSpace(diagnostic.Remediation) == "" {
+		diagnostic.Remediation = diagnostic.OperatorAction
+	}
+	if !diagnostic.Retryable {
+		diagnostic.Retryable = awsSetupDiagnosticRetryable(code)
+	}
+	if strings.TrimSpace(diagnostic.EvidenceRef) == "" {
+		diagnostic.EvidenceRef = "aws-connector:" + code
+	}
+	if strings.TrimSpace(diagnostic.Tradeoff) == "" {
+		diagnostic.Tradeoff = awsSetupDiagnosticTradeoff(code, setup)
+	}
+	if len(diagnostic.Actions) == 0 {
+		diagnostic.Actions = awsSetupDiagnosticActions(code, setup)
+	}
+	return diagnostic
+}
+
+func awsDiagnosticFromPermissionCheck(setup awsConnectorSetupContract, roleARN string, check AWSConnectionPermissionCheck) AWSConnectionDiagnostic {
+	code := "missing_read_only_permission_tier"
+	if strings.Contains(strings.ToLower(check.Name+" "+check.Message), "assumerole") {
+		code = "assume_role_failed"
+	}
+	return enrichAWSConnectionDiagnostic(setup, roleARN, AWSConnectionDiagnostic{
+		Code:        code,
+		Message:     firstNonEmptyAWSValue(strings.TrimSpace(check.Message), "AWS connector validation failed for "+check.Name+"."),
+		Remediation: strings.TrimSpace(check.Remediation),
+		EvidenceRef: "aws-permission-check:" + strings.TrimSpace(check.Name),
+	})
+}
+
+func normalizeAWSSetupDiagnosticCode(code string, text string) string {
+	normalized := strings.ToLower(strings.TrimSpace(code))
+	search := strings.ToLower(text + " " + normalized)
+	switch {
+	case strings.Contains(normalized, "external_id") || strings.Contains(search, "external id") || strings.Contains(search, "externalid"):
+		return "external_id_mismatch"
+	case strings.Contains(normalized, "malformed") || (strings.Contains(search, "role arn") && strings.Contains(search, "valid")):
+		return "role_arn_malformed"
+	case strings.Contains(normalized, "capability") || strings.Contains(normalized, "permission") || strings.Contains(search, "permission"):
+		return "missing_read_only_permission_tier"
+	case strings.Contains(normalized, "access_denied") || strings.Contains(normalized, "assume") || strings.Contains(search, "assume"):
+		return "assume_role_failed"
+	case normalized == "":
+		return "assume_role_failed"
+	default:
+		return normalized
+	}
+}
+
+func awsSetupDiagnosticSeverity(code string) string {
+	switch code {
+	case "delegated_admin_recommended", "partial_stackset_coverage":
+		return "warning"
+	default:
+		return "blocking"
+	}
+}
+
+func awsDiagnosticAffectedScope(setup awsConnectorSetupContract, roleARN string) string {
+	if accountID := awsAccountIDFromRoleARN(roleARN); accountID != "" {
+		return "account/" + accountID
+	}
+	switch setup.ScopeType {
+	case AWSConnectorScopeOrganization:
+		return "organization"
+	case AWSConnectorScopeSelectedOUs:
+		return "selected_ous"
+	case AWSConnectorScopeSelectedAccounts:
+		return "selected_accounts"
+	default:
+		return "single_account"
+	}
+}
+
+func awsAccountIDFromRoleARN(roleARN string) string {
+	parts := strings.Split(roleARN, ":")
+	if len(parts) >= 5 && awsAccountIDPattern.MatchString(parts[4]) {
+		return parts[4]
+	}
+	return ""
+}
+
+func awsSetupDiagnosticAction(code string, setup awsConnectorSetupContract) string {
+	switch code {
+	case "external_id_mismatch":
+		return "Copy the current External ID guidance into the IAM trust policy, then revalidate the role."
+	case "role_arn_malformed":
+		return "Paste the full IAM role ARN from AWS, then revalidate."
+	case "missing_read_only_permission_tier":
+		return "Refresh the expected policy, update the read-only role permissions, then revalidate."
+	case "connector_config_missing":
+		return "Configure the AWS CloudFormation template URL and checksum for this Identrail deployment."
+	default:
+		if awsConnectorDeploymentIsStackSet(setup.DeploymentMethod) {
+			return "Review the StackSet trust and instance status, then refresh connector status."
+		}
+		return "Update the IAM role trust policy so Identrail can assume the role, then revalidate."
+	}
+}
+
+func awsSetupDiagnosticTradeoff(code string, setup awsConnectorSetupContract) string {
+	switch code {
+	case "missing_read_only_permission_tier":
+		return "Keeping the narrower policy limits blast radius, but Identrail will not claim coverage for services it cannot read."
+	case "external_id_mismatch":
+		return "Rotating the trust-policy condition protects this tenant boundary, but the role will stay unavailable until AWS and Identrail match."
+	case "assume_role_failed":
+		if awsConnectorDeploymentIsStackSet(setup.DeploymentMethod) {
+			return "Fixing trust for one StackSet role restores validation without granting write remediation permissions."
+		}
+		return "Fixing trust restores read-only collection without granting write remediation permissions."
+	default:
+		return ""
+	}
+}
+
+func awsSetupDiagnosticRetryable(code string) bool {
+	switch code {
+	case "connector_config_missing":
+		return false
+	default:
+		return true
+	}
+}
+
+func awsSetupDiagnosticActions(code string, setup awsConnectorSetupContract) []AWSConnectorNextAction {
+	switch code {
+	case "external_id_mismatch":
+		return []AWSConnectorNextAction{AWSConnectorNextActionCopyTrustPolicy, AWSConnectorNextActionValidateRole, AWSConnectorNextActionRefreshStatus}
+	case "missing_read_only_permission_tier":
+		return []AWSConnectorNextAction{AWSConnectorNextActionRefreshPolicy, AWSConnectorNextActionRepairPermissions, AWSConnectorNextActionValidateRole}
+	case "role_arn_malformed":
+		return []AWSConnectorNextAction{AWSConnectorNextActionValidateRole, AWSConnectorNextActionOpenDocs}
+	default:
+		if awsConnectorDeploymentIsStackSet(setup.DeploymentMethod) {
+			return []AWSConnectorNextAction{AWSConnectorNextActionOpenStackSet, AWSConnectorNextActionRefreshStatus, AWSConnectorNextActionValidateRole}
+		}
+		return []AWSConnectorNextAction{AWSConnectorNextActionCopyTrustPolicy, AWSConnectorNextActionValidateRole, AWSConnectorNextActionRefreshStatus}
+	}
+}
+
+func dedupeAWSConnectionDiagnostics(diagnostics []AWSConnectionDiagnostic) []AWSConnectionDiagnostic {
+	out := make([]AWSConnectionDiagnostic, 0, len(diagnostics))
+	seen := map[string]struct{}{}
+	for _, diagnostic := range diagnostics {
+		key := strings.Join([]string{
+			strings.TrimSpace(diagnostic.Code),
+			strings.TrimSpace(diagnostic.AffectedScope),
+		}, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, diagnostic)
+	}
+	return out
+}
+
+func scrubAWSConnectionDiagnostic(diagnostic AWSConnectionDiagnostic, externalID string) AWSConnectionDiagnostic {
+	secret := strings.TrimSpace(externalID)
+	if secret == "" {
+		return diagnostic
+	}
+	diagnostic.Message = strings.ReplaceAll(diagnostic.Message, secret, "[redacted]")
+	diagnostic.OperatorAction = strings.ReplaceAll(diagnostic.OperatorAction, secret, "[redacted]")
+	diagnostic.Remediation = strings.ReplaceAll(diagnostic.Remediation, secret, "[redacted]")
+	diagnostic.Tradeoff = strings.ReplaceAll(diagnostic.Tradeoff, secret, "[redacted]")
+	return diagnostic
+}
+
+func scrubAWSPermissionChecks(checks []AWSConnectionPermissionCheck, externalID string) []AWSConnectionPermissionCheck {
+	secret := strings.TrimSpace(externalID)
+	if secret == "" {
+		return checks
+	}
+	for index := range checks {
+		checks[index].Message = strings.ReplaceAll(checks[index].Message, secret, "[redacted]")
+		checks[index].Remediation = strings.ReplaceAll(checks[index].Remediation, secret, "[redacted]")
+	}
+	return checks
 }
 
 // defaultAWSConnectorCapabilities returns the read-only discovery baseline used

--- a/internal/api/aws_connect_capabilities_test.go
+++ b/internal/api/aws_connect_capabilities_test.go
@@ -109,7 +109,8 @@ func TestUpsertAWSConnectionReportsUnavailableWriteCapability(t *testing.T) {
 
 	var capabilityDiagnostic *AWSConnectionDiagnostic
 	for i := range status.Diagnostics {
-		if status.Diagnostics[i].Code == "aws_capability_unavailable_approved_remediation" {
+		if status.Diagnostics[i].Code == "missing_read_only_permission_tier" &&
+			status.Diagnostics[i].AffectedScope == string(domain.ConnectorCapabilityApprovedRemediation) {
 			capabilityDiagnostic = &status.Diagnostics[i]
 			break
 		}

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -618,6 +618,49 @@ func TestRouterAWSConnectionOnboardingReturnsTrustRemediation(t *testing.T) {
 	}
 }
 
+func TestRouterAWSConnectionDiagnosticsRedactExternalID(t *testing.T) {
+	validator := &fakeAWSConnectorValidator{
+		result: AWSConnectionValidationResult{
+			PermissionChecks: []AWSConnectionPermissionCheck{{
+				Name:        "sts:AssumeRole",
+				Passed:      false,
+				Message:     "AWS rejected External ID secret-external-id-value.",
+				Remediation: "Replace secret-external-id-value in the trust policy.",
+			}},
+			Diagnostics: []AWSConnectionDiagnostic{{
+				Code:        "external_id_mismatch",
+				Message:     "Trust policy expected a different External ID than secret-external-id-value.",
+				Remediation: "Copy secret-external-id-value from setup context only.",
+			}},
+		},
+	}
+	r := newAWSConnectionTestRouter(t, validator)
+
+	resp := doAWSConnectionAPI(t, r, http.MethodPost, "/v1/workspaces/workspace-a/projects/project-1/aws/connection", `{
+		"role_arn":"arn:aws:iam::123456789012:role/BadTrustRole",
+		"external_id":"secret-external-id-value"
+	}`)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected diagnostic response 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), "secret-external-id-value") {
+		t.Fatalf("diagnostics must redact external id, got %s", resp.Body.String())
+	}
+
+	var body struct {
+		Connection AWSConnectionStatus `json:"connection"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(body.Connection.Diagnostics) != 1 || body.Connection.Diagnostics[0].Code != "external_id_mismatch" {
+		t.Fatalf("expected one external-id diagnostic, got %+v", body.Connection.Diagnostics)
+	}
+	if !strings.Contains(body.Connection.Diagnostics[0].Message, "[redacted]") {
+		t.Fatalf("expected redacted diagnostic text, got %+v", body.Connection.Diagnostics[0])
+	}
+}
+
 func TestRouterAWSConnectionRejectsInvalidRoleARN(t *testing.T) {
 	r := newAWSConnectionTestRouter(t, &fakeAWSConnectorValidator{})
 

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -631,6 +631,7 @@ func TestRouterAWSConnectionDiagnosticsRedactExternalID(t *testing.T) {
 				Code:        "external_id_mismatch",
 				Message:     "Trust policy expected a different External ID than secret-external-id-value.",
 				Remediation: "Copy secret-external-id-value from setup context only.",
+				EvidenceRef: "aws-connector:secret-external-id-value",
 			}},
 		},
 	}
@@ -653,11 +654,56 @@ func TestRouterAWSConnectionDiagnosticsRedactExternalID(t *testing.T) {
 	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if len(body.Connection.Diagnostics) != 1 || body.Connection.Diagnostics[0].Code != "external_id_mismatch" {
-		t.Fatalf("expected one external-id diagnostic, got %+v", body.Connection.Diagnostics)
+	var externalIDDiagnostic *AWSConnectionDiagnostic
+	for index := range body.Connection.Diagnostics {
+		if body.Connection.Diagnostics[index].Code == "external_id_mismatch" {
+			externalIDDiagnostic = &body.Connection.Diagnostics[index]
+			break
+		}
 	}
-	if !strings.Contains(body.Connection.Diagnostics[0].Message, "[redacted]") {
-		t.Fatalf("expected redacted diagnostic text, got %+v", body.Connection.Diagnostics[0])
+	if externalIDDiagnostic == nil {
+		t.Fatalf("expected external-id diagnostic, got %+v", body.Connection.Diagnostics)
+	}
+	if !strings.Contains(externalIDDiagnostic.Message, "[redacted]") {
+		t.Fatalf("expected redacted diagnostic text, got %+v", *externalIDDiagnostic)
+	}
+	if !strings.Contains(externalIDDiagnostic.EvidenceRef, "[redacted]") {
+		t.Fatalf("expected redacted diagnostic evidence ref, got %+v", *externalIDDiagnostic)
+	}
+}
+
+func TestAWSSetupDiagnosticCodePrefersExplicitCodes(t *testing.T) {
+	cases := []struct {
+		name string
+		code string
+		text string
+		want string
+	}{
+		{
+			name: "access denied maps before external id prose",
+			code: "aws_access_denied",
+			text: "AWS denied AssumeRole; update the trust policy External ID condition if your organization requires one.",
+			want: "assume_role_failed",
+		},
+		{
+			name: "known assume role code wins over prose",
+			code: "assume_role_failed",
+			text: "The remediation mentions external ID, but the API code is already normalized.",
+			want: "assume_role_failed",
+		},
+		{
+			name: "known external id code is preserved",
+			code: "external_id_mismatch",
+			text: "AssumeRole failed while validating the role.",
+			want: "external_id_mismatch",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeAWSSetupDiagnosticCode(tc.code, tc.text); got != tc.want {
+				t.Fatalf("normalizeAWSSetupDiagnosticCode(%q, %q) = %q, want %q", tc.code, tc.text, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/api/aws_stackset_onboarding.go
+++ b/internal/api/aws_stackset_onboarding.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"time"
 
@@ -772,11 +773,14 @@ func awsStackSetRepairDiagnostics(plan awscontract.StackSetOnboardingPlan, diagn
 			code = "stackset_trusted_access_missing"
 		case "stackset.delegated_admin_registered":
 			code = "delegated_admin_recommended"
+		case "stackset.suspended_accounts_excluded":
+			code = "suspended_accounts_excluded"
 		}
 		out = append(out, enrichAWSStackSetDiagnostic(plan, AWSStackSetOnboardingDiagnostic{
 			Source:      "stackset_onboarding_prerequisite",
 			Scope:       prerequisite.ID,
 			Code:        code,
+			Severity:    string(prerequisite.Severity),
 			Message:     prerequisite.Reason,
 			Remediation: prerequisite.Remediation,
 			Retryable:   true,
@@ -802,6 +806,15 @@ func awsStackSetRepairDiagnostics(plan awscontract.StackSetOnboardingPlan, diagn
 				Remediation: "Re-run the failed StackSet instance, then refresh status.",
 				Retryable:   instance.Resumable,
 			}))
+		case awscontract.StackSetStateDegraded:
+			out = append(out, enrichAWSStackSetDiagnostic(plan, AWSStackSetOnboardingDiagnostic{
+				Source:      "stackset_instance",
+				Scope:       awsStackSetInstanceScope(instance.AccountID, instance.Region),
+				Code:        "partial_stackset_coverage",
+				Message:     firstNonEmptyAWSValue(strings.TrimSpace(instance.FailureReason), "A StackSet instance is degraded and coverage is partial."),
+				Remediation: "Revalidate the read-only role in this account, then refresh status.",
+				Retryable:   true,
+			}))
 		case awscontract.StackSetStatePermissionDenied:
 			out = append(out, enrichAWSStackSetDiagnostic(plan, AWSStackSetOnboardingDiagnostic{
 				Source:      "stackset_instance",
@@ -809,6 +822,15 @@ func awsStackSetRepairDiagnostics(plan awscontract.StackSetOnboardingPlan, diagn
 				Code:        "member_account_permission_denied",
 				Message:     firstNonEmptyAWSValue(strings.TrimSpace(instance.FailureReason), "AWS denied StackSet deployment in a member account."),
 				Remediation: "Confirm Organizations trusted access and member-account permissions, then retry this instance.",
+				Retryable:   true,
+			}))
+		case awscontract.StackSetStateBlocked:
+			out = append(out, enrichAWSStackSetDiagnostic(plan, AWSStackSetOnboardingDiagnostic{
+				Source:      "stackset_instance",
+				Scope:       awsStackSetInstanceScope(instance.AccountID, instance.Region),
+				Code:        "selected_target_missing_stackset_instance",
+				Message:     firstNonEmptyAWSValue(strings.TrimSpace(instance.FailureReason), "A StackSet target is blocked before deployment can complete."),
+				Remediation: "Resolve the blocking prerequisite for this target, then refresh status.",
 				Retryable:   true,
 			}))
 		case awscontract.StackSetStateUnsupported:
@@ -820,9 +842,18 @@ func awsStackSetRepairDiagnostics(plan awscontract.StackSetOnboardingPlan, diagn
 				Remediation: "Choose an opted-in AWS region or enable the region in the member account before redeploying.",
 				Retryable:   true,
 			}))
+		case awscontract.StackSetStateSuspended:
+			out = append(out, enrichAWSStackSetDiagnostic(plan, AWSStackSetOnboardingDiagnostic{
+				Source:      "stackset_instance",
+				Scope:       awsStackSetInstanceScope(instance.AccountID, instance.Region),
+				Code:        "suspended_accounts_excluded",
+				Message:     firstNonEmptyAWSValue(strings.TrimSpace(instance.FailureReason), "AWS account is suspended, so StackSet deployment is excluded for this target."),
+				Remediation: "Remove the suspended account from targets or reactivate it in AWS before expecting coverage.",
+				Retryable:   false,
+			}))
 		}
 	}
-	return dedupeAWSStackSetDiagnostics(out)
+	return sortAWSStackSetDiagnosticsBySeverity(dedupeAWSStackSetDiagnostics(out))
 }
 
 func enrichAWSStackSetDiagnostic(plan awscontract.StackSetOnboardingPlan, diagnostic AWSStackSetOnboardingDiagnostic) AWSStackSetOnboardingDiagnostic {
@@ -869,7 +900,7 @@ func normalizeAWSStackSetDiagnosticCode(code string) string {
 
 func awsStackSetDiagnosticSeverity(code string) string {
 	switch code {
-	case "delegated_admin_recommended", "partial_stackset_coverage", "region_unsupported_or_not_opted_in":
+	case "delegated_admin_recommended", "partial_stackset_coverage", "region_unsupported_or_not_opted_in", "suspended_accounts_excluded":
 		return "warning"
 	default:
 		return "blocking"
@@ -888,6 +919,8 @@ func awsStackSetDiagnosticAction(code string) string {
 		return "Use an opted-in region or enable the target region before relaunching StackSet coverage."
 	case "partial_stackset_coverage":
 		return "Retry failed StackSet instances, then refresh status before relying on coverage."
+	case "suspended_accounts_excluded":
+		return "Remove suspended accounts from targets or reactivate them before expecting StackSet coverage."
 	default:
 		return "Open the StackSet launch URL, complete deployment, then refresh status."
 	}
@@ -901,6 +934,8 @@ func awsStackSetDiagnosticTradeoff(code string) string {
 		return "Leaving failed instances unresolved keeps healthy accounts visible, but Identrail will not claim full organization coverage."
 	case "region_unsupported_or_not_opted_in":
 		return "Skipping unsupported regions avoids failed deployments, but coverage will exclude workloads in those regions."
+	case "suspended_accounts_excluded":
+		return "Excluding suspended accounts avoids failed deployments, but coverage will not include those accounts."
 	default:
 		return ""
 	}
@@ -914,8 +949,28 @@ func awsStackSetDiagnosticActions(code string) []AWSConnectorNextAction {
 		return []AWSConnectorNextAction{AWSConnectorNextActionRegisterDelegatedAdmin, AWSConnectorNextActionRefreshStatus, AWSConnectorNextActionOpenDocs}
 	case "selected_target_missing_stackset_instance", "cloudformation_stack_not_deployed":
 		return []AWSConnectorNextAction{AWSConnectorNextActionOpenStackSet, AWSConnectorNextActionRefreshStatus}
+	case "suspended_accounts_excluded":
+		return []AWSConnectorNextAction{AWSConnectorNextActionOpenDocs, AWSConnectorNextActionRefreshStatus}
 	default:
 		return []AWSConnectorNextAction{AWSConnectorNextActionOpenStackSet, AWSConnectorNextActionRefreshStatus, AWSConnectorNextActionOpenDocs}
+	}
+}
+
+func sortAWSStackSetDiagnosticsBySeverity(diagnostics []AWSStackSetOnboardingDiagnostic) []AWSStackSetOnboardingDiagnostic {
+	sort.SliceStable(diagnostics, func(i, j int) bool {
+		return awsStackSetDiagnosticRank(diagnostics[i].Severity) < awsStackSetDiagnosticRank(diagnostics[j].Severity)
+	})
+	return diagnostics
+}
+
+func awsStackSetDiagnosticRank(severity string) int {
+	switch severity {
+	case "critical", "blocking", "error":
+		return 0
+	case "warning", "advisory":
+		return 1
+	default:
+		return 2
 	}
 }
 

--- a/internal/api/aws_stackset_onboarding.go
+++ b/internal/api/aws_stackset_onboarding.go
@@ -165,12 +165,18 @@ type AWSStackSetOnboardingSummary struct {
 
 // AWSStackSetOnboardingDiagnostic is one planning/execution diagnostic.
 type AWSStackSetOnboardingDiagnostic struct {
-	Source      string `json:"source"`
-	Scope       string `json:"scope,omitempty"`
-	Code        string `json:"code"`
-	Message     string `json:"message"`
-	Remediation string `json:"remediation,omitempty"`
-	Retryable   bool   `json:"retryable"`
+	Source         string                   `json:"source"`
+	Scope          string                   `json:"scope,omitempty"`
+	Code           string                   `json:"code"`
+	Severity       string                   `json:"severity,omitempty"`
+	AffectedScope  string                   `json:"affected_scope,omitempty"`
+	Message        string                   `json:"message"`
+	OperatorAction string                   `json:"operator_action,omitempty"`
+	Remediation    string                   `json:"remediation,omitempty"`
+	Retryable      bool                     `json:"retryable"`
+	EvidenceRef    string                   `json:"evidence_ref,omitempty"`
+	Tradeoff       string                   `json:"tradeoff,omitempty"`
+	Actions        []AWSConnectorNextAction `json:"actions,omitempty"`
 }
 
 // AWSStackSetOnboardingCoverageGap names a deliberate boundary of the planner.
@@ -279,6 +285,7 @@ func (s *Service) buildAWSStackSetOnboarding(scope db.Scope, project db.TenancyP
 		TargetRegions:         collectStackSetRegionCodes(plan.Targets.Regions),
 	})
 
+	diagnostics = awsStackSetRepairDiagnostics(plan, diagnostics)
 	status, confidence, failures, remediations := summarizeAWSStackSetOnboarding(fixtureState, plan, diagnostics)
 
 	return AWSStackSetOnboardingResult{
@@ -748,6 +755,190 @@ func summarizeAWSStackSetOnboarding(fixtureState string, plan awscontract.StackS
 				dedupeStrings(append(remediations, "Open the StackSet console launch URL to deploy the read-only connector across the target accounts."))
 		}
 	}
+}
+
+func awsStackSetRepairDiagnostics(plan awscontract.StackSetOnboardingPlan, diagnostics []AWSStackSetOnboardingDiagnostic) []AWSStackSetOnboardingDiagnostic {
+	out := make([]AWSStackSetOnboardingDiagnostic, 0, len(diagnostics)+len(plan.Validation.Prerequisites)+len(plan.Instances)+1)
+	for _, diagnostic := range diagnostics {
+		out = append(out, enrichAWSStackSetDiagnostic(plan, diagnostic))
+	}
+	for _, prerequisite := range plan.Validation.Prerequisites {
+		if prerequisite.Satisfied {
+			continue
+		}
+		code := "selected_target_missing_stackset_instance"
+		switch prerequisite.ID {
+		case "stackset.trusted_access_enabled":
+			code = "stackset_trusted_access_missing"
+		case "stackset.delegated_admin_registered":
+			code = "delegated_admin_recommended"
+		}
+		out = append(out, enrichAWSStackSetDiagnostic(plan, AWSStackSetOnboardingDiagnostic{
+			Source:      "stackset_onboarding_prerequisite",
+			Scope:       prerequisite.ID,
+			Code:        code,
+			Message:     prerequisite.Reason,
+			Remediation: prerequisite.Remediation,
+			Retryable:   true,
+		}))
+	}
+	for _, instance := range plan.Instances {
+		switch instance.State {
+		case awscontract.StackSetStatePending, awscontract.StackSetStateValidating, awscontract.StackSetStateDeploying:
+			out = append(out, enrichAWSStackSetDiagnostic(plan, AWSStackSetOnboardingDiagnostic{
+				Source:      "stackset_instance",
+				Scope:       awsStackSetInstanceScope(instance.AccountID, instance.Region),
+				Code:        "cloudformation_stack_not_deployed",
+				Message:     "AWS has not reported an active StackSet instance for this target yet.",
+				Remediation: "Open the StackSet launch URL, complete deployment, then refresh status.",
+				Retryable:   true,
+			}))
+		case awscontract.StackSetStateFailed:
+			out = append(out, enrichAWSStackSetDiagnostic(plan, AWSStackSetOnboardingDiagnostic{
+				Source:      "stackset_instance",
+				Scope:       awsStackSetInstanceScope(instance.AccountID, instance.Region),
+				Code:        "partial_stackset_coverage",
+				Message:     firstNonEmptyAWSValue(strings.TrimSpace(instance.FailureReason), "A StackSet instance failed and coverage is partial."),
+				Remediation: "Re-run the failed StackSet instance, then refresh status.",
+				Retryable:   instance.Resumable,
+			}))
+		case awscontract.StackSetStatePermissionDenied:
+			out = append(out, enrichAWSStackSetDiagnostic(plan, AWSStackSetOnboardingDiagnostic{
+				Source:      "stackset_instance",
+				Scope:       awsStackSetInstanceScope(instance.AccountID, instance.Region),
+				Code:        "member_account_permission_denied",
+				Message:     firstNonEmptyAWSValue(strings.TrimSpace(instance.FailureReason), "AWS denied StackSet deployment in a member account."),
+				Remediation: "Confirm Organizations trusted access and member-account permissions, then retry this instance.",
+				Retryable:   true,
+			}))
+		case awscontract.StackSetStateUnsupported:
+			out = append(out, enrichAWSStackSetDiagnostic(plan, AWSStackSetOnboardingDiagnostic{
+				Source:      "stackset_instance",
+				Scope:       awsStackSetInstanceScope(instance.AccountID, instance.Region),
+				Code:        "region_unsupported_or_not_opted_in",
+				Message:     "The target region is unsupported or not opted in for this member account.",
+				Remediation: "Choose an opted-in AWS region or enable the region in the member account before redeploying.",
+				Retryable:   true,
+			}))
+		}
+	}
+	return dedupeAWSStackSetDiagnostics(out)
+}
+
+func enrichAWSStackSetDiagnostic(plan awscontract.StackSetOnboardingPlan, diagnostic AWSStackSetOnboardingDiagnostic) AWSStackSetOnboardingDiagnostic {
+	diagnostic.Code = normalizeAWSStackSetDiagnosticCode(diagnostic.Code)
+	if strings.TrimSpace(diagnostic.Severity) == "" {
+		diagnostic.Severity = awsStackSetDiagnosticSeverity(diagnostic.Code)
+	}
+	if strings.TrimSpace(diagnostic.AffectedScope) == "" {
+		diagnostic.AffectedScope = firstNonEmptyAWSValue(strings.TrimSpace(diagnostic.Scope), plan.OrganizationID, plan.StackSetName)
+	}
+	if strings.TrimSpace(diagnostic.OperatorAction) == "" {
+		diagnostic.OperatorAction = firstNonEmptyAWSValue(strings.TrimSpace(diagnostic.Remediation), awsStackSetDiagnosticAction(diagnostic.Code))
+	}
+	if strings.TrimSpace(diagnostic.Remediation) == "" {
+		diagnostic.Remediation = diagnostic.OperatorAction
+	}
+	if strings.TrimSpace(diagnostic.EvidenceRef) == "" {
+		diagnostic.EvidenceRef = "aws-stackset:" + diagnostic.Code
+		if strings.TrimSpace(diagnostic.Scope) != "" {
+			diagnostic.EvidenceRef += ":" + strings.TrimSpace(diagnostic.Scope)
+		}
+	}
+	if strings.TrimSpace(diagnostic.Tradeoff) == "" {
+		diagnostic.Tradeoff = awsStackSetDiagnosticTradeoff(diagnostic.Code)
+	}
+	if len(diagnostic.Actions) == 0 {
+		diagnostic.Actions = awsStackSetDiagnosticActions(diagnostic.Code)
+	}
+	return diagnostic
+}
+
+func normalizeAWSStackSetDiagnosticCode(code string) string {
+	switch strings.TrimSpace(code) {
+	case "trusted_access_disabled":
+		return "stackset_trusted_access_missing"
+	case "delegated_admin_missing":
+		return "delegated_admin_recommended"
+	case "create_stack_instance_throttled":
+		return "partial_stackset_coverage"
+	default:
+		return strings.TrimSpace(code)
+	}
+}
+
+func awsStackSetDiagnosticSeverity(code string) string {
+	switch code {
+	case "delegated_admin_recommended", "partial_stackset_coverage", "region_unsupported_or_not_opted_in":
+		return "warning"
+	default:
+		return "blocking"
+	}
+}
+
+func awsStackSetDiagnosticAction(code string) string {
+	switch code {
+	case "stackset_trusted_access_missing":
+		return "Enable Organizations trusted access for CloudFormation StackSets, then refresh status."
+	case "delegated_admin_recommended":
+		return "Register a delegated administrator for StackSets to reduce management-account blast radius."
+	case "member_account_permission_denied":
+		return "Fix member-account StackSet permissions, retry that instance, then refresh status."
+	case "region_unsupported_or_not_opted_in":
+		return "Use an opted-in region or enable the target region before relaunching StackSet coverage."
+	case "partial_stackset_coverage":
+		return "Retry failed StackSet instances, then refresh status before relying on coverage."
+	default:
+		return "Open the StackSet launch URL, complete deployment, then refresh status."
+	}
+}
+
+func awsStackSetDiagnosticTradeoff(code string) string {
+	switch code {
+	case "delegated_admin_recommended":
+		return "Using the management account can work, but delegated administration narrows the operational blast radius."
+	case "partial_stackset_coverage":
+		return "Leaving failed instances unresolved keeps healthy accounts visible, but Identrail will not claim full organization coverage."
+	case "region_unsupported_or_not_opted_in":
+		return "Skipping unsupported regions avoids failed deployments, but coverage will exclude workloads in those regions."
+	default:
+		return ""
+	}
+}
+
+func awsStackSetDiagnosticActions(code string) []AWSConnectorNextAction {
+	switch code {
+	case "stackset_trusted_access_missing":
+		return []AWSConnectorNextAction{AWSConnectorNextActionEnableTrustedAccess, AWSConnectorNextActionRefreshStatus, AWSConnectorNextActionOpenDocs}
+	case "delegated_admin_recommended":
+		return []AWSConnectorNextAction{AWSConnectorNextActionRegisterDelegatedAdmin, AWSConnectorNextActionRefreshStatus, AWSConnectorNextActionOpenDocs}
+	case "selected_target_missing_stackset_instance", "cloudformation_stack_not_deployed":
+		return []AWSConnectorNextAction{AWSConnectorNextActionOpenStackSet, AWSConnectorNextActionRefreshStatus}
+	default:
+		return []AWSConnectorNextAction{AWSConnectorNextActionOpenStackSet, AWSConnectorNextActionRefreshStatus, AWSConnectorNextActionOpenDocs}
+	}
+}
+
+func awsStackSetInstanceScope(accountID string, region string) string {
+	return strings.Trim(strings.TrimSpace(accountID)+"/"+strings.TrimSpace(region), "/")
+}
+
+func dedupeAWSStackSetDiagnostics(diagnostics []AWSStackSetOnboardingDiagnostic) []AWSStackSetOnboardingDiagnostic {
+	out := make([]AWSStackSetOnboardingDiagnostic, 0, len(diagnostics))
+	seen := map[string]struct{}{}
+	for _, diagnostic := range diagnostics {
+		key := strings.Join([]string{
+			strings.TrimSpace(diagnostic.Code),
+			strings.TrimSpace(diagnostic.AffectedScope),
+			strings.TrimSpace(diagnostic.EvidenceRef),
+		}, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, diagnostic)
+	}
+	return out
 }
 
 func collectStackSetOUIDs(units []awscontract.OrganizationUnit) []string {

--- a/internal/api/aws_stackset_onboarding_test.go
+++ b/internal/api/aws_stackset_onboarding_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/providers/awscontract"
 	"github.com/identrail/identrail/internal/telemetry"
 	"go.uber.org/zap"
 )
@@ -124,6 +125,9 @@ func TestGetAWSStackSetOnboardingFixtureStates(t *testing.T) {
 	if degraded.Summary.SuspendedInstances == 0 {
 		t.Fatalf("expected suspended instances from the degraded fixture")
 	}
+	if !hasNonBlockingAWSStackSetDiagnostic(degraded.Diagnostics, "suspended_accounts_excluded") {
+		t.Fatalf("expected suspended accounts to stay advisory, got %+v", degraded.Diagnostics)
+	}
 
 	partial, err := svc.GetAWSStackSetOnboarding(ctx, "default", "project-a", AWSStackSetOnboardingRequest{ConnectorID: "aws-prod", FixtureState: "partial_failure"})
 	if err != nil {
@@ -138,6 +142,9 @@ func TestGetAWSStackSetOnboardingFixtureStates(t *testing.T) {
 	if len(partial.RecoveryActions) == 0 {
 		t.Fatalf("expected recovery actions in partial fixture")
 	}
+	if len(partial.Diagnostics) < 2 || partial.Diagnostics[0].Code != "member_account_permission_denied" || partial.Diagnostics[0].Severity != "blocking" {
+		t.Fatalf("expected blocking member-account permission diagnostic before warnings, got %+v", partial.Diagnostics)
+	}
 
 	denied, err := svc.GetAWSStackSetOnboarding(ctx, "default", "project-a", AWSStackSetOnboardingRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
 	if err != nil {
@@ -149,6 +156,67 @@ func TestGetAWSStackSetOnboardingFixtureStates(t *testing.T) {
 	if denied.Validation.BlockingCount == 0 {
 		t.Fatalf("expected blocking prereqs when trusted access unavailable, got %+v", denied.Validation)
 	}
+}
+
+func TestAWSStackSetRepairDiagnosticsCoversDegradedAndOrdersBlockers(t *testing.T) {
+	plan := awscontract.StackSetOnboardingPlan{
+		StackSetName:   "identrail-readonly",
+		OrganizationID: "o-example",
+		Instances: []awscontract.StackSetOnboardingInstance{
+			{
+				AccountID:     "111111111111",
+				Region:        "us-east-1",
+				State:         awscontract.StackSetStateDegraded,
+				FailureReason: "Role validation drifted after deployment.",
+				Resumable:     true,
+			},
+			{
+				AccountID:     "222222222222",
+				Region:        "us-east-1",
+				State:         awscontract.StackSetStatePermissionDenied,
+				FailureReason: "AccessDenied during StackSet operation.",
+				Resumable:     true,
+			},
+			{
+				AccountID:     "333333333333",
+				Region:        "us-east-1",
+				State:         awscontract.StackSetStateSuspended,
+				FailureReason: "Account is suspended.",
+			},
+		},
+	}
+
+	diagnostics := awsStackSetRepairDiagnostics(plan, nil)
+	if len(diagnostics) != 3 {
+		t.Fatalf("expected three diagnostics, got %+v", diagnostics)
+	}
+	if diagnostics[0].Code != "member_account_permission_denied" || diagnostics[0].Severity != "blocking" {
+		t.Fatalf("expected permission blocker first, got %+v", diagnostics)
+	}
+	if !hasAWSStackSetDiagnostic(diagnostics, "partial_stackset_coverage", "warning") {
+		t.Fatalf("expected degraded instance to produce partial-coverage warning, got %+v", diagnostics)
+	}
+	if !hasNonBlockingAWSStackSetDiagnostic(diagnostics, "suspended_accounts_excluded") {
+		t.Fatalf("expected suspended instance to produce advisory diagnostic, got %+v", diagnostics)
+	}
+}
+
+func hasNonBlockingAWSStackSetDiagnostic(diagnostics []AWSStackSetOnboardingDiagnostic, code string) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code == code && awsStackSetDiagnosticRank(diagnostic.Severity) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAWSStackSetDiagnostic(diagnostics []AWSStackSetOnboardingDiagnostic, code string, severity string) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code == code && diagnostic.Severity == severity {
+			return true
+		}
+	}
+	return false
 }
 
 func TestGetAWSStackSetOnboardingRejectsInvalidInputs(t *testing.T) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -828,8 +828,15 @@ export type AWSConnectionPermissionCheck = {
 
 export type AWSConnectionDiagnostic = {
   code: string;
+  severity?: string;
+  affected_scope?: string;
   message: string;
+  operator_action?: string;
   remediation?: string;
+  retryable?: boolean;
+  evidence_ref?: string;
+  tradeoff?: string;
+  actions?: AWSConnectorNextAction[];
 };
 
 export type AWSPermissionPreviewItem = {
@@ -9077,9 +9084,15 @@ export type AWSStackSetOnboardingDiagnostic = {
   source: string;
   scope?: string;
   code: string;
+  severity?: string;
+  affected_scope?: string;
   message: string;
+  operator_action?: string;
   remediation?: string;
   retryable: boolean;
+  evidence_ref?: string;
+  tradeoff?: string;
+  actions?: AWSConnectorNextAction[];
 };
 
 export type AWSStackSetOnboardingCoverageGap = {
@@ -9709,6 +9722,9 @@ export type AWSConnectorNextAction =
   | 'validate_role'
   | 'refresh_status'
   | 'repair_permissions'
+  | 'refresh_policy'
+  | 'copy_trust_policy'
+  | 'open_docs'
   | 'start_intelligence';
 
 export type AWSConnectorTargetSummary = {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -9056,6 +9056,26 @@ describe('Domain-first app routes', () => {
             evidence_ref: 'aws-permission-check:iam:ListRoles',
             tradeoff: 'Identrail will not claim coverage for services it cannot read.',
             actions: ['refresh_policy', 'validate_role', 'refresh_status']
+          },
+          {
+            code: 'delegated_admin_recommended',
+            severity: 'warning',
+            affected_scope: 'organization',
+            message: 'Delegated administration is recommended for StackSets.',
+            operator_action: 'Open the runbook and register a delegated admin.',
+            remediation: 'Open the runbook and register a delegated admin.',
+            retryable: true,
+            evidence_ref: 'aws-stackset:delegated-admin',
+            tradeoff: 'Delegated administration narrows the management-account blast radius.',
+            actions: ['open_docs']
+          }
+        ],
+        permission_checks: [
+          {
+            name: 'iam:ListRoles',
+            passed: false,
+            message: 'IAM read-only permissions are missing for the connector role.',
+            remediation: 'Refresh the expected policy, update the role, then revalidate.'
           }
         ]
       }
@@ -9081,7 +9101,9 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByRole('heading', { name: /Next setup action/i })).toBeInTheDocument();
     expect(screen.getByText(/Primary blocker/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/Missing Read Only Permission Tier/i).length).toBeGreaterThanOrEqual(1);
+    const repairList = screen.getByLabelText('AWS guided repair actions');
+    expect(within(repairList).getAllByText(/Missing Read Only Permission Tier/i)).toHaveLength(1);
+    expect(screen.getByRole('link', { name: /Open runbook/i })).toHaveAttribute('href', '/docs');
     expect(screen.getByText(/Identrail will not claim coverage/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /Refresh policy/i }));
@@ -9093,6 +9115,62 @@ describe('Domain-first app routes', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
+  });
+
+  it('labels warning-only AWS guided repair items as warnings', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        status: 'degraded',
+        health_status: 'warning',
+        diagnostics: [
+          {
+            code: 'partial_stackset_coverage',
+            severity: 'warning',
+            affected_scope: 'organization',
+            message: 'One StackSet instance is degraded.',
+            operator_action: 'Retry failed StackSet instances, then refresh status.',
+            remediation: 'Retry failed StackSet instances, then refresh status.',
+            retryable: true,
+            evidence_ref: 'aws-stackset:partial',
+            actions: ['refresh_status']
+          }
+        ],
+        permission_checks: []
+      }
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const repairList = await screen.findByLabelText('AWS guided repair actions');
+    expect(within(repairList).getByText(/Primary warning/i)).toBeInTheDocument();
+    expect(within(repairList).queryByText(/Primary blocker/i)).not.toBeInTheDocument();
   });
 
   it('preserves AWS connector 404 details for stale environments', async () => {
@@ -10263,11 +10341,10 @@ describe('Domain-first app routes', () => {
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
-    // The panel prefers the connector-specific launch-response snapshot over
-    // the synthetic refresh endpoint, so the connector-tied recovery action
-    // wins even after refresh fetches the fixture payload.
-    expect(await screen.findByText(/Connector-specific recovery action/i)).toBeInTheDocument();
-    expect(screen.queryByText(/Fixture recovery action/i)).not.toBeInTheDocument();
+    // Refresh results supersede the launch snapshot so operators see the
+    // latest reconciled StackSet state after status polling completes.
+    expect(await screen.findByText(/Fixture recovery action/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Connector-specific recovery action/i)).not.toBeInTheDocument();
   });
 
   it('hydrates the StackSet name from the existing connection so resume matches stored setup', async () => {
@@ -11056,7 +11133,7 @@ describe('Domain-first app routes', () => {
     fireEvent.click(screen.getByRole('button', { name: /This AWS account/i }));
 
     // Under Single account, the persisted StackSet launch URL must not surface.
-    const links = screen.queryAllByRole('link', { name: /Open AWS stack|Open StackSet in AWS/i });
+    const links = screen.queryAllByRole('link', { name: /Open AWS stack|Open StackSet(?: in AWS)?/i });
     for (const link of links) {
       expect(link.getAttribute('href') ?? '').not.toContain('stacksets/persisted');
     }
@@ -11112,7 +11189,7 @@ describe('Domain-first app routes', () => {
 
     // Selected OUs shares the stackset_ deployment method with organization,
     // but the scope type differs — the persisted URL must not leak through.
-    const links = screen.queryAllByRole('link', { name: /Open AWS stack|Open StackSet in AWS/i });
+    const links = screen.queryAllByRole('link', { name: /Open AWS stack|Open StackSet(?: in AWS)?/i });
     for (const link of links) {
       expect(link.getAttribute('href') ?? '').not.toContain('stacksets/org-persisted');
     }

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -9018,6 +9018,83 @@ describe('Domain-first app routes', () => {
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
   });
 
+  it('shows guided AWS repair blockers with safe action buttons', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        connected: false,
+        status: 'degraded',
+        health_status: 'error',
+        onboarding_status: 'needs_fix',
+        diagnostics: [
+          {
+            code: 'missing_read_only_permission_tier',
+            severity: 'blocking',
+            affected_scope: 'account/123456789012',
+            message: 'IAM read-only permissions are missing for the connector role.',
+            operator_action: 'Refresh the expected policy, update the role, then revalidate.',
+            remediation: 'Refresh the expected policy, update the role, then revalidate.',
+            retryable: true,
+            evidence_ref: 'aws-permission-check:iam:ListRoles',
+            tradeoff: 'Identrail will not claim coverage for services it cannot read.',
+            actions: ['refresh_policy', 'validate_role', 'refresh_status']
+          }
+        ]
+      }
+    });
+    const refreshPolicy = vi.spyOn(api.apiClient, 'refreshAWSConnectorPolicy').mockResolvedValue({
+      policy_hash: 'sha256:updated',
+      policy_document: {},
+      permission_preview: [
+        { service: 'IAM', actions: ['iam:ListRoles'], resources: ['*'], reason: 'List IAM roles.' }
+      ],
+      permission_tiers: []
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: /Next setup action/i })).toBeInTheDocument();
+    expect(screen.getByText(/Primary blocker/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Missing Read Only Permission Tier/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/Identrail will not claim coverage/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Refresh policy/i }));
+
+    await waitFor(() =>
+      expect(refreshPolicy).toHaveBeenCalledWith(
+        'aws-connector-1',
+        { workspace_id: 'workspace-a', project_id: 'production' },
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+  });
+
   it('preserves AWS connector 404 details for stale environments', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3937,23 +3937,25 @@ function awsGuidedRepairItems(connection: AWSConnectionStatus | null, stackSetOn
   for (const diagnostic of connection?.diagnostics ?? []) {
     items.push(awsRepairItemFromConnectionDiagnostic(diagnostic, connection));
   }
-  for (const check of connection?.permission_checks ?? []) {
-    if (check.passed) {
-      continue;
+  if ((connection?.diagnostics ?? []).length === 0) {
+    for (const check of connection?.permission_checks ?? []) {
+      if (check.passed) {
+        continue;
+      }
+      const code = /assumerole/i.test(check.name) ? 'assume_role_failed' : 'missing_read_only_permission_tier';
+      items.push({
+        id: `check-${check.name}`,
+        code,
+        severity: 'blocking',
+        scope: awsAccountRegionLabel(connection),
+        message: check.message,
+        operatorAction: check.remediation || (code === 'assume_role_failed' ? 'Update the trust policy, then revalidate the role.' : 'Refresh the expected policy, update the role, then revalidate.'),
+        evidenceRef: `aws-permission-check:${check.name}`,
+        tradeoff: code === 'missing_read_only_permission_tier' ? 'Identrail will not claim coverage for services it cannot read.' : '',
+        retryable: true,
+        actions: code === 'assume_role_failed' ? ['copy_trust_policy', 'validate_role', 'refresh_status'] : ['refresh_policy', 'validate_role', 'refresh_status']
+      });
     }
-    const code = /assumerole/i.test(check.name) ? 'assume_role_failed' : 'missing_read_only_permission_tier';
-    items.push({
-      id: `check-${check.name}`,
-      code,
-      severity: 'blocking',
-      scope: awsAccountRegionLabel(connection),
-      message: check.message,
-      operatorAction: check.remediation || (code === 'assume_role_failed' ? 'Update the trust policy, then revalidate the role.' : 'Refresh the expected policy, update the role, then revalidate.'),
-      evidenceRef: `aws-permission-check:${check.name}`,
-      tradeoff: code === 'missing_read_only_permission_tier' ? 'Identrail will not claim coverage for services it cannot read.' : '',
-      retryable: true,
-      actions: code === 'assume_role_failed' ? ['copy_trust_policy', 'validate_role', 'refresh_status'] : ['refresh_policy', 'validate_role', 'refresh_status']
-    });
   }
   for (const prereq of stackSetOnboarding?.validation.prerequisites ?? connection?.prerequisites ?? []) {
     if (prereq.satisfied) {
@@ -4062,6 +4064,13 @@ function awsRepairActionLabel(action: AWSConnectorNextAction): string {
   }
 }
 
+function awsGuidedRepairPriorityLabel(item: AWSGuidedRepairItem, index: number): string {
+  if (index !== 0) {
+    return formatTokenLabel(item.severity);
+  }
+  return awsRepairSeverityRank(item.severity) === 0 ? 'Primary blocker' : `Primary ${formatTokenLabel(item.severity).toLowerCase()}`;
+}
+
 function AWSGuidedRepairList({
   items,
   actionsForItem
@@ -4082,7 +4091,7 @@ function AWSGuidedRepairList({
       {items.map((item, index) => (
         <article key={item.id} className={`idt-aws-repair-card is-${awsRepairSeverityRank(item.severity) === 0 ? 'blocking' : 'warning'}`}>
           <header>
-            <span>{index === 0 ? 'Primary blocker' : formatTokenLabel(item.severity)}</span>
+            <span>{awsGuidedRepairPriorityLabel(item, index)}</span>
             <strong>{formatTokenLabel(item.code)}</strong>
           </header>
           <p>{item.message}</p>
@@ -21343,13 +21352,10 @@ function AWSStackSetProgressPanel({
   onRefresh,
   refreshing
 }: AWSStackSetProgressPanelProps) {
-  // Prefer the start-response snapshot: it is derived from the connector's
-  // own targets and checkpoints. getAWSProjectStackSetOnboarding today uses
-  // a synthetic fixture that does not reflect this connector's OUs, accounts,
-  // or instances, so we only fall back to it when no start is available (an
-  // existing persisted connector on page load).
+  // Refresh responses reflect the latest AWS reconciliation, while the start
+  // response is only the launch snapshot.
   const onboarding: AWSStackSetOnboardingResult | undefined | null =
-    start?.stackset_onboarding ?? persistedOnboarding ?? null;
+    persistedOnboarding ?? start?.stackset_onboarding ?? null;
   const summary: AWSStackSetOnboardingSummary | undefined = onboarding?.summary;
   const coverage: AWSStackSetOnboardingCoverageExpectation | undefined = onboarding?.coverage_expectation;
   const recoveryActions: AWSStackSetOnboardingRecoveryAction[] = onboarding?.recovery_actions ?? [];
@@ -22668,6 +22674,9 @@ export function ProductAWSConnectPage() {
   const launchURL =
     cloudFormationAWSStart?.launch_url ??
     (persistedLaunchURLMatchesMode ? connection?.launch_url ?? '' : '');
+  const stackSetLaunchURL =
+    stackSetAWSStart?.launch_url ??
+    (persistedLaunchURLMatchesMode && isStackSetSetup ? connection?.launch_url ?? '' : '');
   const hasConnectorSetup = Boolean(awsCloudFormationStart || connection?.connector_id);
   const hasRoleOnlyConnection = Boolean(connection?.role_arn && !connection?.connector_id && !awsCloudFormationStart);
   const showOperationalPanels = Boolean(
@@ -22677,7 +22686,7 @@ export function ProductAWSConnectPage() {
       connection?.health_status === 'error'
   );
   const activeStackSetOnboarding =
-    stackSetAWSStart?.stackset_onboarding ?? awsStackSetOnboarding ?? null;
+    awsStackSetOnboarding ?? stackSetAWSStart?.stackset_onboarding ?? null;
   const guidedRepairItems = awsGuidedRepairItems(connection, activeStackSetOnboarding);
   const guidedRepairActionsForItem = (item: AWSGuidedRepairItem): DomainAction[] =>
     item.actions.slice(0, 3).map((action, index) => {
@@ -22696,11 +22705,11 @@ export function ProductAWSConnectPage() {
         case 'open_stackset':
           return {
             label,
-            href: stackSetAWSStart?.launch_url || connection?.launch_url || undefined,
+            href: stackSetLaunchURL || undefined,
             target: '_blank',
             icon: <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />,
             variant,
-            disabled: !(stackSetAWSStart?.launch_url || connection?.launch_url)
+            disabled: !stackSetLaunchURL
           };
         case 'refresh_status':
           return {
@@ -22747,7 +22756,7 @@ export function ProductAWSConnectPage() {
         case 'open_docs':
           return {
             label,
-            href: '/docs/aws-connect-troubleshooting',
+            href: '/docs',
             icon: <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />,
             variant,
             target: '_blank'

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -37,6 +37,8 @@ import {
   type AWSConnectorStartResponse,
   type AWSConnectorScopeType,
   type AWSConnectorDeploymentMethod,
+  type AWSConnectorNextAction,
+  type AWSConnectionDiagnostic,
   type AWSConnectionStatus,
   type AWSCodeBuildServiceRoleInventoryResult,
   type AWSCodeBuildServiceRoleRecord,
@@ -167,6 +169,7 @@ import {
   type AWSOrganizationsTopologyAccount,
   type AWSOrganizationsTopologyResult,
   type AWSStackSetOnboardingResult,
+  type AWSStackSetOnboardingDiagnostic,
   type AWSStackSetOnboardingInstance,
   type AWSStackSetOnboardingPrerequisite,
   type AWSStackSetOnboardingSummary,
@@ -238,6 +241,7 @@ import {
   DomainStatusPanel,
   DomainTimeline,
   type DomainDataTableColumn,
+  type DomainAction,
   type DomainTimelineEntry
 } from './components/app/DomainFoundation';
 import { getDomainAsset, type DomainAssetKey } from './design/domainAssets';
@@ -3878,6 +3882,252 @@ function AWSConnectionDiagnostics({
         </article>
       ))}
     </>
+  );
+}
+
+type AWSGuidedRepairItem = {
+  id: string;
+  code: string;
+  severity: string;
+  scope: string;
+  message: string;
+  operatorAction: string;
+  evidenceRef: string;
+  tradeoff: string;
+  retryable: boolean;
+  actions: AWSConnectorNextAction[];
+};
+
+function awsRepairSeverityRank(severity: string): number {
+  switch (severity) {
+    case 'critical':
+    case 'blocking':
+    case 'error':
+      return 0;
+    case 'warning':
+      return 1;
+    default:
+      return 2;
+  }
+}
+
+function awsRepairTone(items: AWSGuidedRepairItem[], connected: boolean): 'success' | 'warning' | 'danger' | 'neutral' {
+  if (items.some((item) => awsRepairSeverityRank(item.severity) === 0)) {
+    return 'danger';
+  }
+  if (items.length > 0) {
+    return 'warning';
+  }
+  return connected ? 'success' : 'neutral';
+}
+
+function awsRepairStatus(items: AWSGuidedRepairItem[], connected: boolean): string {
+  if (items.length === 0) {
+    return connected ? 'Healthy' : 'Pending';
+  }
+  const blockers = items.filter((item) => awsRepairSeverityRank(item.severity) === 0).length;
+  if (blockers > 0) {
+    return `${blockers} blocker${blockers === 1 ? '' : 's'}`;
+  }
+  return `${items.length} warning${items.length === 1 ? '' : 's'}`;
+}
+
+function awsGuidedRepairItems(connection: AWSConnectionStatus | null, stackSetOnboarding: AWSStackSetOnboardingResult | null): AWSGuidedRepairItem[] {
+  const items: AWSGuidedRepairItem[] = [];
+  for (const diagnostic of connection?.diagnostics ?? []) {
+    items.push(awsRepairItemFromConnectionDiagnostic(diagnostic, connection));
+  }
+  for (const check of connection?.permission_checks ?? []) {
+    if (check.passed) {
+      continue;
+    }
+    const code = /assumerole/i.test(check.name) ? 'assume_role_failed' : 'missing_read_only_permission_tier';
+    items.push({
+      id: `check-${check.name}`,
+      code,
+      severity: 'blocking',
+      scope: awsAccountRegionLabel(connection),
+      message: check.message,
+      operatorAction: check.remediation || (code === 'assume_role_failed' ? 'Update the trust policy, then revalidate the role.' : 'Refresh the expected policy, update the role, then revalidate.'),
+      evidenceRef: `aws-permission-check:${check.name}`,
+      tradeoff: code === 'missing_read_only_permission_tier' ? 'Identrail will not claim coverage for services it cannot read.' : '',
+      retryable: true,
+      actions: code === 'assume_role_failed' ? ['copy_trust_policy', 'validate_role', 'refresh_status'] : ['refresh_policy', 'validate_role', 'refresh_status']
+    });
+  }
+  for (const prereq of stackSetOnboarding?.validation.prerequisites ?? connection?.prerequisites ?? []) {
+    if (prereq.satisfied) {
+      continue;
+    }
+    const code = prereq.id === 'stackset.trusted_access_enabled'
+      ? 'stackset_trusted_access_missing'
+      : prereq.id === 'stackset.delegated_admin_registered'
+        ? 'delegated_admin_recommended'
+        : 'selected_target_missing_stackset_instance';
+    items.push({
+      id: `prereq-${prereq.id}`,
+      code,
+      severity: prereq.severity,
+      scope: prereq.id,
+      message: prereq.reason,
+      operatorAction: prereq.remediation || 'Resolve this prerequisite, then refresh status.',
+      evidenceRef: `aws-stackset-prerequisite:${prereq.id}`,
+      tradeoff: code === 'delegated_admin_recommended' ? 'Delegated administration narrows the management-account blast radius.' : '',
+      retryable: true,
+      actions: code === 'stackset_trusted_access_missing'
+        ? ['open_docs', 'refresh_status']
+        : code === 'delegated_admin_recommended'
+          ? ['open_docs', 'refresh_status']
+          : ['open_stackset', 'refresh_status']
+    });
+  }
+  for (const diagnostic of stackSetOnboarding?.diagnostics ?? []) {
+    items.push(awsRepairItemFromStackSetDiagnostic(diagnostic));
+  }
+  return dedupeAWSGuidedRepairItems(items)
+    .sort((left, right) => awsRepairSeverityRank(left.severity) - awsRepairSeverityRank(right.severity))
+    .slice(0, 6);
+}
+
+function awsRepairItemFromConnectionDiagnostic(diagnostic: AWSConnectionDiagnostic, connection: AWSConnectionStatus | null): AWSGuidedRepairItem {
+  return {
+    id: `diagnostic-${diagnostic.code}-${diagnostic.affected_scope ?? diagnostic.evidence_ref ?? diagnostic.message}`,
+    code: diagnostic.code,
+    severity: diagnostic.severity ?? (connection?.connected ? 'warning' : 'blocking'),
+    scope: diagnostic.affected_scope ?? awsAccountRegionLabel(connection),
+    message: diagnostic.message,
+    operatorAction: diagnostic.operator_action ?? diagnostic.remediation ?? 'Resolve this diagnostic, then revalidate the role.',
+    evidenceRef: diagnostic.evidence_ref ?? `aws-connector:${diagnostic.code}`,
+    tradeoff: diagnostic.tradeoff ?? '',
+    retryable: diagnostic.retryable ?? true,
+    actions: diagnostic.actions ?? ['validate_role', 'refresh_status']
+  };
+}
+
+function awsRepairItemFromStackSetDiagnostic(diagnostic: AWSStackSetOnboardingDiagnostic): AWSGuidedRepairItem {
+  return {
+    id: `stackset-${diagnostic.code}-${diagnostic.affected_scope ?? diagnostic.scope ?? diagnostic.evidence_ref ?? diagnostic.message}`,
+    code: diagnostic.code,
+    severity: diagnostic.severity ?? 'warning',
+    scope: diagnostic.affected_scope ?? diagnostic.scope ?? diagnostic.source,
+    message: diagnostic.message,
+    operatorAction: diagnostic.operator_action ?? diagnostic.remediation ?? 'Resolve this StackSet diagnostic, then refresh status.',
+    evidenceRef: diagnostic.evidence_ref ?? `aws-stackset:${diagnostic.code}`,
+    tradeoff: diagnostic.tradeoff ?? '',
+    retryable: diagnostic.retryable,
+    actions: diagnostic.actions ?? ['open_stackset', 'refresh_status']
+  };
+}
+
+function dedupeAWSGuidedRepairItems(items: AWSGuidedRepairItem[]): AWSGuidedRepairItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = `${item.code}\0${item.scope}\0${item.evidenceRef}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function awsRepairActionLabel(action: AWSConnectorNextAction): string {
+  switch (action) {
+    case 'launch_stack':
+      return 'Open AWS stack';
+    case 'open_stackset':
+      return 'Open StackSet';
+    case 'enable_trusted_access':
+      return 'Trusted access guide';
+    case 'register_delegated_admin':
+      return 'Delegated admin guide';
+    case 'select_targets':
+      return 'Review targets';
+    case 'validate_role':
+      return 'Revalidate role';
+    case 'refresh_status':
+      return 'Refresh status';
+    case 'repair_permissions':
+      return 'Repair permissions';
+    case 'refresh_policy':
+      return 'Refresh policy';
+    case 'copy_trust_policy':
+      return 'Copy trust policy';
+    case 'open_docs':
+      return 'Open runbook';
+    case 'start_intelligence':
+      return 'Start discovery';
+    default:
+      return formatTokenLabel(action);
+  }
+}
+
+function AWSGuidedRepairList({
+  items,
+  actionsForItem
+}: {
+  items: AWSGuidedRepairItem[];
+  actionsForItem: (item: AWSGuidedRepairItem) => DomainAction[];
+}) {
+  if (items.length === 0) {
+    return (
+      <article className="idt-aws-repair-card is-clear">
+        <strong>All checks passing</strong>
+        <p>Connector diagnostics are clear for this environment.</p>
+      </article>
+    );
+  }
+  return (
+    <div className="idt-aws-repair-list" aria-label="AWS guided repair actions">
+      {items.map((item, index) => (
+        <article key={item.id} className={`idt-aws-repair-card is-${awsRepairSeverityRank(item.severity) === 0 ? 'blocking' : 'warning'}`}>
+          <header>
+            <span>{index === 0 ? 'Primary blocker' : formatTokenLabel(item.severity)}</span>
+            <strong>{formatTokenLabel(item.code)}</strong>
+          </header>
+          <p>{item.message}</p>
+          <p><strong>Next:</strong> {item.operatorAction}</p>
+          {item.tradeoff ? <small>{item.tradeoff}</small> : null}
+          <dl>
+            <div>
+              <dt>Scope</dt>
+              <dd>{item.scope || 'Current connector'}</dd>
+            </div>
+            <div>
+              <dt>Evidence</dt>
+              <dd>{item.evidenceRef}</dd>
+            </div>
+          </dl>
+          <div className="idt-source-actions">
+            {actionsForItem(item).map((action, actionIndex) =>
+              action.href ? (
+                <a
+                  key={`${item.id}-${action.label}-${actionIndex}`}
+                  className={`idt-btn ${action.variant === 'primary' ? 'idt-btn-primary' : action.variant === 'secondary' ? 'idt-btn-dark' : 'idt-btn-ghost'}`}
+                  href={action.href}
+                  target={action.target}
+                  rel={action.rel ?? (action.target === '_blank' ? 'noreferrer' : undefined)}
+                >
+                  {action.icon}
+                  <span>{action.label}</span>
+                </a>
+              ) : (
+                <button
+                  key={`${item.id}-${action.label}-${actionIndex}`}
+                  className={`idt-btn ${action.variant === 'primary' ? 'idt-btn-primary' : action.variant === 'secondary' ? 'idt-btn-dark' : 'idt-btn-ghost'}`}
+                  type="button"
+                  onClick={action.onClick}
+                  disabled={action.disabled}
+                >
+                  {action.icon}
+                  <span>{action.label}</span>
+                </button>
+              )
+            )}
+          </div>
+        </article>
+      ))}
+    </div>
   );
 }
 
@@ -22228,6 +22478,49 @@ export function ProductAWSConnectPage() {
     }
   };
 
+  const handleAWSRefreshPolicy = async () => {
+    if (!selectedEnvironmentID || !activeConnectorID) {
+      setErrorMessage('Prepare or select an AWS connector before refreshing the expected policy.');
+      return;
+    }
+    setSubmitting(true);
+    setErrorMessage('');
+    setAWSSetupMessage('');
+    const requestID = ++awsPollRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const requestScopeKey = scopeKeyRef.current;
+    const isStale = () =>
+      requestID !== awsPollRequestRef.current ||
+      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+      scopeKeyRef.current !== requestScopeKey;
+    try {
+      const response = await apiClient.refreshAWSConnectorPolicy(
+        activeConnectorID,
+        {
+          workspace_id: scope.workspaceID,
+          project_id: requestEnvironmentID
+        },
+        buildProductAuthContext(scope)
+      );
+      if (isStale()) {
+        return;
+      }
+      setAWSPermissionPreview(response.permission_preview);
+      setAWSPermissionTiers(response.permission_tiers ?? []);
+      setAWSPreviewOpen(true);
+      setSuccessMessage('Expected AWS read-only policy refreshed.');
+    } catch (error) {
+      if (isStale()) {
+        return;
+      }
+      setErrorMessage(formatAWSConnectorSetupError(error));
+    } finally {
+      if (!isStale()) {
+        setSubmitting(false);
+      }
+    }
+  };
+
   const handleAWSSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!selectedEnvironmentID) {
@@ -22383,6 +22676,98 @@ export function ProductAWSConnectPage() {
       connection?.health_status === 'warning' ||
       connection?.health_status === 'error'
   );
+  const activeStackSetOnboarding =
+    stackSetAWSStart?.stackset_onboarding ?? awsStackSetOnboarding ?? null;
+  const guidedRepairItems = awsGuidedRepairItems(connection, activeStackSetOnboarding);
+  const guidedRepairActionsForItem = (item: AWSGuidedRepairItem): DomainAction[] =>
+    item.actions.slice(0, 3).map((action, index) => {
+      const label = awsRepairActionLabel(action);
+      const variant = index === 0 ? 'primary' : 'ghost';
+      switch (action) {
+        case 'launch_stack':
+          return {
+            label,
+            href: launchURL || undefined,
+            target: '_blank',
+            icon: <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />,
+            variant,
+            disabled: !launchURL
+          };
+        case 'open_stackset':
+          return {
+            label,
+            href: stackSetAWSStart?.launch_url || connection?.launch_url || undefined,
+            target: '_blank',
+            icon: <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />,
+            variant,
+            disabled: !(stackSetAWSStart?.launch_url || connection?.launch_url)
+          };
+        case 'refresh_status':
+          return {
+            label,
+            onClick: () => {
+              if (activeConnectorID) {
+                void handleAWSPoll();
+                if (isStackSetSetup) {
+                  void refreshStackSetOnboarding();
+                }
+              } else {
+                void refreshConnection('manual');
+              }
+            },
+            variant,
+            disabled: refreshingConnection || submitting
+          };
+        case 'validate_role':
+          return {
+            label,
+            onClick: () => {
+              document.querySelector<HTMLButtonElement>('[data-aws-validate-action="true"]')?.click();
+            },
+            variant,
+            disabled: !canValidateRole || submitting
+          };
+        case 'refresh_policy':
+          return {
+            label,
+            onClick: () => void handleAWSRefreshPolicy(),
+            variant,
+            disabled: !activeConnectorID || submitting
+          };
+        case 'copy_trust_policy':
+          return {
+            label,
+            onClick: () => void copyAWSManualValue('trust-policy', manualTrustPolicy),
+            variant,
+            disabled: !manualTrustPolicy
+          };
+        case 'enable_trusted_access':
+        case 'register_delegated_admin':
+        case 'repair_permissions':
+        case 'open_docs':
+          return {
+            label,
+            href: '/docs/aws-connect-troubleshooting',
+            icon: <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />,
+            variant,
+            target: '_blank'
+          };
+        case 'select_targets':
+          return {
+            label,
+            onClick: () => document.querySelector<HTMLInputElement>('[aria-describedby="idt-aws-scope-regions-hint"]')?.focus(),
+            variant
+          };
+        case 'start_intelligence':
+          return {
+            label,
+            href: controlPath,
+            variant
+          };
+        default:
+          return { label, onClick: () => undefined, variant };
+      }
+    });
   const onboardingStatus = connection?.onboarding_status ?? awsCloudFormationStart?.onboarding_status ?? (connectedNow ? 'connected' : 'draft');
   const setupSummaryTitle = (() => {
     if (connectedNow) {
@@ -22780,7 +23165,7 @@ export function ProductAWSConnectPage() {
                           {submitting ? 'Refreshing...' : 'Refresh status'}
                         </button>
                       ) : null}
-                      <button className="idt-btn idt-btn-primary" type="submit" disabled={!canSubmit || !canValidateRole}>
+                      <button className="idt-btn idt-btn-primary" type="submit" disabled={!canSubmit || !canValidateRole} data-aws-validate-action="true">
                         {submitting ? 'Validating...' : 'Validate connection'}
                       </button>
                     </div>
@@ -22825,7 +23210,7 @@ export function ProductAWSConnectPage() {
                           {submitting ? 'Refreshing...' : 'Refresh status'}
                         </button>
                       ) : null}
-                      <button className="idt-btn idt-btn-primary" type="submit" disabled={!canSubmit || !canValidateRole}>
+                      <button className="idt-btn idt-btn-primary" type="submit" disabled={!canSubmit || !canValidateRole} data-aws-validate-action="true">
                         {submitting ? 'Validating...' : 'Validate role'}
                       </button>
                     </div>
@@ -22889,6 +23274,17 @@ export function ProductAWSConnectPage() {
                 ) : null}
               </div>
             </section>
+
+            {(hasConnectorSetup || guidedRepairItems.length > 0 || connectedNow) ? (
+              <DomainStatusPanel
+                eyebrow="Guided repair"
+                title={guidedRepairItems.length > 0 ? 'Next setup action' : 'Connector health summary'}
+                status={awsRepairStatus(guidedRepairItems, connectedNow)}
+                tone={awsRepairTone(guidedRepairItems, connectedNow)}
+              >
+                <AWSGuidedRepairList items={guidedRepairItems} actionsForItem={guidedRepairActionsForItem} />
+              </DomainStatusPanel>
+            ) : null}
 
             {showOperationalPanels ? (
               <>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -23999,6 +23999,74 @@ html[data-theme='light'] .idt-app-shell-screen select {
   margin: 0;
 }
 
+.idt-aws-repair-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.idt-aws-repair-card {
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.8rem;
+  background: #050505;
+}
+
+.idt-aws-repair-card.is-blocking {
+  border-color: rgba(255, 90, 90, 0.42);
+}
+
+.idt-aws-repair-card.is-warning {
+  border-color: rgba(255, 153, 0, 0.38);
+}
+
+.idt-aws-repair-card.is-clear {
+  border-color: rgba(91, 221, 139, 0.34);
+}
+
+.idt-aws-repair-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.idt-aws-repair-card header span {
+  color: var(--app-dim);
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-aws-repair-card p {
+  margin: 0.55rem 0 0;
+  color: var(--app-muted);
+}
+
+.idt-aws-repair-card small {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--app-dim);
+}
+
+.idt-aws-repair-card dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin: 0.7rem 0 0;
+}
+
+.idt-aws-repair-card dt {
+  color: var(--app-dim);
+  font-size: 0.7rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-aws-repair-card dd {
+  margin: 0.15rem 0 0;
+  overflow-wrap: anywhere;
+}
+
 .idt-aws-control-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));


### PR DESCRIPTION
## Summary
- Adds stable AWS Connect diagnostic codes with severity, affected scope, retry metadata, evidence refs, tradeoffs, and safe repair actions.
- Enriches StackSet onboarding diagnostics from prerequisites and instance states, including trusted access, delegated admin, missing instances, permission denied, unsupported regions, and partial coverage.
- Adds a guided repair panel to AWS Connect, a troubleshooting runbook, and regression coverage for blocker-first repair actions and External ID redaction.

Closes #1754

## Validation
- go test ./internal/api
- go test ./internal/api -run 'TestRouterAWSConnection(OnboardingReturnsTrustRemediation|DiagnosticsRedactExternalID)|TestUpsertAWSConnectionReportsUnavailableWriteCapability|TestRouterAWSConnectorCloudFormationFlow|TestRouterAWSConnectorOrganizationStackSetFlow|TestAWSConnectorValidateClearsStackSetLaunchPrerequisitesWhenConnected|TestAWSStackSetOnboarding'\n- npm --prefix web test -- --run productShell.test.tsx --testNamePattern='AWS connect|guided AWS repair|StackSet|diagnostic|permission'\n- npm --prefix web run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds guided AWS repair diagnostics and a blocker‑first repair panel with safe, non‑destructive actions to unblock setup faster. Enriches StackSet onboarding diagnostics and prefers refreshed status for the latest view; aligns with Linear #1754.

- **New Features**
  - Standardized AWS Connect diagnostics with `severity`, `affected_scope`, `retryable`, `evidence_ref`, `tradeoff`, and `actions`; normalizes common codes (`assume_role_failed`, `external_id_mismatch`, `role_arn_malformed`, `missing_read_only_permission_tier`). Adds a guided repair panel with blocker/warning labels, scope/evidence details, and safe actions (`open_stackset`/`launch_stack`, `validate_role`, `refresh_status`, `refresh_policy`, `copy_trust_policy`, `open_docs`). Includes a troubleshooting runbook and extends next‑actions to `refresh_policy`, `copy_trust_policy`, `open_docs`.
  - StackSet onboarding diagnostics map prerequisites and instance states to stable codes and actions; adds `selected_target_missing_stackset_instance` and `suspended_accounts_excluded` alongside existing codes (`stackset_trusted_access_missing`, `delegated_admin_recommended`, `cloudformation_stack_not_deployed`, `member_account_permission_denied`, `region_unsupported_or_not_opted_in`, `partial_stackset_coverage`).

- **Bug Fixes**
  - Redacts `external_id` across diagnostics, evidence refs, and permission checks; orders diagnostics by severity so blockers show first.
  - StackSet progress now shows refreshed results over the launch snapshot; standardizes unavailable capability errors under `missing_read_only_permission_tier` and prefers `operator_action` as the first remediation hint.

<sup>Written for commit 2e501781676e2b239e8b40a8ac96f15506fcced7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

