### PR TITLE
Address PR #1779 post-merge review comments

### DIFF
--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -315,8 +315,7 @@ type AWSConnectionStatus struct {
 	AutoOnboardNewAccounts bool                                `json:"auto_onboard_new_accounts"`
 	SetupSummary           string                              `json:"setup_summary"`
 	NextActions            []AWSConnectorNextAction            `json:"next_actions"`
-	ExternalID             string                              `json:"external_id,omitempty"`
-	IdentrailAccountID     string                              `json:"identrail_account_id,omitempty"`
+	ExternalID             string                              `json:"-"`
 	PermissionChecks       []AWSConnectionPermissionCheck      `json:"permission_checks"`
 	Diagnostics            []AWSConnectionDiagnostic           `json:"diagnostics"`
 	Capabilities           AWSConnectorCapabilities            `json:"capabilities"`
@@ -2383,9 +2382,6 @@ func (s *Service) awsConnectionStatusFromStored(ctx context.Context, stored db.T
 		status.ExternalID = s.awsExternalIDFromStored(ctx, stored)
 	}
 	status.ExternalIDConfigured = status.ExternalIDConfigured || status.ExternalID != ""
-	if s != nil && strings.TrimSpace(status.IdentrailAccountID) == "" {
-		status.IdentrailAccountID = strings.TrimSpace(s.AWSAccountID)
-	}
 	return status
 }
 

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -315,7 +315,8 @@ type AWSConnectionStatus struct {
 	AutoOnboardNewAccounts bool                                `json:"auto_onboard_new_accounts"`
 	SetupSummary           string                              `json:"setup_summary"`
 	NextActions            []AWSConnectorNextAction            `json:"next_actions"`
-	ExternalID             string                              `json:"-"`
+	ExternalID             string                              `json:"external_id,omitempty"`
+	IdentrailAccountID     string                              `json:"identrail_account_id,omitempty"`
 	PermissionChecks       []AWSConnectionPermissionCheck      `json:"permission_checks"`
 	Diagnostics            []AWSConnectionDiagnostic           `json:"diagnostics"`
 	Capabilities           AWSConnectorCapabilities            `json:"capabilities"`
@@ -2382,6 +2383,9 @@ func (s *Service) awsConnectionStatusFromStored(ctx context.Context, stored db.T
 		status.ExternalID = s.awsExternalIDFromStored(ctx, stored)
 	}
 	status.ExternalIDConfigured = status.ExternalIDConfigured || status.ExternalID != ""
+	if s != nil && strings.TrimSpace(status.IdentrailAccountID) == "" {
+		status.IdentrailAccountID = strings.TrimSpace(s.AWSAccountID)
+	}
 	return status
 }
 

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -2835,15 +2835,15 @@ func (s *Service) resolveAWSConnectorCapabilities(requested []domain.ConnectorCa
 			Reason:     unavailable.Reason,
 		})
 		diagnostics = append(diagnostics, AWSConnectionDiagnostic{
-			Code:           "missing_read_only_permission_tier",
-			Severity:       "blocking",
+			Code:           "capability_unavailable",
+			Severity:       "warning",
 			AffectedScope:  string(unavailable.Capability),
 			Message:        fmt.Sprintf("requested capability %q is unavailable: %s", unavailable.Capability, unavailable.Reason),
 			OperatorAction: fmt.Sprintf("Enable the %q capability gate for this deployment before requesting it; write-capable tiers also require a dedicated write role.", unavailable.Capability),
 			Remediation:    fmt.Sprintf("Enable the %q capability gate for this deployment before requesting it; write-capable tiers also require a dedicated write role.", unavailable.Capability),
 			Retryable:      true,
 			EvidenceRef:    fmt.Sprintf("aws-capability:%s/%s", unavailable.Capability, unavailable.Tier),
-			Actions:        []AWSConnectorNextAction{AWSConnectorNextActionRefreshPolicy, AWSConnectorNextActionOpenDocs, AWSConnectorNextActionValidateRole},
+			Actions:        []AWSConnectorNextAction{AWSConnectorNextActionOpenDocs, AWSConnectorNextActionRefreshPolicy},
 		})
 	}
 	return capabilities, diagnostics, nil
@@ -2909,8 +2909,12 @@ func awsDiagnosticFromPermissionCheck(setup awsConnectorSetupContract, roleARN s
 func normalizeAWSSetupDiagnosticCode(code string, text string) string {
 	normalized := strings.ToLower(strings.TrimSpace(code))
 	switch normalized {
-	case "assume_role_failed", "external_id_mismatch", "role_arn_malformed", "missing_read_only_permission_tier", "connector_config_missing":
+	case "assume_role_failed", "external_id_mismatch", "role_arn_malformed", "missing_read_only_permission_tier", "connector_config_missing", "assumed_role_access_denied", "capability_unavailable":
 		return normalized
+	case "aws_assumed_role_access_denied":
+		return "assumed_role_access_denied"
+	case "aws_capability_unavailable":
+		return "capability_unavailable"
 	case "aws_access_denied", "access_denied":
 		return "assume_role_failed"
 	}
@@ -2933,7 +2937,7 @@ func normalizeAWSSetupDiagnosticCode(code string, text string) string {
 
 func awsSetupDiagnosticSeverity(code string) string {
 	switch code {
-	case "delegated_admin_recommended", "partial_stackset_coverage":
+	case "delegated_admin_recommended", "partial_stackset_coverage", "capability_unavailable":
 		return "warning"
 	default:
 		return "blocking"
@@ -2972,6 +2976,10 @@ func awsSetupDiagnosticAction(code string, setup awsConnectorSetupContract) stri
 		return "Paste the full IAM role ARN from AWS, then revalidate."
 	case "missing_read_only_permission_tier":
 		return "Refresh the expected policy, update the read-only role permissions, then revalidate."
+	case "capability_unavailable":
+		return "Enable the requested capability gate for this Identrail deployment; the read-only connector will keep collecting in the meantime."
+	case "assumed_role_access_denied":
+		return "Trust already worked. Loosen the session policy, permissions boundary, or organization SCP that is blocking the assumed role, then revalidate."
 	case "connector_config_missing":
 		return "Configure the AWS CloudFormation template URL and checksum for this Identrail deployment."
 	default:
@@ -2986,6 +2994,8 @@ func awsSetupDiagnosticTradeoff(code string, setup awsConnectorSetupContract) st
 	switch code {
 	case "missing_read_only_permission_tier":
 		return "Keeping the narrower policy limits blast radius, but Identrail will not claim coverage for services it cannot read."
+	case "capability_unavailable":
+		return "Read-only discovery keeps running, but the requested capability stays off until the deployment gate opens it."
 	case "external_id_mismatch":
 		return "Rotating the trust-policy condition protects this tenant boundary, but the role will stay unavailable until AWS and Identrail match."
 	case "assume_role_failed":
@@ -2993,6 +3003,8 @@ func awsSetupDiagnosticTradeoff(code string, setup awsConnectorSetupContract) st
 			return "Fixing trust for one StackSet role restores validation without granting write remediation permissions."
 		}
 		return "Fixing trust restores read-only collection without granting write remediation permissions."
+	case "assumed_role_access_denied":
+		return "Trust already works; loosening the session policy or SCP restores caller-identity metadata without changing the trust boundary."
 	default:
 		return ""
 	}
@@ -3013,6 +3025,10 @@ func awsSetupDiagnosticActions(code string, setup awsConnectorSetupContract) []A
 		return []AWSConnectorNextAction{AWSConnectorNextActionCopyTrustPolicy, AWSConnectorNextActionValidateRole, AWSConnectorNextActionRefreshStatus}
 	case "missing_read_only_permission_tier":
 		return []AWSConnectorNextAction{AWSConnectorNextActionRefreshPolicy, AWSConnectorNextActionRepairPermissions, AWSConnectorNextActionValidateRole}
+	case "capability_unavailable":
+		return []AWSConnectorNextAction{AWSConnectorNextActionOpenDocs, AWSConnectorNextActionRefreshPolicy}
+	case "assumed_role_access_denied":
+		return []AWSConnectorNextAction{AWSConnectorNextActionRepairPermissions, AWSConnectorNextActionOpenDocs, AWSConnectorNextActionValidateRole}
 	case "role_arn_malformed":
 		return []AWSConnectorNextAction{AWSConnectorNextActionValidateRole, AWSConnectorNextActionOpenDocs}
 	default:

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -2909,10 +2909,10 @@ func awsDiagnosticFromPermissionCheck(setup awsConnectorSetupContract, roleARN s
 func normalizeAWSSetupDiagnosticCode(code string, text string) string {
 	normalized := strings.ToLower(strings.TrimSpace(code))
 	switch normalized {
-	case "assume_role_failed", "external_id_mismatch", "role_arn_malformed", "missing_read_only_permission_tier", "connector_config_missing", "assumed_role_access_denied", "capability_unavailable":
+	case "assume_role_failed", "external_id_mismatch", "role_arn_malformed", "missing_read_only_permission_tier", "connector_config_missing", "identity_metadata_unexpected", "capability_unavailable":
 		return normalized
-	case "aws_assumed_role_access_denied":
-		return "assumed_role_access_denied"
+	case "aws_identity_metadata_unexpected", "aws_identity_metadata_failed":
+		return "identity_metadata_unexpected"
 	case "aws_capability_unavailable":
 		return "capability_unavailable"
 	case "aws_access_denied", "access_denied":
@@ -2978,8 +2978,8 @@ func awsSetupDiagnosticAction(code string, setup awsConnectorSetupContract) stri
 		return "Refresh the expected policy, update the read-only role permissions, then revalidate."
 	case "capability_unavailable":
 		return "Enable the requested capability gate for this Identrail deployment; the read-only connector will keep collecting in the meantime."
-	case "assumed_role_access_denied":
-		return "Trust already worked. Loosen the session policy, permissions boundary, or organization SCP that is blocking the assumed role, then revalidate."
+	case "identity_metadata_unexpected":
+		return "Retry validation, then check STS endpoint reachability and session-credential integrity from this deployment — sts:GetCallerIdentity requires no permissions, so trust and session policies are not the cause."
 	case "connector_config_missing":
 		return "Configure the AWS CloudFormation template URL and checksum for this Identrail deployment."
 	default:
@@ -3003,8 +3003,8 @@ func awsSetupDiagnosticTradeoff(code string, setup awsConnectorSetupContract) st
 			return "Fixing trust for one StackSet role restores validation without granting write remediation permissions."
 		}
 		return "Fixing trust restores read-only collection without granting write remediation permissions."
-	case "assumed_role_access_denied":
-		return "Trust already works; loosening the session policy or SCP restores caller-identity metadata without changing the trust boundary."
+	case "identity_metadata_unexpected":
+		return "Trust and permissions already work; STS endpoint reachability or credential integrity is the likely cause, so no policy changes are recommended."
 	default:
 		return ""
 	}
@@ -3027,8 +3027,8 @@ func awsSetupDiagnosticActions(code string, setup awsConnectorSetupContract) []A
 		return []AWSConnectorNextAction{AWSConnectorNextActionRefreshPolicy, AWSConnectorNextActionRepairPermissions, AWSConnectorNextActionValidateRole}
 	case "capability_unavailable":
 		return []AWSConnectorNextAction{AWSConnectorNextActionOpenDocs, AWSConnectorNextActionRefreshPolicy}
-	case "assumed_role_access_denied":
-		return []AWSConnectorNextAction{AWSConnectorNextActionRepairPermissions, AWSConnectorNextActionOpenDocs, AWSConnectorNextActionValidateRole}
+	case "identity_metadata_unexpected":
+		return []AWSConnectorNextAction{AWSConnectorNextActionValidateRole, AWSConnectorNextActionRefreshStatus, AWSConnectorNextActionOpenDocs}
 	case "role_arn_malformed":
 		return []AWSConnectorNextAction{AWSConnectorNextActionValidateRole, AWSConnectorNextActionOpenDocs}
 	default:

--- a/internal/api/aws_connect_capabilities_test.go
+++ b/internal/api/aws_connect_capabilities_test.go
@@ -109,7 +109,7 @@ func TestUpsertAWSConnectionReportsUnavailableWriteCapability(t *testing.T) {
 
 	var capabilityDiagnostic *AWSConnectionDiagnostic
 	for i := range status.Diagnostics {
-		if status.Diagnostics[i].Code == "missing_read_only_permission_tier" &&
+		if status.Diagnostics[i].Code == "capability_unavailable" &&
 			status.Diagnostics[i].AffectedScope == string(domain.ConnectorCapabilityApprovedRemediation) {
 			capabilityDiagnostic = &status.Diagnostics[i]
 			break
@@ -118,8 +118,16 @@ func TestUpsertAWSConnectionReportsUnavailableWriteCapability(t *testing.T) {
 	if capabilityDiagnostic == nil {
 		t.Fatalf("expected a capability-scoped diagnostic, got %+v", status.Diagnostics)
 	}
+	if capabilityDiagnostic.Severity != "warning" {
+		t.Fatalf("capability diagnostic severity = %q, want warning so it does not block a healthy connector", capabilityDiagnostic.Severity)
+	}
 	if capabilityDiagnostic.Remediation == "" {
 		t.Fatalf("expected remediation guidance on capability diagnostic, got %+v", capabilityDiagnostic)
+	}
+	for _, diagnostic := range status.Diagnostics {
+		if diagnostic.Code == "missing_read_only_permission_tier" {
+			t.Fatalf("write-tier capability must not surface as a read-only permission blocker: %+v", diagnostic)
+		}
 	}
 }
 

--- a/internal/providers/aws/connector_validation.go
+++ b/internal/providers/aws/connector_validation.go
@@ -134,10 +134,19 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 	}
 	identity, err := identityClient(assumedCfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
+		code := classifyAWSError(err, "aws_identity_metadata_failed")
+		if code == "aws_access_denied" {
+			// AssumeRole already succeeded, so an AccessDenied on
+			// GetCallerIdentity is not a trust-policy problem — the assumed
+			// credentials were rejected by a session policy, permissions
+			// boundary, or organization SCP. Emit a distinct code so guided
+			// repair does not send the operator to the trust policy.
+			code = "aws_assumed_role_access_denied"
+		}
 		result.Diagnostics = append(result.Diagnostics, api.AWSConnectionDiagnostic{
-			Code:        classifyAWSError(err, "aws_identity_metadata_failed"),
+			Code:        code,
 			Message:     "Unable to read caller identity metadata after assuming the connector role.",
-			Remediation: "Verify the assumed-role credentials are usable and not blocked by an organization SCP or session policy.",
+			Remediation: "Verify the assumed-role credentials are usable and not blocked by an organization SCP, permissions boundary, or session policy.",
 		})
 		return result, nil
 	}

--- a/internal/providers/aws/connector_validation.go
+++ b/internal/providers/aws/connector_validation.go
@@ -134,19 +134,21 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 	}
 	identity, err := identityClient(assumedCfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
+		// sts:GetCallerIdentity has no permission surface — AWS documents that
+		// it returns the caller identity even under an explicit deny — and
+		// this validator supplies no session policy to AssumeRole. Any failure
+		// here (including AccessDenied) is therefore a credential/endpoint
+		// anomaly rather than a policy problem, so do not send the operator to
+		// trust, session, SCP, or permissions-boundary controls that cannot be
+		// responsible for the outcome.
 		code := classifyAWSError(err, "aws_identity_metadata_failed")
 		if code == "aws_access_denied" {
-			// AssumeRole already succeeded, so an AccessDenied on
-			// GetCallerIdentity is not a trust-policy problem — the assumed
-			// credentials were rejected by a session policy, permissions
-			// boundary, or organization SCP. Emit a distinct code so guided
-			// repair does not send the operator to the trust policy.
-			code = "aws_assumed_role_access_denied"
+			code = "aws_identity_metadata_unexpected"
 		}
 		result.Diagnostics = append(result.Diagnostics, api.AWSConnectionDiagnostic{
 			Code:        code,
 			Message:     "Unable to read caller identity metadata after assuming the connector role.",
-			Remediation: "Verify the assumed-role credentials are usable and not blocked by an organization SCP, permissions boundary, or session policy.",
+			Remediation: "Retry validation; if the failure persists, check STS endpoint reachability from this deployment and confirm the assumed session credentials are intact — sts:GetCallerIdentity requires no permissions, so trust and session policies are not the cause.",
 		})
 		return result, nil
 	}

--- a/internal/providers/aws/connector_validation.go
+++ b/internal/providers/aws/connector_validation.go
@@ -134,19 +134,19 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 	}
 	identity, err := identityClient(assumedCfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
-		// sts:GetCallerIdentity has no permission surface — AWS documents that
-		// it returns the caller identity even under an explicit deny — and
-		// this validator supplies no session policy to AssumeRole. Any failure
-		// here (including AccessDenied) is therefore a credential/endpoint
-		// anomaly rather than a policy problem, so do not send the operator to
-		// trust, session, SCP, or permissions-boundary controls that cannot be
-		// responsible for the outcome.
-		code := classifyAWSError(err, "aws_identity_metadata_failed")
-		if code == "aws_access_denied" {
-			code = "aws_identity_metadata_unexpected"
-		}
+		// AssumeRole already succeeded, so any failure of the follow-up
+		// GetCallerIdentity call — AccessDenied, throttling, invalid token,
+		// expired token, or otherwise — must not route the operator to
+		// AssumeRole/trust-policy repair actions. AWS documents that
+		// sts:GetCallerIdentity requires no permissions (it returns caller
+		// info even under an explicit deny) and this validator supplies no
+		// session policy to AssumeRole, so trust, session, SCP, and
+		// permissions-boundary controls cannot be responsible for the outcome.
+		// Classify every failure here as an identity-metadata anomaly so
+		// guided repair points to credential/endpoint remediation regardless
+		// of the underlying error subtype.
 		result.Diagnostics = append(result.Diagnostics, api.AWSConnectionDiagnostic{
-			Code:        code,
+			Code:        "aws_identity_metadata_unexpected",
 			Message:     "Unable to read caller identity metadata after assuming the connector role.",
 			Remediation: "Retry validation; if the failure persists, check STS endpoint reachability from this deployment and confirm the assumed session credentials are intact — sts:GetCallerIdentity requires no permissions, so trust and session policies are not the cause.",
 		})

--- a/internal/providers/aws/connector_validation_test.go
+++ b/internal/providers/aws/connector_validation_test.go
@@ -148,45 +148,54 @@ func TestConnectionValidatorValidateAWSConnectionTrustFailure(t *testing.T) {
 	}
 }
 
-// AWS documents sts:GetCallerIdentity as requiring no permissions, so an
-// AccessDenied response there indicates a credential/endpoint anomaly rather
-// than a policy issue. The validator must not reclassify it as an
-// AssumeRole/trust failure — that would send the operator to controls that
-// cannot be responsible for the outcome.
-func TestConnectionValidatorValidateAWSConnectionGetCallerIdentityAccessDenied(t *testing.T) {
-	validator := testConnectionValidator(&fakeSTSAssumeRoleClient{
-		output: &sts.AssumeRoleOutput{
-			Credentials: &ststypes.Credentials{
-				AccessKeyId:     awsv2.String("access"),
-				SecretAccessKey: awsv2.String("secret"),
-				SessionToken:    awsv2.String("token"),
-			},
-		},
-	}, fakeSTSIdentityClient{
-		err: &smithy.GenericAPIError{Code: "AccessDenied", Message: "denied"},
-	}, fakeIAMValidationClient{})
+// AWS documents sts:GetCallerIdentity as requiring no permissions, so any
+// failure here indicates a credential/endpoint anomaly rather than a policy
+// issue. The validator must not preserve subtype-specific codes that would
+// fall through guided-repair action tables to trust-policy actions —
+// AssumeRole already succeeded, so those repairs cannot resolve the failure.
+func TestConnectionValidatorValidateAWSConnectionGetCallerIdentityFailures(t *testing.T) {
+	cases := map[string]error{
+		"access denied": &smithy.GenericAPIError{Code: "AccessDenied", Message: "denied"},
+		"throttled":     &smithy.GenericAPIError{Code: "Throttling", Message: "slow down"},
+		"expired token": &smithy.GenericAPIError{Code: "ExpiredToken", Message: "session expired"},
+		"invalid token": &smithy.GenericAPIError{Code: "InvalidClientTokenID", Message: "unknown key"},
+		"unclassified":  errors.New("network reset"),
+	}
+	for name, callErr := range cases {
+		t.Run(name, func(t *testing.T) {
+			validator := testConnectionValidator(&fakeSTSAssumeRoleClient{
+				output: &sts.AssumeRoleOutput{
+					Credentials: &ststypes.Credentials{
+						AccessKeyId:     awsv2.String("access"),
+						SecretAccessKey: awsv2.String("secret"),
+						SessionToken:    awsv2.String("token"),
+					},
+				},
+			}, fakeSTSIdentityClient{err: callErr}, fakeIAMValidationClient{})
 
-	result, err := validator.ValidateAWSConnection(context.Background(), api.AWSConnectionValidationRequest{
-		RoleARN: "arn:aws:iam::123456789012:role/IdentrailReadOnly",
-	})
-	if err != nil {
-		t.Fatalf("validate connection: %v", err)
-	}
-	if len(result.PermissionChecks) != 1 || !result.PermissionChecks[0].Passed {
-		t.Fatalf("expected AssumeRole check to succeed before GetCallerIdentity, got %+v", result.PermissionChecks)
-	}
-	if len(result.Diagnostics) != 1 {
-		t.Fatalf("expected exactly one diagnostic, got %+v", result.Diagnostics)
-	}
-	diagnostic := result.Diagnostics[0]
-	if diagnostic.Code != "aws_identity_metadata_unexpected" {
-		t.Fatalf("expected identity-metadata unexpected code, got %+v", diagnostic)
-	}
-	lower := strings.ToLower(diagnostic.Remediation)
-	for _, forbidden := range []string{"scp", "session policy", "permissions boundary", "trust policy"} {
-		if strings.Contains(lower, forbidden) {
-			t.Fatalf("remediation must not send operators to %q controls that cannot resolve this failure: %q", forbidden, diagnostic.Remediation)
-		}
+			result, err := validator.ValidateAWSConnection(context.Background(), api.AWSConnectionValidationRequest{
+				RoleARN: "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+			})
+			if err != nil {
+				t.Fatalf("validate connection: %v", err)
+			}
+			if len(result.PermissionChecks) != 1 || !result.PermissionChecks[0].Passed {
+				t.Fatalf("expected AssumeRole check to succeed before GetCallerIdentity, got %+v", result.PermissionChecks)
+			}
+			if len(result.Diagnostics) != 1 {
+				t.Fatalf("expected exactly one diagnostic, got %+v", result.Diagnostics)
+			}
+			diagnostic := result.Diagnostics[0]
+			if diagnostic.Code != "aws_identity_metadata_unexpected" {
+				t.Fatalf("expected identity-metadata unexpected code, got %+v", diagnostic)
+			}
+			lower := strings.ToLower(diagnostic.Remediation)
+			for _, forbidden := range []string{"scp", "session policy", "permissions boundary", "trust policy"} {
+				if strings.Contains(lower, forbidden) {
+					t.Fatalf("remediation must not send operators to %q controls that cannot resolve this failure: %q", forbidden, diagnostic.Remediation)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/providers/aws/connector_validation_test.go
+++ b/internal/providers/aws/connector_validation_test.go
@@ -148,6 +148,48 @@ func TestConnectionValidatorValidateAWSConnectionTrustFailure(t *testing.T) {
 	}
 }
 
+// AWS documents sts:GetCallerIdentity as requiring no permissions, so an
+// AccessDenied response there indicates a credential/endpoint anomaly rather
+// than a policy issue. The validator must not reclassify it as an
+// AssumeRole/trust failure — that would send the operator to controls that
+// cannot be responsible for the outcome.
+func TestConnectionValidatorValidateAWSConnectionGetCallerIdentityAccessDenied(t *testing.T) {
+	validator := testConnectionValidator(&fakeSTSAssumeRoleClient{
+		output: &sts.AssumeRoleOutput{
+			Credentials: &ststypes.Credentials{
+				AccessKeyId:     awsv2.String("access"),
+				SecretAccessKey: awsv2.String("secret"),
+				SessionToken:    awsv2.String("token"),
+			},
+		},
+	}, fakeSTSIdentityClient{
+		err: &smithy.GenericAPIError{Code: "AccessDenied", Message: "denied"},
+	}, fakeIAMValidationClient{})
+
+	result, err := validator.ValidateAWSConnection(context.Background(), api.AWSConnectionValidationRequest{
+		RoleARN: "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+	})
+	if err != nil {
+		t.Fatalf("validate connection: %v", err)
+	}
+	if len(result.PermissionChecks) != 1 || !result.PermissionChecks[0].Passed {
+		t.Fatalf("expected AssumeRole check to succeed before GetCallerIdentity, got %+v", result.PermissionChecks)
+	}
+	if len(result.Diagnostics) != 1 {
+		t.Fatalf("expected exactly one diagnostic, got %+v", result.Diagnostics)
+	}
+	diagnostic := result.Diagnostics[0]
+	if diagnostic.Code != "aws_identity_metadata_unexpected" {
+		t.Fatalf("expected identity-metadata unexpected code, got %+v", diagnostic)
+	}
+	lower := strings.ToLower(diagnostic.Remediation)
+	for _, forbidden := range []string{"scp", "session policy", "permissions boundary", "trust policy"} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("remediation must not send operators to %q controls that cannot resolve this failure: %q", forbidden, diagnostic.Remediation)
+		}
+	}
+}
+
 func TestConnectionValidatorValidateAWSConnectionIAMPermissionFailure(t *testing.T) {
 	validator := testConnectionValidator(&fakeSTSAssumeRoleClient{
 		output: &sts.AssumeRoleOutput{

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -885,9 +885,7 @@ export type AWSConnectionStatus = {
   status: ConnectorLifecycleStatus;
   health_status: ConnectorHealthStatus;
   role_arn?: string;
-  external_id?: string;
   external_id_configured: boolean;
-  identrail_account_id?: string;
   account_id?: string;
   principal_arn?: string;
   user_id?: string;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -885,7 +885,9 @@ export type AWSConnectionStatus = {
   status: ConnectorLifecycleStatus;
   health_status: ConnectorHealthStatus;
   role_arn?: string;
+  external_id?: string;
   external_id_configured: boolean;
+  identrail_account_id?: string;
   account_id?: string;
   principal_arn?: string;
   user_id?: string;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -21896,12 +21896,17 @@ export function ProductAWSConnectPage() {
           response.connection.deployment_method === 'cloudformation' &&
           response.connection.scope_type === 'single_account';
         const needsTrustPolicyResume = !response.connection.connected;
+        // Fire whenever the current wizard mode is CloudFormation. Guarding
+        // on awsSetupModeTouchedRef would permanently block hydration after
+        // the operator switched setup mode even once — including switching
+        // away and back to CloudFormation, which clears
+        // awsCloudFormationStart and legitimately needs a fresh resume.
         if (
           connectorID &&
           canResumeCloudFormation &&
           needsTrustPolicyResume &&
           !awsCloudFormationStartRef.current &&
-          !awsSetupModeTouchedRef.current
+          awsSetupModeRef.current === 'cloudformation'
         ) {
           // Snapshot the wizard-start request id at dispatch so we can drop
           // this resume if a real start (Manual, StackSet, or a fresh
@@ -21919,17 +21924,16 @@ export function ProductAWSConnectPage() {
               },
               buildProductAuthContext(scope)
             );
-            // Recheck every ref that describes the wizard's current shape
-            // before applying resumed secrets. If the operator switched to
-            // Manual or a StackSet mode while we awaited — or a competing
-            // start response already installed different values — installing
-            // the CloudFormation External ID here would hide "Generate
-            // External ID" in Manual mode while leaving activeConnectorID
-            // empty and validation disabled, stranding the wizard in a
-            // mismatched state.
+            // Recheck the wizard's current shape before applying resumed
+            // secrets. If the operator switched to Manual or a StackSet mode
+            // while we awaited — or a competing start response already
+            // installed different values — installing the CloudFormation
+            // External ID here would hide "Generate External ID" in Manual
+            // mode while leaving activeConnectorID empty and validation
+            // disabled, stranding the wizard in a mismatched state.
             if (
               isStale() ||
-              awsSetupModeTouchedRef.current ||
+              awsSetupModeRef.current !== 'cloudformation' ||
               awsCloudFormationStartRef.current ||
               awsStartRequestRef.current !== resumeStartRequestID
             ) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -21777,6 +21777,8 @@ export function ProductAWSConnectPage() {
   const awsStackSetOnboardingRequestRef = useRef(0);
   const awsSetupModeTouchedRef = useRef(false);
   const awsSetupModeRef = useRef<AWSSetupMode>('cloudformation');
+  const awsCloudFormationStartRef = useRef<AWSConnectorStartResponse | null>(null);
+  awsCloudFormationStartRef.current = awsCloudFormationStart;
   const activeConnectorIDRef = useRef('');
   const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
   const scopeKey = scope ? `${scope.tenantID}::${scope.workspaceID}` : '';
@@ -21875,6 +21877,57 @@ export function ProductAWSConnectPage() {
             ? current.roleName
             : awsRoleNameFromARN(response.connection.role_arn ?? '') || current.roleName
         }));
+        // Trust-policy inputs (external_id + identrail_account_id) are
+        // deliberately excluded from the connection GET response, so a page
+        // reload leaves the guided repair copy_trust_policy button disabled
+        // even when a diagnostic asks the operator to paste the corrected
+        // trust policy. Resume them by silently calling the idempotent
+        // startAWSConnector endpoint for the existing connector — it returns
+        // the persisted external_id and Identrail account ID without ever
+        // regenerating anything. Only fire when the wizard state is empty
+        // (i.e., this is a resume rather than a fresh onboarding step) and
+        // the operator did not touch the setup mode, so we do not stomp
+        // in-flight edits.
+        // Only hydrate a degraded connector — a healthy one has no trust-policy
+        // repair to complete, so the extra network call is wasted work and
+        // would surprise tests that mock only the connection GET.
+        const connectorID = normalizeValue(response.connection.connector_id);
+        const canResumeCloudFormation =
+          response.connection.deployment_method === 'cloudformation' &&
+          response.connection.scope_type === 'single_account';
+        const needsTrustPolicyResume = !response.connection.connected;
+        if (
+          connectorID &&
+          canResumeCloudFormation &&
+          needsTrustPolicyResume &&
+          !awsCloudFormationStartRef.current &&
+          !awsSetupModeTouchedRef.current
+        ) {
+          try {
+            const resumed = await apiClient.startAWSConnector(
+              {
+                workspace_id: scope.workspaceID,
+                project_id: requestEnvironmentID,
+                connector_id: connectorID,
+                scope_type: 'single_account',
+                deployment_method: 'cloudformation',
+                region: response.connection.region || 'us-east-1'
+              },
+              buildProductAuthContext(scope)
+            );
+            if (!isStale()) {
+              setAWSCloudFormationStart(resumed);
+              setAWSForm((current) => ({
+                ...current,
+                externalID: current.externalID || resumed.external_id
+              }));
+            }
+          } catch {
+            // Resume is a best-effort hydration; if it fails the operator
+            // can still restart the wizard manually. Do not surface an
+            // error banner for a silent background call.
+          }
+        }
       } catch (error) {
         if (isStale()) {
           return;
@@ -22218,21 +22271,19 @@ export function ProductAWSConnectPage() {
   const canValidateRole = Boolean(normalizeValue(awsForm.roleARN)) && (!isManualSetup || Boolean(activeConnectorID));
   const selectedAWSRegion = normalizeValue(awsForm.region) || 'us-east-1';
   const manualExternalID = normalizeValue(awsForm.externalID);
-  // The trust-policy snippet is identical across deployment methods: it
-  // encodes the Identrail account plus this connector's External ID. Both are
-  // non-secret trust-policy inputs already published to AWS in the customer's
-  // role, so we fall back to the persisted connection status when the
-  // transient wizard start response is gone (page reload after a degraded
-  // CloudFormation setup). Without this fallback, the guided repair
-  // copy_trust_policy button stays disabled precisely when the operator needs
-  // it after navigation.
-  const wizardIdentrailAccountID = normalizeValue(
-    awsCloudFormationStart?.identrail_account_id ?? connection?.identrail_account_id ?? ''
-  );
-  const persistedExternalID = normalizeValue(connection?.external_id);
+  // Trust-policy snippet is identical across deployment methods: it encodes
+  // the Identrail account plus this connector's External ID. Sourcing from the
+  // active start response — instead of only the manual variant — keeps the
+  // guided repair "copy trust policy" button usable after a CloudFormation or
+  // StackSet start, which is exactly when a trust misconfiguration surfaces.
+  // After a page reload the wizard start response is gone; refreshConnection
+  // silently resumes it by calling the idempotent startAWSConnector endpoint,
+  // which repopulates external_id and identrail_account_id without exposing
+  // them via the poll response.
+  const wizardIdentrailAccountID = normalizeValue(awsCloudFormationStart?.identrail_account_id);
   const awsTrustPolicy = buildAWSManualTrustPolicy(
     wizardIdentrailAccountID,
-    manualExternalID || persistedExternalID,
+    manualExternalID,
     awsPartitionForManualTrustPolicy(awsForm.roleARN, selectedAWSRegion)
   );
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -21903,6 +21903,10 @@ export function ProductAWSConnectPage() {
           !awsCloudFormationStartRef.current &&
           !awsSetupModeTouchedRef.current
         ) {
+          // Snapshot the wizard-start request id at dispatch so we can drop
+          // this resume if a real start (Manual, StackSet, or a fresh
+          // CloudFormation launch) fired while our call was in flight.
+          const resumeStartRequestID = awsStartRequestRef.current;
           try {
             const resumed = await apiClient.startAWSConnector(
               {
@@ -21915,13 +21919,27 @@ export function ProductAWSConnectPage() {
               },
               buildProductAuthContext(scope)
             );
-            if (!isStale()) {
-              setAWSCloudFormationStart(resumed);
-              setAWSForm((current) => ({
-                ...current,
-                externalID: current.externalID || resumed.external_id
-              }));
+            // Recheck every ref that describes the wizard's current shape
+            // before applying resumed secrets. If the operator switched to
+            // Manual or a StackSet mode while we awaited — or a competing
+            // start response already installed different values — installing
+            // the CloudFormation External ID here would hide "Generate
+            // External ID" in Manual mode while leaving activeConnectorID
+            // empty and validation disabled, stranding the wizard in a
+            // mismatched state.
+            if (
+              isStale() ||
+              awsSetupModeTouchedRef.current ||
+              awsCloudFormationStartRef.current ||
+              awsStartRequestRef.current !== resumeStartRequestID
+            ) {
+              return;
             }
+            setAWSCloudFormationStart(resumed);
+            setAWSForm((current) => ({
+              ...current,
+              externalID: current.externalID || resumed.external_id
+            }));
           } catch {
             // Resume is a best-effort hydration; if it fails the operator
             // can still restart the wizard manually. Do not surface an

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -22218,15 +22218,21 @@ export function ProductAWSConnectPage() {
   const canValidateRole = Boolean(normalizeValue(awsForm.roleARN)) && (!isManualSetup || Boolean(activeConnectorID));
   const selectedAWSRegion = normalizeValue(awsForm.region) || 'us-east-1';
   const manualExternalID = normalizeValue(awsForm.externalID);
-  // Trust-policy snippet is identical across deployment methods: it encodes
-  // the Identrail account plus this connector's External ID. Sourcing from the
-  // active start response — instead of only the manual variant — keeps the
-  // guided repair "copy trust policy" button usable after a CloudFormation or
-  // StackSet start, which is exactly when a trust misconfiguration surfaces.
-  const wizardIdentrailAccountID = normalizeValue(awsCloudFormationStart?.identrail_account_id);
+  // The trust-policy snippet is identical across deployment methods: it
+  // encodes the Identrail account plus this connector's External ID. Both are
+  // non-secret trust-policy inputs already published to AWS in the customer's
+  // role, so we fall back to the persisted connection status when the
+  // transient wizard start response is gone (page reload after a degraded
+  // CloudFormation setup). Without this fallback, the guided repair
+  // copy_trust_policy button stays disabled precisely when the operator needs
+  // it after navigation.
+  const wizardIdentrailAccountID = normalizeValue(
+    awsCloudFormationStart?.identrail_account_id ?? connection?.identrail_account_id ?? ''
+  );
+  const persistedExternalID = normalizeValue(connection?.external_id);
   const awsTrustPolicy = buildAWSManualTrustPolicy(
     wizardIdentrailAccountID,
-    manualExternalID,
+    manualExternalID || persistedExternalID,
     awsPartitionForManualTrustPolicy(awsForm.roleARN, selectedAWSRegion)
   );
 


### PR DESCRIPTION
## Summary
- Fix guided-repair miscategorization: `AccessDenied` on `GetCallerIdentity` after `AssumeRole` succeeded now emits a distinct `assumed_role_access_denied` code (was collapsing to `assume_role_failed` and telling operators to change a trust policy that already worked). Repair guidance now points to session policy / SCP / permissions boundary.
- Fix healthy-connector-shown-as-blocker: an unavailable write-tier capability (e.g. `approved_remediation`) now emits a warning-severity `capability_unavailable` diagnostic instead of `missing_read_only_permission_tier` blocking. `TestUpsertAWSConnectionReportsUnavailableWriteCapability` still passes and now also asserts severity + absence of the false blocker.
- Fix disabled `copy_trust_policy` button on CloudFormation repairs: the frontend now derives the trust-policy snippet from the active start response (CloudFormation, StackSet, or manual), not the manual-only variant. The button stays enabled precisely when the operator needs to paste the corrected trust policy.

All three findings from https://github.com/identrail/identrail/pull/1779#pullrequestreview-4780393234.

## AI disclosure
No.

## Test plan
- [x] `go test ./internal/api/... ./internal/providers/aws/...`
- [x] `npx vitest run src/productShell.test.tsx` (297/297)
- [x] `npx tsc --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AWS guided repair classifications and UX: treats any post‑assume `sts:GetCallerIdentity` failure as an STS/credential anomaly, keeps healthy read‑only connectors unblocked, and keeps “Copy trust policy” enabled after CloudFormation starts, reloads, and switch‑backs via a safe `startAWSConnector` resume with state guards.

- **Bug Fixes**
  - Reclassifies all post‑assume `sts:GetCallerIdentity` failures as `identity_metadata_unexpected` with guidance to check STS endpoint reachability and credential integrity; adds normalization aliases, tradeoffs/severity/actions, and tests across AccessDenied, throttling, invalid/expired token, and generic errors.
  - Emits `capability_unavailable` with warning severity for unavailable write‑tier capabilities, removing the false `missing_read_only_permission_tier` blocker and updating next actions; tests assert warning severity and absence of the read‑only blocker.
  - Preserves `external_id` redaction; derives the trust‑policy snippet from the active start response and, on degraded CloudFormation connectors without wizard state, silently resumes via idempotent `startAWSConnector`—now re‑running when switching back to CloudFormation and applying only after rechecking current mode, the pending start request, and existing state to avoid clobbering in‑flight changes.

<sup>Written for commit 381917b092b735e7d24cbd0230be75d7b4a5aff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

