### PR TITLE
Finish AWS connected success state

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://github.com/identrail/identrail/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/identrail/identrail/ci.yml?branch=dev&style=flat&label=ci&labelColor=000000" alt="CI status" /></a>
-  <a href="https://github.com/identrail/identrail/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/version-v1.0.1-0969da?style=flat&labelColor=000000" alt="Version v1.0.1" /></a>
+  <a href="https://github.com/identrail/identrail/releases/tag/v1.0.2"><img src="https://img.shields.io/badge/version-v1.0.2-0969da?style=flat&labelColor=000000" alt="Version v1.0.2" /></a>
   <a href="https://www.bestpractices.dev/projects/12950"><img src="https://img.shields.io/cii/level/12950?style=flat&label=openssf%20best%20practices&labelColor=000000" alt="OpenSSF Best Practices" /></a>
 </p>
 
@@ -104,6 +104,18 @@ identrail scan
 ```
 
 Change `IDENTRAIL_AWS_REGION` to the AWS region you want to inspect.
+
+For hosted AWS connectors, check the connected status and next action from the
+API-backed CLI:
+
+```bash
+identrail aws-status \
+  --api-url "$IDENTRAIL_API_URL" \
+  --api-key "$IDENTRAIL_API_KEY" \
+  --tenant-id tenant-a \
+  --workspace-id workspace-a \
+  --project-id production
+```
 
 ### 4. Scan Kubernetes
 

--- a/docs/auth/aws-connector.md
+++ b/docs/auth/aws-connector.md
@@ -39,10 +39,11 @@ When a persistent database is configured and AWS connector setup is enabled, `ID
 
 ## Flow
 
-The app presents AWS setup as a scope-first wizard. The default executable path
-is **Single AWS account** through CloudFormation. Existing manual-role setup is
-available under **Advanced** for teams that manage IAM through their own change
-process. Organization and selected OU/account setup remain planned paths.
+The app presents AWS setup as a scope-first wizard. Supported executable paths
+are **Single AWS account** through CloudFormation, **Organization** through a
+service-managed StackSet, **Selected OUs**, **Selected accounts**, and
+**Existing IAM role** for teams that manage IAM through their own change
+process.
 
 1. The operator chooses **Single AWS account**, adds a display name, and picks
    the home region used for setup.
@@ -165,6 +166,42 @@ The executable `POST /v1/connectors/aws` setup path supports
 `organization`/`stackset_service_managed`, `selected_ous`/
 `stackset_service_managed`, and selected-account StackSet setup. Terraform
 remains reserved for follow-on implementation issues.
+
+## Connected State
+
+After validation succeeds, the AWS Connect page opens on a connected summary
+instead of the setup wizard. The summary shows the active scope, account and
+region coverage, connector health, last validation time, permission health, and
+baseline readiness. It links operators into the AWS overview, machine identity
+inventory, coverage gaps, and findings when health is degraded.
+
+Setup controls stay hidden for connected environments until the operator chooses
+**Manage connection**. Opening management intentionally reveals the existing
+wizard for expanding scope, refreshing status, or validating a repaired role.
+Switching environments closes management and clears setup drafts so role ARNs,
+External IDs, StackSet targets, and stale async responses cannot leak across
+project scopes.
+
+Each scope carries an explicit tradeoff in the success state:
+
+- Single account is narrow and predictable; use management to expand coverage.
+- Organization scope can include future accounts automatically, unless the
+  connector was created with fixed targets.
+- Selected OUs follow accounts in those OUs only.
+- Selected accounts stay pinned to the listed account IDs.
+- Manual role setup leaves IAM trust and permissions under the customer's
+  external change process.
+
+The hosted CLI exposes the same status without returning connector secrets:
+
+```bash
+identrail aws-status \
+  --api-url "$IDENTRAIL_API_URL" \
+  --api-key "$IDENTRAIL_API_KEY" \
+  --tenant-id tenant-a \
+  --workspace-id workspace-a \
+  --project-id production
+```
 
 ## Account and Region Coverage Registry
 

--- a/docs/aws-connect-troubleshooting.md
+++ b/docs/aws-connect-troubleshooting.md
@@ -17,6 +17,7 @@ AWS Connect diagnostics describe setup coverage gaps, not runtime machine-identi
 | `selected_target_missing_stackset_instance` | A selected OU, account, or region does not have an active StackSet instance. | Review targets, launch or retry StackSet deployment, then refresh status. | Healthy targets remain visible, but coverage is partial. |
 | `member_account_permission_denied` | AWS denied StackSet deployment in a member account. | Fix member-account StackSet permissions and retry the instance. | The account is excluded from claimed coverage until repaired. |
 | `region_unsupported_or_not_opted_in` | The selected region is unsupported or not opted in for the member account. | Enable the region or remove it from the selected target set. | Removing it avoids failures, but coverage excludes workloads there. |
+| `suspended_accounts_excluded` | One or more selected organization accounts are suspended and excluded from effective coverage. | Remove suspended accounts from the selected targets or reactivate them in AWS Organizations, then refresh status. | Excluding suspended accounts keeps active targets usable, but Identrail will not claim coverage for those accounts. |
 | `partial_stackset_coverage` | Some StackSet instances failed while others remain usable. | Retry failed instances, then refresh status. | Identrail keeps successful targets visible but does not claim full coverage. |
 
 ## Repair Actions

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -39,6 +39,34 @@ Reads persisted findings state and prints output.
 Key flags:
 - `--output table|json`
 
+## `identrail aws-status`
+
+Fetches hosted AWS connector status for one project or environment. Table output
+summarizes connection state, health, declared scope, account coverage, region
+coverage, permission checks, next action, connector ID, and diagnostic count.
+JSON output returns the API response envelope. The command never prints the
+connector External ID.
+
+Example:
+```bash
+identrail aws-status \
+  --api-url "$IDENTRAIL_API_URL" \
+  --api-key "$IDENTRAIL_API_KEY" \
+  --tenant-id tenant-a \
+  --workspace-id workspace-a \
+  --project-id production
+```
+
+Key flags:
+- `--api-url`
+- `--api-key`
+- `--tenant-id`
+- `--workspace-id` (required unless configured as the default workspace)
+- `--project-id` (required)
+- `--connector-id` (optional, uses the connector-specific poll route)
+- `--timeout`
+- `--output table|json`
+
 ## `identrail repo-scan`
 
 Runs the local repository exposure scanner. This is the backward-compatible long

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/identrail/identrail/internal/api"
 	"github.com/identrail/identrail/internal/app"
 	"github.com/identrail/identrail/internal/config"
 	"github.com/identrail/identrail/internal/domain"
@@ -60,6 +61,7 @@ func BuildRootCmd(cfg config.Config, out io.Writer) *cobra.Command {
 
 	root.AddCommand(buildScanCmd(cfg, out, &stateFile))
 	root.AddCommand(buildScanReplayCmd(cfg, out))
+	root.AddCommand(buildAWSStatusCmd(cfg, out))
 	root.AddCommand(buildFindingsCmd(out, &stateFile))
 	root.AddCommand(buildRepoScanCmd(cfg, out))
 	root.AddCommand(buildRepoFindingsCmd(cfg, out))
@@ -260,6 +262,108 @@ func buildScanReplayCmd(cfg config.Config, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&workspaceID, "workspace-id", strings.TrimSpace(cfg.DefaultWorkspaceID), "Workspace scope header for replay request")
 	cmd.Flags().StringVar(&scanID, "scan-id", "", "Failed or dead-lettered scan ID to replay")
 	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Second, "HTTP timeout for replay request")
+	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
+	return cmd
+}
+
+func buildAWSStatusCmd(cfg config.Config, out io.Writer) *cobra.Command {
+	var (
+		apiURL       string
+		apiKey       string
+		tenantID     string
+		workspaceID  string
+		projectID    string
+		connectorID  string
+		timeout      time.Duration
+		outputFormat string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "aws-status",
+		Short: "Show hosted AWS connector status",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if strings.TrimSpace(apiURL) == "" {
+				return fmt.Errorf("--api-url is required")
+			}
+			if strings.TrimSpace(workspaceID) == "" {
+				return fmt.Errorf("--workspace-id is required")
+			}
+			if strings.TrimSpace(projectID) == "" {
+				return fmt.Errorf("--project-id is required")
+			}
+			formatter, err := parseOutputFormat(outputFormat)
+			if err != nil {
+				return err
+			}
+			normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+			normalizedProjectID := strings.TrimSpace(projectID)
+			baseURL := strings.TrimRight(strings.TrimSpace(apiURL), "/")
+			statusURL := baseURL +
+				"/v1/workspaces/" + url.PathEscape(normalizedWorkspaceID) +
+				"/projects/" + url.PathEscape(normalizedProjectID) +
+				"/aws/connection"
+			if normalizedConnectorID := strings.TrimSpace(connectorID); normalizedConnectorID != "" {
+				query := url.Values{}
+				query.Set("workspace_id", normalizedWorkspaceID)
+				query.Set("project_id", normalizedProjectID)
+				statusURL = baseURL +
+					"/v1/connectors/aws/" + url.PathEscape(normalizedConnectorID) +
+					"/poll?" + query.Encode()
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
+			if err != nil {
+				return fmt.Errorf("build aws status request: %w", err)
+			}
+			if normalizedKey := strings.TrimSpace(apiKey); normalizedKey != "" {
+				req.Header.Set("X-API-Key", normalizedKey)
+			}
+			if normalizedTenant := strings.TrimSpace(tenantID); normalizedTenant != "" {
+				req.Header.Set("X-Identrail-Tenant-ID", normalizedTenant)
+			}
+			req.Header.Set("X-Identrail-Workspace-ID", normalizedWorkspaceID)
+
+			resp, err := (&http.Client{Timeout: timeout}).Do(req)
+			if err != nil {
+				return fmt.Errorf("aws status request failed: %w", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				var apiErr scanReplayCLIErrorResponse
+				if err := json.NewDecoder(resp.Body).Decode(&apiErr); err == nil && strings.TrimSpace(apiErr.Error) != "" {
+					return fmt.Errorf("aws status request failed: %s (status %d)", strings.TrimSpace(apiErr.Error), resp.StatusCode)
+				}
+				return fmt.Errorf("aws status request failed with status %d", resp.StatusCode)
+			}
+
+			var response struct {
+				Connection api.AWSConnectionStatus `json:"connection"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+				return fmt.Errorf("decode aws status response: %w", err)
+			}
+
+			switch formatter {
+			case outputJSON:
+				return writeJSON(out, response)
+			default:
+				return renderAWSStatusOutput(out, response.Connection)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&apiURL, "api-url", defaultCLIAPIURL(), "Identrail API base URL")
+	cmd.Flags().StringVar(&apiKey, "api-key", strings.TrimSpace(os.Getenv("IDENTRAIL_API_KEY")), "API key used for AWS status request")
+	cmd.Flags().StringVar(&tenantID, "tenant-id", strings.TrimSpace(cfg.DefaultTenantID), "Tenant scope header for AWS status request")
+	cmd.Flags().StringVar(&workspaceID, "workspace-id", strings.TrimSpace(cfg.DefaultWorkspaceID), "Workspace scope header for AWS status request")
+	cmd.Flags().StringVar(&projectID, "project-id", "", "Environment or project ID to inspect")
+	cmd.Flags().StringVar(&connectorID, "connector-id", "", "AWS connector ID to inspect when a project has multiple connectors")
+	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Second, "HTTP timeout for AWS status request")
 	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
 	return cmd
 }
@@ -475,6 +579,96 @@ func defaultCLIAPIURL() string {
 		return configured
 	}
 	return defaultAPIURL
+}
+
+func renderAWSStatusOutput(out io.Writer, connection api.AWSConnectionStatus) error {
+	passed := 0
+	for _, check := range connection.PermissionChecks {
+		if check.Passed {
+			passed++
+		}
+	}
+	permissions := "not_validated"
+	if len(connection.PermissionChecks) > 0 {
+		permissions = fmt.Sprintf("%d/%d_passed", passed, len(connection.PermissionChecks))
+	}
+	excludedAccountCount := 0
+	if connection.TargetSummary != nil {
+		excludedAccountCount = connection.TargetSummary.ExcludedAccountCount
+	} else {
+		excludedAccountCount = len(connection.ExcludedAccountIDs)
+	}
+	accounts := "pending"
+	if connection.TargetSummary != nil && connection.TargetSummary.AccountCountKnown {
+		accounts = formatCLICount(connection.TargetSummary.AccountCount, "account")
+		if excludedAccountCount > 0 {
+			accounts += "_after_" + formatCLIExcludedAccountCount(excludedAccountCount)
+		}
+	} else if connection.TargetSummary != nil && connection.TargetSummary.AllAccounts {
+		accounts = "all_accounts"
+		if excludedAccountCount > 0 {
+			accounts += "_except_" + formatCLIExcludedAccountCount(excludedAccountCount)
+		}
+	} else if connection.TargetSummary != nil {
+		accounts = "pending"
+	} else if len(connection.TargetAccountIDs) > 0 {
+		accounts = formatCLICount(len(connection.TargetAccountIDs), "account")
+	} else if strings.TrimSpace(connection.AccountID) != "" {
+		accounts = "1_account"
+	}
+	regions := "pending"
+	if connection.TargetSummary != nil && connection.TargetSummary.RegionCount > 0 {
+		regions = formatCLICount(connection.TargetSummary.RegionCount, "region")
+	} else if len(connection.TargetRegions) > 0 {
+		regions = formatCLICount(len(connection.TargetRegions), "region")
+	} else if strings.TrimSpace(connection.Region) != "" {
+		regions = "1_region"
+	}
+	scope := string(connection.ScopeType)
+	if connection.ScopeType == "organization" && connection.TargetSummary != nil && connection.TargetSummary.AllAccounts {
+		scope = "organization_all_accounts"
+		if excludedAccountCount > 0 {
+			scope += "_except_" + formatCLIExcludedAccountCount(excludedAccountCount)
+		}
+	}
+	status := "not_connected"
+	if connection.Connected {
+		status = "connected"
+	} else if strings.TrimSpace(string(connection.OnboardingStatus)) != "" {
+		status = string(connection.OnboardingStatus)
+	}
+	next := "none"
+	if len(connection.NextActions) > 0 {
+		next = string(connection.NextActions[0])
+	}
+	if _, err := fmt.Fprintf(out, "AWS connector: %s health=%s scope=%s accounts=%s regions=%s permissions=%s next=%s\n", status, connection.HealthStatus, scope, accounts, regions, permissions, next); err != nil {
+		return err
+	}
+	if strings.TrimSpace(connection.ConnectorID) != "" {
+		if _, err := fmt.Fprintf(out, "Connector: %s\n", strings.TrimSpace(connection.ConnectorID)); err != nil {
+			return err
+		}
+	}
+	if len(connection.Diagnostics) == 0 {
+		_, err := fmt.Fprintln(out, "Diagnostics: none")
+		return err
+	}
+	_, err := fmt.Fprintf(out, "Diagnostics: %d\n", len(connection.Diagnostics))
+	return err
+}
+
+func formatCLICount(count int, noun string) string {
+	if count == 1 {
+		return fmt.Sprintf("%d_%s", count, noun)
+	}
+	return fmt.Sprintf("%d_%ss", count, noun)
+}
+
+func formatCLIExcludedAccountCount(count int) string {
+	if count == 1 {
+		return "1_excluded_account"
+	}
+	return fmt.Sprintf("%d_excluded_accounts", count)
 }
 
 func renderAuthzRollbackOutput(out io.Writer, response authzPolicyRollbackCLIResponse) error {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/identrail/identrail/internal/api"
 	"github.com/identrail/identrail/internal/config"
 	"github.com/identrail/identrail/internal/domain"
 	awsprovider "github.com/identrail/identrail/internal/providers/aws"
@@ -346,6 +347,234 @@ func TestExecuteScanReplayTable(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Replay queued: source_scan=scan-123 replay_scan=replay-456 provider=aws status=queued retry_count=0") {
 		t.Fatalf("expected table replay output, got %q", out.String())
+	}
+}
+
+func TestExecuteAWSStatusTable(t *testing.T) {
+	cfg := config.Config{DefaultTenantID: "default", DefaultWorkspaceID: "default"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/workspaces/workspace-a/projects/production/aws/connection" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if got := strings.TrimSpace(r.Header.Get("X-API-Key")); got != "admin-key" {
+			t.Fatalf("expected api key header, got %q", got)
+		}
+		if got := strings.TrimSpace(r.Header.Get("X-Identrail-Tenant-ID")); got != "tenant-a" {
+			t.Fatalf("expected tenant header, got %q", got)
+		}
+		if got := strings.TrimSpace(r.Header.Get("X-Identrail-Workspace-ID")); got != "workspace-a" {
+			t.Fatalf("expected workspace header, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Connection api.AWSConnectionStatus `json:"connection"`
+		}{
+			Connection: api.AWSConnectionStatus{
+				Provider:             "aws",
+				Connected:            true,
+				ConnectorID:          "aws-connector-1",
+				Status:               domain.ConnectorStatusActive,
+				HealthStatus:         "healthy",
+				ExternalIDConfigured: true,
+				ExternalID:           "do-not-print",
+				AccountID:            "123456789012",
+				Region:               "us-east-1",
+				ScopeType:            api.AWSConnectorScopeSingleAccount,
+				DeploymentMethod:     api.AWSConnectorDeploymentCloudFormation,
+				OnboardingStatus:     api.AWSConnectorOnboardingConnected,
+				TargetRegions:        []string{"us-east-1"},
+				TargetAccountIDs:     []string{"123456789012"},
+				SetupSummary:         "AWS connector is connected and ready for discovery.",
+				NextActions:          []api.AWSConnectorNextAction{api.AWSConnectorNextActionStartIntelligence},
+				PermissionChecks: []api.AWSConnectionPermissionCheck{
+					{Name: "iam:GetRole", Passed: true, Message: "Role metadata can be inspected."},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := Execute(cfg, []string{
+		"aws-status",
+		"--api-url", server.URL,
+		"--api-key", "admin-key",
+		"--tenant-id", "tenant-a",
+		"--workspace-id", "workspace-a",
+		"--project-id", "production",
+		"--output", "table",
+	}, &out)
+	if err != nil {
+		t.Fatalf("aws status failed: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, "AWS connector: connected health=healthy scope=single_account accounts=1_account regions=1_region permissions=1/1_passed next=start_intelligence") {
+		t.Fatalf("expected aws status table output, got %q", body)
+	}
+	if strings.Contains(strings.ToLower(body), "external") || strings.Contains(body, "do-not-print") {
+		t.Fatalf("expected external id to stay out of status output, got %q", body)
+	}
+}
+
+func TestExecuteAWSStatusConnectorIDUsesPollRoute(t *testing.T) {
+	cfg := config.Config{DefaultTenantID: "tenant-a", DefaultWorkspaceID: "workspace-a"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/connectors/aws/aws-prod/poll" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("workspace_id"); got != "workspace-a" {
+			t.Fatalf("expected workspace query, got %q", got)
+		}
+		if got := r.URL.Query().Get("project_id"); got != "production" {
+			t.Fatalf("expected project query, got %q", got)
+		}
+		if got := strings.TrimSpace(r.Header.Get("X-Identrail-Workspace-ID")); got != "workspace-a" {
+			t.Fatalf("expected workspace header, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Connection api.AWSConnectionStatus `json:"connection"`
+		}{
+			Connection: api.AWSConnectionStatus{
+				Provider:             "aws",
+				Connected:            true,
+				ConnectorID:          "aws-prod",
+				Status:               domain.ConnectorStatusActive,
+				HealthStatus:         "healthy",
+				ExternalIDConfigured: true,
+				AccountID:            "123456789012",
+				Region:               "us-east-1",
+				ScopeType:            api.AWSConnectorScopeSingleAccount,
+				DeploymentMethod:     api.AWSConnectorDeploymentCloudFormation,
+				OnboardingStatus:     api.AWSConnectorOnboardingConnected,
+				TargetRegions:        []string{"us-east-1"},
+				TargetAccountIDs:     []string{"123456789012"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := Execute(cfg, []string{
+		"aws-status",
+		"--api-url", server.URL,
+		"--project-id", "production",
+		"--connector-id", "aws-prod",
+	}, &out)
+	if err != nil {
+		t.Fatalf("aws status failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "Connector: aws-prod") {
+		t.Fatalf("expected connector-specific status output, got %q", out.String())
+	}
+}
+
+func TestExecuteAWSStatusPendingSelectedAccountCoverage(t *testing.T) {
+	cfg := config.Config{DefaultTenantID: "tenant-a", DefaultWorkspaceID: "workspace-a"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Connection api.AWSConnectionStatus `json:"connection"`
+		}{
+			Connection: api.AWSConnectionStatus{
+				Provider:             "aws",
+				Connected:            true,
+				ConnectorID:          "aws-connector-1",
+				Status:               domain.ConnectorStatusActive,
+				HealthStatus:         "healthy",
+				ExternalIDConfigured: true,
+				ScopeType:            api.AWSConnectorScopeSelectedAccounts,
+				DeploymentMethod:     api.AWSConnectorDeploymentStackSetServiceManaged,
+				OnboardingStatus:     api.AWSConnectorOnboardingConnected,
+				TargetRegions:        []string{"us-east-1"},
+				TargetAccountIDs:     []string{"111111111111", "222222222222"},
+				TargetSummary: &api.AWSConnectorTargetSummary{
+					AccountCount:      0,
+					AccountCountKnown: false,
+					RegionCount:       1,
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := Execute(cfg, []string{
+		"aws-status",
+		"--api-url", server.URL,
+		"--project-id", "production",
+	}, &out)
+	if err != nil {
+		t.Fatalf("aws status failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "accounts=pending") {
+		t.Fatalf("expected pending selected-account coverage, got %q", out.String())
+	}
+	if strings.Contains(out.String(), "accounts=2_accounts") {
+		t.Fatalf("did not expect raw selected target count as coverage, got %q", out.String())
+	}
+}
+
+func TestExecuteAWSStatusOrganizationExclusionsQualifyAllAccounts(t *testing.T) {
+	cfg := config.Config{DefaultTenantID: "tenant-a", DefaultWorkspaceID: "workspace-a"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Connection api.AWSConnectionStatus `json:"connection"`
+		}{
+			Connection: api.AWSConnectionStatus{
+				Provider:             "aws",
+				Connected:            true,
+				ConnectorID:          "aws-org-1",
+				Status:               domain.ConnectorStatusActive,
+				HealthStatus:         "healthy",
+				ExternalIDConfigured: true,
+				ScopeType:            api.AWSConnectorScopeOrganization,
+				DeploymentMethod:     api.AWSConnectorDeploymentStackSetServiceManaged,
+				OnboardingStatus:     api.AWSConnectorOnboardingConnected,
+				TargetRegions:        []string{"us-east-1"},
+				ExcludedAccountIDs:   []string{"999999999999"},
+				TargetSummary: &api.AWSConnectorTargetSummary{
+					AccountCountKnown:    false,
+					RegionCount:          1,
+					ExcludedAccountCount: 1,
+					AllAccounts:          true,
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := Execute(cfg, []string{
+		"aws-status",
+		"--api-url", server.URL,
+		"--project-id", "production",
+	}, &out)
+	if err != nil {
+		t.Fatalf("aws status failed: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, "scope=organization_all_accounts_except_1_excluded_account") {
+		t.Fatalf("expected scope to qualify exclusions, got %q", body)
+	}
+	if !strings.Contains(body, "accounts=all_accounts_except_1_excluded_account") {
+		t.Fatalf("expected account coverage to qualify exclusions, got %q", body)
+	}
+}
+
+func TestExecuteAWSStatusRejectsPositionalArgs(t *testing.T) {
+	cfg := config.Config{DefaultTenantID: "tenant-a", DefaultWorkspaceID: "workspace-a"}
+	var out bytes.Buffer
+	err := Execute(cfg, []string{"aws-status", "--project-id", "production", "extra"}, &out)
+	if err == nil {
+		t.Fatal("expected positional argument validation error")
 	}
 }
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -2026,6 +2026,12 @@ function mockAWSBaseline(api: typeof import('./api/client'), baseline: AWSPlatfo
   mockAWSServiceCollectorContract(api);
 }
 
+async function openAWSConnectionManagement(): Promise<HTMLElement> {
+  const summary = await screen.findByRole('region', { name: 'AWS connected summary' });
+  fireEvent.click(within(summary).getByRole('button', { name: /Manage connection/i }));
+  return screen.findByRole('region', { name: 'AWS account setup' });
+}
+
 const disconnectedKubernetes: KubernetesConnectionStatus = {
   provider: 'kubernetes',
   connected: false,
@@ -8836,6 +8842,7 @@ describe('Domain-first app routes', () => {
     fireEvent.click(refreshButtons[refreshButtons.length - 1]);
 
     await waitFor(() => expect(getAWSProjectConnection).toHaveBeenCalledTimes(2));
+    await openAWSConnectionManagement();
     expect(screen.getByLabelText('External ID')).toHaveValue('manual-external-id-to-keep');
     expect(screen.getByLabelText('Role ARN')).toHaveValue('arn:aws:iam::123456789012:role/CustomerManagedIdentrail');
     expect(String((screen.getByLabelText('Trust policy') as HTMLTextAreaElement).value)).toContain(
@@ -10231,6 +10238,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
+    await openAWSConnectionManagement();
     expect(await screen.findByRole('region', { name: /StackSet onboarding progress/i })).toBeInTheDocument();
     expect(getStackSetOnboarding).toHaveBeenCalledWith(
       'workspace-a',
@@ -10424,7 +10432,8 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    // Wait for the connection to hydrate.
+    // Wait for the connection to hydrate, then open setup management.
+    await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10533,6 +10542,7 @@ describe('Domain-first app routes', () => {
     );
 
     // Wait for the production connector to hydrate the custom stack set name.
+    await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
 
     // Switch to the staging environment (no connector yet).
@@ -10609,6 +10619,7 @@ describe('Domain-first app routes', () => {
     );
 
     // Wait for the connector's scope to hydrate the wizard.
+    await openAWSConnectionManagement();
     await screen.findByRole('heading', { level: 4, name: /Set the coverage scope/i });
 
     // The wizard exposes an alert that says this setup is not relaunchable and
@@ -10682,6 +10693,7 @@ describe('Domain-first app routes', () => {
     // still be reachable for a Terraform-provisioned connector — the wizard
     // step's Refresh button clicks into pollAWSConnector, not the sidebar
     // Permission health refresh action.
+    await openAWSConnectionManagement();
     const wizardStep = await screen.findByRole('heading', { level: 4, name: /Verify the connection/i });
     const wizardStepBody = wizardStep.closest('.idt-aws-wizard-step') as HTMLElement | null;
     expect(wizardStepBody).not.toBeNull();
@@ -10927,6 +10939,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
+    await openAWSConnectionManagement();
     expect(await screen.findByText(/Persisted organization recovery action/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
     expect(screen.queryByText(/Persisted organization recovery action/i)).not.toBeInTheDocument();
@@ -11069,6 +11082,7 @@ describe('Domain-first app routes', () => {
     );
 
     // Initial hydrate.
+    await openAWSConnectionManagement();
     expect(await screen.findByText(/Persisted recovery action to restore/i)).toBeInTheDocument();
     const initialCallCount = getStackSetOnboarding.mock.calls.length;
 
@@ -11128,6 +11142,7 @@ describe('Domain-first app routes', () => {
     );
 
     // Panel shows a StackSet link initially.
+    await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
 
     fireEvent.click(screen.getByRole('button', { name: /This AWS account/i }));
@@ -11184,6 +11199,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
+    await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
     fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
 
@@ -11274,6 +11290,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
+    await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -11361,6 +11378,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
+    await openAWSConnectionManagement();
     expect(await screen.findByText(/Preserved recovery action/i)).toBeInTheDocument();
     const priorCalls = getStackSetOnboarding.mock.calls.length;
 
@@ -11452,6 +11470,7 @@ describe('Domain-first app routes', () => {
     );
 
     // Wait for the existing organization connector to hydrate.
+    await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
 
     fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
@@ -11508,6 +11527,71 @@ describe('Domain-first app routes', () => {
     expect(screen.getByRole('heading', { level: 3, name: /Platform readiness/i })).toBeInTheDocument();
   });
 
+  it('shows connected AWS status as the default success state before setup management', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        target_summary: {
+          account_count: 1,
+          account_count_known: true,
+          ou_count: 0,
+          region_count: 1,
+          excluded_account_count: 0,
+          expected_stack_instances: 1,
+          expected_stack_instances_known: true,
+          all_accounts: false
+        }
+      }
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const summary = await screen.findByRole('region', { name: 'AWS connected summary' });
+    expect(within(summary).getByRole('heading', { level: 3, name: /Production AWS/i })).toBeInTheDocument();
+    expect(within(summary).getByText('Single account')).toBeInTheDocument();
+    expect(within(summary).getByText('1 account')).toBeInTheDocument();
+    expect(within(summary).getByText('1 region')).toBeInTheDocument();
+    expect(within(summary).getByRole('link', { name: /Start AWS intelligence/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws?environment=production'
+    );
+    expect(within(summary).getByRole('link', { name: /Review machine identities/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/identities?environment=production'
+    );
+    expect(screen.queryByRole('region', { name: 'AWS account setup' })).not.toBeInTheDocument();
+
+    fireEvent.click(within(summary).getByRole('button', { name: /Manage connection/i }));
+
+    expect(await screen.findByRole('region', { name: 'AWS account setup' })).toBeInTheDocument();
+  });
+
   it('keeps edited AWS role drafts when polling status returns older connection data', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
@@ -11545,12 +11629,15 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
+    expect(await screen.findByRole('region', { name: 'AWS connected summary' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Manage connection/i }));
     const roleInput = await screen.findByLabelText('Stack role ARN');
     fireEvent.change(roleInput, { target: { value: 'arn:aws:iam::123456789012:role/CorrectedConnectorRole' } });
     fireEvent.click(within(screen.getByLabelText('AWS account setup')).getByRole('button', { name: /Refresh status/i }));
 
     await waitFor(() => expect(api.apiClient.pollAWSConnector).toHaveBeenCalled());
-    expect(screen.getByLabelText('Stack role ARN')).toHaveValue('arn:aws:iam::123456789012:role/CorrectedConnectorRole');
+    expect(screen.getByRole('region', { name: 'AWS connected summary' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Stack role ARN')).not.toBeInTheDocument();
   });
 
   it('keeps legacy role-only AWS connections out of connector validation', async () => {
@@ -11593,6 +11680,8 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
+    expect(await screen.findByRole('region', { name: 'AWS connected summary' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Manage connection/i }));
     expect(await screen.findByRole('heading', { level: 3, name: /Choose what Identrail should cover/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('Stack role ARN')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Validate connection/i })).not.toBeInTheDocument();
@@ -12315,6 +12404,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
+    await openAWSConnectionManagement();
     expect(await screen.findByRole('heading', { level: 3, name: /Choose what Identrail should cover/i })).toBeInTheDocument();
     const refreshButton = within(screen.getByLabelText('AWS account setup')).getByRole('button', {
       name: /Refresh status/i
@@ -12399,8 +12489,9 @@ describe('Domain-first app routes', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
-    expect(await screen.findByDisplayValue('arn:aws:iam::123456789012:role/IdentrailReadOnly')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Validate connection/i })).toBeEnabled();
+    expect(await screen.findByRole('region', { name: 'AWS connected summary' })).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('arn:aws:iam::123456789012:role/IdentrailReadOnly')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Validate connection/i })).not.toBeInTheDocument();
   });
 
   it('ignores stale AWS validation responses after switching environments', async () => {
@@ -12448,6 +12539,8 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
+    expect(await screen.findByRole('region', { name: 'AWS connected summary' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Manage connection/i }));
     const submitButton = await screen.findByRole('button', { name: /Validate connection/i });
     fireEvent.click(submitButton);
     await waitFor(() =>
@@ -12513,7 +12606,7 @@ describe('Domain-first app routes', () => {
     );
 
     expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('older-production');
-    expect(await screen.findByRole('heading', { level: 3, name: /Choose what Identrail should cover/i })).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: 'AWS connected summary' })).toBeInTheDocument();
     // The connected-state primary CTA is the AWS overview link.
     expect(screen.getByRole('link', { name: /AWS overview/i })).toHaveAttribute(
       'href',
@@ -12529,6 +12622,62 @@ describe('Domain-first app routes', () => {
       'older-production',
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
+  });
+
+  it('qualifies organization all-account summaries when accounts are excluded', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...connectedAWS,
+        scope_type: 'organization',
+        deployment_method: 'stackset_service_managed',
+        target_account_ids: [],
+        target_ou_ids: ['r-abcd'],
+        excluded_account_ids: ['111111111111', '222222222222'],
+        auto_onboard_new_accounts: true,
+        target_summary: {
+          account_count: 0,
+          account_count_known: false,
+          ou_count: 0,
+          region_count: 1,
+          excluded_account_count: 2,
+          expected_stack_instances: 0,
+          expected_stack_instances_known: false,
+          all_accounts: true
+        }
+      }
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const summary = await screen.findByRole('region', { name: 'AWS connected summary' });
+    expect(within(summary).getByText('Organization, all accounts except 2 excluded accounts')).toBeInTheDocument();
+    expect(within(summary).getByText('All organization accounts except 2 excluded accounts')).toBeInTheDocument();
   });
 
   it('keeps requested environment selected when getProject check fails for a transient error', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3755,6 +3755,90 @@ function awsConnectionLabel(connection: AWSConnectionStatus | null): string {
   return connection.connected ? 'Connected' : connectionLifecycle(connection);
 }
 
+function awsExcludedAccountCount(connection: AWSConnectionStatus): number {
+  return connection.target_summary?.excluded_account_count ?? connection.excluded_account_ids.length;
+}
+
+function awsExcludedAccountLabel(count: number): string {
+  return `${count} excluded account${count === 1 ? '' : 's'}`;
+}
+
+function awsConnectedScopeLabel(connection: AWSConnectionStatus): string {
+  const excludedCount = awsExcludedAccountCount(connection);
+  switch (connection.scope_type) {
+    case 'organization':
+      if (!connection.target_summary?.all_accounts) {
+        return 'Organization';
+      }
+      return excludedCount > 0
+        ? `Organization, all accounts except ${awsExcludedAccountLabel(excludedCount)}`
+        : 'Organization, all accounts';
+    case 'selected_ous':
+      return 'Selected organizational units';
+    case 'selected_accounts':
+      return 'Selected accounts';
+    case 'manual_role':
+      return 'Existing IAM role';
+    case 'single_account':
+    default:
+      return 'Single account';
+  }
+}
+
+function awsConnectedAccountCoverageLabel(connection: AWSConnectionStatus): string {
+  const excludedCount = awsExcludedAccountCount(connection);
+  if (connection.target_summary?.all_accounts) {
+    const coverage = connection.target_summary.account_count_known
+      ? `${connection.target_summary.account_count} account${connection.target_summary.account_count === 1 ? '' : 's'}`
+      : 'All organization accounts';
+    return excludedCount > 0 ? `${coverage} except ${awsExcludedAccountLabel(excludedCount)}` : coverage;
+  }
+  if (connection.target_summary?.account_count_known) {
+    const coverage = `${connection.target_summary.account_count} account${connection.target_summary.account_count === 1 ? '' : 's'}`;
+    return excludedCount > 0 ? `${coverage} after ${awsExcludedAccountLabel(excludedCount)}` : coverage;
+  }
+  if (connection.target_summary) {
+    return 'Pending';
+  }
+  if (connection.target_account_ids.length > 0) {
+    return `${connection.target_account_ids.length} account${connection.target_account_ids.length === 1 ? '' : 's'}`;
+  }
+  return connection.account_id ? `Account ${connection.account_id}` : 'Pending';
+}
+
+function awsConnectedRegionCoverageLabel(connection: AWSConnectionStatus): string {
+  const count = connection.target_summary?.region_count ?? connection.target_regions.length;
+  if (count > 0) {
+    return `${count} region${count === 1 ? '' : 's'}`;
+  }
+  return connection.region ? connection.region : 'Pending';
+}
+
+function awsConnectedTradeoffs(connection: AWSConnectionStatus): string[] {
+  switch (connection.scope_type) {
+    case 'organization':
+      return connection.auto_onboard_new_accounts
+        ? ['New organization accounts are included automatically.', 'Excluded accounts stay out of collection until removed from the exclusion list.']
+        : ['Organization coverage is fixed to the current targets.', 'New accounts need an explicit onboarding update before Identrail collects them.'];
+    case 'selected_ous':
+      return [
+        connection.excluded_account_ids.length > 0
+          ? 'Accounts in the selected OUs are collected, except excluded accounts.'
+          : 'Only accounts in the selected OUs are collected.',
+        connection.auto_onboard_new_accounts
+          ? 'New accounts under those OUs are included automatically.'
+          : 'New accounts under those OUs need an explicit onboarding update.'
+      ];
+    case 'selected_accounts':
+      return ['Only the selected account IDs are collected.', 'OU movement does not change coverage until the selected account list changes.'];
+    case 'manual_role':
+      return ['IAM trust and permissions are managed outside Identrail.', 'Update the role manually before rerunning validation.'];
+    case 'single_account':
+    default:
+      return ['Collection is limited to one account and home region.', 'Use Manage connection to expand coverage through an organization or selected scope.'];
+  }
+}
+
 function awsRouteLink(scope: ProductSession, routeID: ProductDomainRouteID, environmentID: string): string {
   return appendEnvironmentQuery(domainRoutePath(scope, 'aws', findDomainRoute('aws', routeID)), environmentID);
 }
@@ -4137,6 +4221,123 @@ function AWSGuidedRepairList({
         </article>
       ))}
     </div>
+  );
+}
+
+function AWSConnectedSuccessPanel({
+  scope,
+  environmentID,
+  connection,
+  baseline,
+  refreshing,
+  baselineLoading,
+  onRefresh,
+  onRunBaseline,
+  onManageConnection
+}: {
+  scope: ProductSession;
+  environmentID: string;
+  connection: AWSConnectionStatus;
+  baseline: AWSPlatformBaselineResult | null;
+  refreshing: boolean;
+  baselineLoading: boolean;
+  onRefresh: () => void;
+  onRunBaseline: () => void;
+  onManageConnection: () => void;
+}) {
+  const overviewPath = awsRouteLink(scope, 'overview', environmentID);
+  const identitiesPath = awsRouteLink(scope, 'identities', environmentID);
+  const coveragePath = awsRouteLink(scope, 'coverage', environmentID);
+  const findingsPath = awsRouteLink(scope, 'findings', environmentID);
+  const tradeoffs = awsConnectedTradeoffs(connection);
+  const permissionFailures = connection.permission_checks.filter((check) => !check.passed).length;
+  const showFindingsAction =
+    connection.health_status === 'warning' ||
+    connection.health_status === 'error' ||
+    connection.status === 'degraded' ||
+    permissionFailures > 0;
+
+  return (
+    <section className="idt-source-config idt-aws-connected-success" aria-label="AWS connected summary">
+      <div className="idt-source-config-header">
+        <div className="idt-source-config-title">
+          <SourceLogoMark provider="aws" className="is-hero" />
+          <div>
+            <p className="idt-app-kicker">Connected</p>
+            <h3>{connection.display_name || 'AWS connector is active'}</h3>
+            <p>{connection.setup_summary || 'AWS is connected and ready for identity intelligence.'}</p>
+          </div>
+        </div>
+        <DomainStatusBadge variant={awsStatusVariant(connection)} detail={connection.health_status} />
+      </div>
+
+      <dl className="idt-aws-connected-facts">
+        <div>
+          <dt>Scope</dt>
+          <dd>{awsConnectedScopeLabel(connection)}</dd>
+        </div>
+        <div>
+          <dt>Accounts</dt>
+          <dd>{awsConnectedAccountCoverageLabel(connection)}</dd>
+        </div>
+        <div>
+          <dt>Regions</dt>
+          <dd>{awsConnectedRegionCoverageLabel(connection)}</dd>
+        </div>
+        <div>
+          <dt>Health</dt>
+          <dd>{formatTokenLabel(connection.health_status)}</dd>
+        </div>
+        <div>
+          <dt>Last validation</dt>
+          <dd>{formatConnectionTime(connection.last_validated_at ?? connection.updated_at)}</dd>
+        </div>
+        <div>
+          <dt>Permissions</dt>
+          <dd>
+            {connection.permission_checks.length > 0
+              ? `${connection.permission_checks.length - permissionFailures}/${connection.permission_checks.length} passed`
+              : 'Not validated'}
+          </dd>
+        </div>
+        <div>
+          <dt>Readiness</dt>
+          <dd>{awsBaselineLabel(baseline)}</dd>
+        </div>
+      </dl>
+
+      <div className="idt-aws-connected-actions">
+        <Link className="idt-btn idt-btn-primary" to={overviewPath}>
+          Start AWS intelligence
+        </Link>
+        <Link className="idt-btn idt-btn-dark" to={identitiesPath}>
+          Review machine identities
+        </Link>
+        <Link className="idt-btn idt-btn-secondary" to={coveragePath}>
+          View coverage gaps
+        </Link>
+        {showFindingsAction ? (
+          <Link className="idt-btn idt-btn-ghost" to={findingsPath}>
+            Review findings
+          </Link>
+        ) : null}
+        <button className="idt-btn idt-btn-ghost" type="button" onClick={onRefresh} disabled={refreshing}>
+          {refreshing ? 'Refreshing...' : 'Refresh status'}
+        </button>
+        <button className="idt-btn idt-btn-ghost" type="button" onClick={onRunBaseline} disabled={baselineLoading}>
+          {baselineLoading ? 'Running...' : 'Run baseline'}
+        </button>
+        <button className="idt-btn idt-btn-ghost" type="button" onClick={onManageConnection}>
+          Manage connection
+        </button>
+      </div>
+
+      <ul className="idt-aws-connected-tradeoffs" aria-label="AWS setup tradeoffs">
+        {tradeoffs.map((tradeoff) => (
+          <li key={tradeoff}>{tradeoff}</li>
+        ))}
+      </ul>
+    </section>
   );
 }
 
@@ -21534,6 +21735,7 @@ export function ProductAWSConnectPage() {
   const [baseline, setBaseline] = useState<AWSPlatformBaselineResult | null>(null);
   const [baselineLoading, setBaselineLoading] = useState(false);
   const [baselineError, setBaselineError] = useState('');
+  const [manageConnectionOpen, setManageConnectionOpen] = useState(false);
   const [awsForm, setAWSForm] = useState({
     roleARN: '',
     externalID: '',
@@ -21614,6 +21816,9 @@ export function ProductAWSConnectPage() {
           return;
         }
         setConnection(response.connection);
+        if (response.connection.connected) {
+          setManageConnectionOpen(false);
+        }
         const responseSetupMode = awsSetupModeFromResponse(response.connection.scope_type);
         const preserveManualDraft = awsSetupModeTouchedRef.current
           ? awsSetupModeRef.current === 'manual'
@@ -21827,6 +22032,7 @@ export function ProductAWSConnectPage() {
     setAWSCopiedField('');
     setBaseline(null);
     setBaselineError('');
+    setManageConnectionOpen(false);
     setSubmitting(false);
     setAWSCloudFormationStart(null);
     setAWSPermissionPreview([]);
@@ -21913,9 +22119,11 @@ export function ProductAWSConnectPage() {
     awsStartRequestRef.current += 1;
     awsPollRequestRef.current += 1;
     awsValidationRequestRef.current += 1;
+    awsStackSetOnboardingRequestRef.current += 1;
     setConnection(null);
     setBaseline(null);
     setBaselineError('');
+    setManageConnectionOpen(false);
     setAWSSetupMessage('');
     navigate(
       {
@@ -22010,9 +22218,14 @@ export function ProductAWSConnectPage() {
   const canValidateRole = Boolean(normalizeValue(awsForm.roleARN)) && (!isManualSetup || Boolean(activeConnectorID));
   const selectedAWSRegion = normalizeValue(awsForm.region) || 'us-east-1';
   const manualExternalID = normalizeValue(awsForm.externalID);
-  const manualIdentrailAccountID = normalizeValue(manualAWSStart?.identrail_account_id);
-  const manualTrustPolicy = buildAWSManualTrustPolicy(
-    manualIdentrailAccountID,
+  // Trust-policy snippet is identical across deployment methods: it encodes
+  // the Identrail account plus this connector's External ID. Sourcing from the
+  // active start response — instead of only the manual variant — keeps the
+  // guided repair "copy trust policy" button usable after a CloudFormation or
+  // StackSet start, which is exactly when a trust misconfiguration surfaces.
+  const wizardIdentrailAccountID = normalizeValue(awsCloudFormationStart?.identrail_account_id);
+  const awsTrustPolicy = buildAWSManualTrustPolicy(
+    wizardIdentrailAccountID,
     manualExternalID,
     awsPartitionForManualTrustPolicy(awsForm.roleARN, selectedAWSRegion)
   );
@@ -22435,7 +22648,7 @@ export function ProductAWSConnectPage() {
     }
   };
 
-  const handleAWSPoll = async () => {
+  const handleAWSPoll = async (options?: { keepManagementOpen?: boolean }) => {
     if (!selectedEnvironmentID || !activeConnectorID) {
       setErrorMessage('Launch the stack or save a connector before polling AWS status.');
       return;
@@ -22462,6 +22675,9 @@ export function ProductAWSConnectPage() {
         return;
       }
       setConnection(response.connection);
+      if (response.connection.connected && !options?.keepManagementOpen) {
+        setManageConnectionOpen(false);
+      }
       setAWSForm((current) => ({
         ...current,
         roleARN: current.roleARN || response.connection.role_arn || '',
@@ -22585,6 +22801,9 @@ export function ProductAWSConnectPage() {
         return;
       }
       setConnection(response.connection);
+      if (response.connection.connected) {
+        setManageConnectionOpen(false);
+      }
       setAWSForm((current) => ({
         ...current,
         roleARN: current.roleARN || response.connection.role_arn || '',
@@ -22610,6 +22829,7 @@ export function ProductAWSConnectPage() {
   };
 
   const connectedNow = Boolean(connection?.connected);
+  const showAWSSetupControls = Boolean(selectedEnvironmentID) && (!connectedNow || manageConnectionOpen);
   const awaitingFirstConnectLoad = loadingConnection && !connection && !errorMessage;
   const connectSubtitle = (() => {
     if (awaitingFirstConnectLoad || environmentScope.loading) {
@@ -22746,9 +22966,9 @@ export function ProductAWSConnectPage() {
         case 'copy_trust_policy':
           return {
             label,
-            onClick: () => void copyAWSManualValue('trust-policy', manualTrustPolicy),
+            onClick: () => void copyAWSManualValue('trust-policy', awsTrustPolicy),
             variant,
-            disabled: !manualTrustPolicy
+            disabled: !awsTrustPolicy
           };
         case 'enable_trusted_access':
         case 'register_delegated_admin':
@@ -22871,6 +23091,22 @@ export function ProductAWSConnectPage() {
 
       {selectedEnvironmentID ? (
         <div className="idt-aws-connect-layout">
+          <div className="idt-aws-connect-main">
+            {connectedNow && connection ? (
+              <AWSConnectedSuccessPanel
+                scope={scope}
+                environmentID={selectedEnvironmentID}
+                connection={connection}
+                baseline={baseline}
+                refreshing={refreshingConnection}
+                baselineLoading={baselineLoading}
+                onRefresh={() => void refreshConnection('manual')}
+                onRunBaseline={() => void verifyBaseline()}
+                onManageConnection={() => setManageConnectionOpen(true)}
+              />
+            ) : null}
+
+            {showAWSSetupControls ? (
           <section className="idt-source-config idt-aws-connect-panel idt-aws-scope-wizard" aria-label="AWS account setup">
             <div className="idt-source-config-header idt-aws-wizard-header">
               <div className="idt-source-config-title">
@@ -23124,14 +23360,14 @@ export function ProductAWSConnectPage() {
                             </button>
                           </div>
                         </label>
-                        {manualTrustPolicy ? (
+                        {awsTrustPolicy ? (
                           <label>
                             Trust policy
-                            <textarea value={manualTrustPolicy} readOnly rows={10} />
+                            <textarea value={awsTrustPolicy} readOnly rows={10} />
                             <button
                               className="idt-btn idt-btn-ghost"
                               type="button"
-                              onClick={() => void copyAWSManualValue('trust-policy', manualTrustPolicy)}
+                              onClick={() => void copyAWSManualValue('trust-policy', awsTrustPolicy)}
                             >
                               {awsCopiedField === 'trust-policy' ? 'Copied trust policy' : 'Copy trust policy'}
                             </button>
@@ -23170,7 +23406,7 @@ export function ProductAWSConnectPage() {
                     </label>
                     <div className="idt-source-actions">
                       {activeConnectorID ? (
-                        <button className="idt-btn idt-btn-secondary" type="button" onClick={handleAWSPoll} disabled={submitting}>
+                        <button className="idt-btn idt-btn-secondary" type="button" onClick={() => void handleAWSPoll()} disabled={submitting}>
                           {submitting ? 'Refreshing...' : 'Refresh status'}
                         </button>
                       ) : null}
@@ -23215,7 +23451,7 @@ export function ProductAWSConnectPage() {
                     </details>
                     <div className="idt-source-actions">
                       {activeConnectorID ? (
-                        <button className="idt-btn idt-btn-secondary" type="button" onClick={handleAWSPoll} disabled={submitting}>
+                        <button className="idt-btn idt-btn-secondary" type="button" onClick={() => void handleAWSPoll()} disabled={submitting}>
                           {submitting ? 'Refreshing...' : 'Refresh status'}
                         </button>
                       ) : null}
@@ -23235,7 +23471,7 @@ export function ProductAWSConnectPage() {
                 onRefresh={
                   activeConnectorID
                     ? () => {
-                        void handleAWSPoll();
+                        void handleAWSPoll({ keepManagementOpen: true });
                         void refreshStackSetOnboarding();
                       }
                     : undefined
@@ -23244,6 +23480,8 @@ export function ProductAWSConnectPage() {
               />
             ) : null}
           </section>
+            ) : null}
+          </div>
 
           <div className="idt-aws-connect-side">
             <section className="idt-source-config idt-aws-connect-summary" aria-label="AWS setup summary">
@@ -29048,6 +29286,13 @@ export function ProductShellLayout() {
         path: domainCommandPath(`${basePath}/aws/coverage`)
       });
       items.push({
+        id: 'aws-identities',
+        label: 'AWS identities',
+        description: 'Machine identities discovered from the connected AWS scope',
+        keywords: ['aws', 'identities', 'iam', 'roles', 'machine'],
+        path: domainCommandPath(`${basePath}/aws/identities`)
+      });
+      items.push({
         id: 'aws-findings',
         label: 'AWS findings',
         description: 'Domain-scoped AWS risk queue',
@@ -29058,8 +29303,8 @@ export function ProductShellLayout() {
         items.push({
           id: 'aws-connect',
           label: 'Connect AWS',
-          description: 'Start AWS account and identity onboarding',
-          keywords: ['aws', 'connect', 'account', 'role'],
+          description: 'Review AWS connection status or manage onboarding',
+          keywords: ['aws', 'connect', 'account', 'role', 'status', 'onboarding'],
           path: domainCommandPath(`${basePath}/aws/connect`)
         });
       }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -24137,6 +24137,12 @@ html[data-theme='light'] .idt-app-shell-screen select {
   min-width: 0;
 }
 
+.idt-aws-connect-main {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
 .idt-app-console-layout .idt-aws-connect-panel .idt-source-meta {
   grid-template-columns: minmax(0, 1fr) minmax(8rem, 0.55fr) minmax(12.5rem, 0.8fr);
 }
@@ -24344,6 +24350,67 @@ html[data-theme='light'] .idt-app-shell-screen select {
 .idt-aws-connect-summary {
   display: grid;
   gap: 0.75rem;
+}
+
+.idt-aws-connected-success {
+  display: grid;
+  gap: 0.9rem;
+  border-color: rgba(88, 214, 141, 0.36);
+}
+
+.idt-aws-connected-success .idt-source-config-header {
+  align-items: flex-start;
+}
+
+.idt-aws-connected-facts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.idt-aws-connected-facts div {
+  min-width: 0;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.68rem 0.74rem;
+  background: #050505;
+}
+
+.idt-aws-connected-facts dt {
+  color: var(--app-dim);
+  font-size: 0.7rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-aws-connected-facts dd {
+  min-width: 0;
+  margin: 0.18rem 0 0;
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 850;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-connected-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.idt-aws-connected-actions .idt-btn {
+  min-height: 2.35rem;
+}
+
+.idt-aws-connected-tradeoffs {
+  display: grid;
+  gap: 0.42rem;
+  margin: 0;
+  padding-left: 1.05rem;
+  color: var(--app-muted);
+  font-size: 0.86rem;
+  line-height: 1.45;
 }
 
 .idt-app-console-layout .idt-aws-connect-summary .idt-source-meta {
@@ -25188,6 +25255,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge
   .idt-domain-page-body.has-subnav.has-aside,
   .idt-aws-status-grid,
   .idt-aws-connect-layout,
+  .idt-aws-connected-facts,
   .idt-aws-inventory-split,
   .idt-app-console-layout .idt-aws-connect-panel .idt-source-meta,
   .idt-aws-next-actions {
@@ -25221,7 +25289,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge
   .idt-domain-action,
   .idt-domain-header-actions .idt-btn,
   .idt-domain-filter-actions .idt-btn,
-  .idt-domain-action-footer .idt-btn {
+  .idt-domain-action-footer .idt-btn,
+  .idt-aws-connected-actions .idt-btn {
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- show connected AWS environments with a success summary, scoped coverage facts, next actions, and setup tradeoffs
- hide setup controls until Manage connection and reset the manager on scope changes or connected refreshes
- add `identrail aws-status` for hosted AWS connector status and update README/docs

## Tests
- `go test ./internal/cli`
- `npm --prefix web test -- --run productShell.test.tsx -t "connected AWS status|keeps edited AWS role drafts|legacy role-only AWS|ignores stale AWS validation responses after switching environments"`
- `npm --prefix web run build`

Closes #1755

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes the AWS connected success state: shows a default connected summary with scope-aware coverage, health, last validation, permission pass rate, readiness, and quick links. Adds `identrail aws-status` (table/JSON, optional `--connector-id`) and never prints the External ID.

- **New Features**
  - Default connected panel with scope label (qualifies organization “all accounts” with exclusions), account/region coverage, health, last validation, permission pass rate, readiness, and links to AWS overview, identities, coverage, and findings. Includes “Refresh status,” “Run baseline,” and “Manage connection,” plus scope tradeoffs. The wizard is hidden by default and opens only via “Manage connection”; it auto‑closes and clears drafts on environment/scope changes or after successful refresh/validate. Trust‑policy snippet is available after any start method; “Copy trust policy” now sources from the active start response.
  - New CLI `identrail aws-status` with table/JSON output and flags `--api-url`, `--api-key`, `--tenant-id`, `--workspace-id`, `--project-id`, `--connector-id`, `--timeout`; `--connector-id` uses the connector poll route. Docs updated for organization StackSet, selected OUs/accounts, existing role, connected-state behavior, CLI reference, new troubleshooting code `suspended_accounts_excluded`, and a README example.

- **Bug Fixes**
  - Ignores stale AWS validation responses after switching environments, resets manager state on scope changes, and keeps legacy role‑only AWS connections out of connector validation.

<sup>Written for commit 0df8801ba8a55c9401c4558f7a4d49b7db281a33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

