### PR TITLE
Revert "Tighten marketing site messaging and layout"

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -393,28 +393,27 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: /Find the access paths that can reach production/i
+        name: /See every machine identity path/i
       })
     ).toBeInTheDocument();
 
     const scanButtons = screen.getAllByRole('button', { name: 'Request Trust Path Review' });
     expect(scanButtons.length).toBeGreaterThan(0);
-    expect(document.querySelectorAll('.idt-logo-cloud-group')).toHaveLength(1);
-    expect(document.querySelectorAll('.idt-logo-cloud-group .idt-logo-cloud-item')).toHaveLength(3);
-    expect(screen.getByRole('heading', { level: 2, name: /A role, repo, or service account/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 2, name: /One finding, with the whole path attached/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 2, name: /From source connection to owner-ready evidence/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 2, name: /See what your first finding looks like/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'View Identrail on GitHub' })).toHaveAttribute(
-      'href',
-      'https://github.com/identrail/identrail'
-    );
+    expect(document.querySelectorAll('.idt-logo-cloud-group')).toHaveLength(2);
+    expect(document.querySelectorAll('.idt-logo-cloud-group:first-child .idt-logo-cloud-item')).toHaveLength(8);
     fireEvent.click(scanButtons[0]);
     expect(screen.getByRole('dialog', { name: /Verify company identity/i })).toBeInTheDocument();
     expect(screen.queryByText('Read-only trust review')).not.toBeInTheDocument();
     expect(screen.queryByText(/Need enterprise procurement/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole('heading', { level: 2, name: /Connect sources, trace risk/i })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /Book Demo/i }).length).toBeGreaterThan(0);
     expect(document.querySelector('#risk-scan-form')).not.toBeInTheDocument();
     expect(document.querySelector('.idt-trust-strip + .idt-home-after-stack')).toBeInTheDocument();
+    expect(document.querySelector('.idt-home-after-stack .idt-shell')).not.toBeInTheDocument();
   });
 
 
@@ -560,13 +559,13 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: /Machine identity risk, with the path attached/i
+        name: /Machine identity risk, mapped end to end/i
       })
     ).toBeInTheDocument();
 
-    expect(screen.getByRole('heading', { level: 2, name: /Three steps from source to decision/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 2, name: /See the path behind the finding/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 2, name: /From discovery to review/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /Four product surfaces/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /The Trust Graph is the control plane/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /From discovery to fix/i })).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: /Request Trust Path Review/i }).length).toBeGreaterThan(0);
     expect(document.querySelector('main main')).not.toBeInTheDocument();
     expect(document.querySelector('.idt-product-hero-visual')).toHaveAttribute('aria-hidden', 'true');
@@ -738,7 +737,7 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: /Connect the sources behind machine identity risk/i
+        name: /Identity signal coverage across cloud, cluster, and code workflows/i
       })
     ).toBeInTheDocument();
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -358,8 +358,31 @@ const DOCS_FEATURED_GUIDES = [
     eyebrow: 'Architecture map',
     title: 'Understand the trust graph engine',
     description:
-      'See how source collection, repository exposure, graph construction, and finding analysis fit together.',
+      'See how ingestion, repository exposure, graph construction, and authorization controls work as one system.',
     href: 'https://github.com/identrail/identrail/blob/dev/docs/architecture.md'
+  }
+] as const;
+
+const DIFFERENTIATION_ROWS = [
+  {
+    area: 'Trust-path explainability',
+    identrail: 'Shows full identity chain with policy evidence and affected resources',
+    closed: 'Often returns abstract risk findings without chain-level context'
+  },
+  {
+    area: 'Rollout safety',
+    identrail: 'Read-only collection, simulation-first remediation, staged enforcement',
+    closed: 'Policy hardening usually relies on external tooling and manual checks'
+  },
+  {
+    area: 'Open-core transparency',
+    identrail: 'Public repository, documentation, and release history',
+    closed: 'Limited implementation visibility and slower verification by engineers'
+  },
+  {
+    area: 'Developer and platform fit',
+    identrail: 'Built for security + platform collaboration with inspectable outputs',
+    closed: 'Security-only workflows can be harder for platform teams to operationalize'
   }
 ] as const;
 
@@ -502,6 +525,18 @@ const INTEGRATION_ROWS = [
     signals: 'Workflow identities, OIDC trust, repository exposure telemetry',
     depth: 'Deep',
     status: 'GA'
+  },
+  {
+    source: 'OpenID Connect',
+    signals: 'Provider trust boundaries and subject claim controls',
+    depth: 'Focused',
+    status: 'GA'
+  },
+  {
+    source: 'Prometheus',
+    signals: 'Operational metrics for scans, workers, and authz policy telemetry',
+    depth: 'Focused',
+    status: 'GA'
   }
 ] as const;
 
@@ -512,13 +547,13 @@ const READ_ONLY_CONTROL_ROWS = [
     excluded: 'No secret material ingestion, no credential writeback'
   },
   {
-    area: 'Finding analysis',
-    access: 'Detection and graph analysis run against collected identity metadata',
-    excluded: 'No direct access changes during analysis'
+    area: 'Policy simulation',
+    access: 'Simulation engine evaluates proposed changes against collected graph state',
+    excluded: 'No direct policy mutation during simulation'
   },
   {
-    area: 'Review workflow',
-    access: 'Evidence, ownership, and remediation context stay attached to each finding',
+    area: 'Remediation workflow',
+    access: 'Action plans and exportable recommendations',
     excluded: 'No automatic enforcement without explicit operator action'
   }
 ] as const;
@@ -533,7 +568,7 @@ const FEATURE_DEEP_PAGES = [
     bullets: [
       'Map every role assumption chain and transitive trust path across accounts',
       'Prioritize overprivileged IAM paths by reachable sensitive resources',
-      'Review trust-policy evidence before a production change'
+      'Preview trust-policy hardening before production rollout'
     ],
     outcomes: [
       'Faster IAM triage for security engineering teams',
@@ -550,7 +585,7 @@ const FEATURE_DEEP_PAGES = [
     bullets: [
       'Trace namespace and cluster-level escalation paths from service accounts',
       'Understand cluster-to-cloud trust bridges through OIDC federation',
-      'Review RBAC exposure with cluster and workload context'
+      'Simulate RBAC hardening changes to avoid workload breakage'
     ],
     outcomes: [
       'Lower RBAC drift and accidental privilege growth',
@@ -600,16 +635,16 @@ const SOLUTION_DEEP_PAGES = [
     navLabel: 'AWS',
     heroTitle: 'Solution for AWS security teams',
     description:
-      'Reduce IAM blast radius with explainable trust paths, prioritized findings, and evidence your team can review.',
+      'Reduce IAM blast radius with explainable trust paths, prioritized exposure queues, and rollout-safe least-privilege workflows.',
     bullets: [
       'Continuously discover machine identities and trust relationships in AWS',
       'Detect high-impact assumption chains and overprivileged role paths',
       'Coordinate remediation with platform teams through shared graph evidence'
     ],
     outcomes: [
-      'Faster IAM triage for security engineering teams',
-      'Clear ownership for platform remediation',
-      'Evidence-backed review of trust policy changes'
+      '60-90% reduction in overprivileged IAM role exposure',
+      'Faster incident-response triage for identity pathways',
+      'Audit-ready visibility into trust policy changes'
     ]
   },
   {
@@ -617,11 +652,11 @@ const SOLUTION_DEEP_PAGES = [
     navLabel: 'Kubernetes',
     heroTitle: 'Solution for Kubernetes platform teams',
     description:
-      'Understand service-account and RBAC exposure in production clusters without losing workload context.',
+      'Control service-account and RBAC risk in production clusters without slowing down release velocity.',
     bullets: [
       'Expose hidden service-account privilege escalation paths',
       'Correlate RBAC risk with cloud permissions and federated trust',
-      'Review RBAC changes with source and workload evidence'
+      'Roll out safer RBAC policy controls with staged validation'
     ],
     outcomes: [
       'Reduced cluster authorization incidents',
@@ -631,19 +666,19 @@ const SOLUTION_DEEP_PAGES = [
   },
   {
     slug: 'multi-cloud',
-    navLabel: 'Multiple environments',
-    heroTitle: 'Solution for AWS organizations and shared clusters',
+    navLabel: 'Multi-cloud',
+    heroTitle: 'Solution for multi-cloud machine identity operations',
     description:
-      'Keep identity findings consistent across AWS accounts and shared Kubernetes environments with one review model.',
+      'Unify fragmented identity posture and trust-path analysis across cloud and cluster boundaries with one operating model.',
     bullets: [
-      'Connect AWS and Kubernetes sources in one findings workflow',
-      'Apply consistent evidence and ownership criteria across environments',
-      'Keep source context attached as findings move between teams'
+      'Normalize machine identity telemetry into one graph-backed workflow',
+      'Apply consistent triage criteria across environments',
+      'Track policy and exposure changes with centralized evidence'
     ],
     outcomes: [
-      'One review model across accounts and clusters',
-      'Less context switching during triage',
-      'Clearer handoffs between security and platform teams'
+      'Unified identity risk visibility across environments',
+      'Lower operational overhead for security operations',
+      'Improved governance consistency for compliance programs'
     ]
   },
   {
@@ -651,10 +686,10 @@ const SOLUTION_DEEP_PAGES = [
     navLabel: 'Platform Engineering',
     heroTitle: 'Solution for platform engineering organizations',
     description:
-      'Give platform teams the context to review identity findings and make focused authorization changes.',
+      'Ship authorization changes faster with simulation and staged rollout controls that protect production reliability.',
     bullets: [
-      'See which workloads and resources a finding can reach',
-      'Review source evidence before changing authorization',
+      'Preview policy impact before enforcement',
+      'Run controlled rollouts with rollback safety rails',
       'Share remediation context directly with service owners'
     ],
     outcomes: [
@@ -1803,7 +1838,7 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
       </div>
 
       {viewMode === 'graph' ? (
-        <div id={graphPanelId} role="tabpanel" aria-labelledby={graphTabId} className="idt-demo-graph" aria-label="Interactive trust graph preview">
+        <div id={graphPanelId} role="tabpanel" aria-labelledby={graphTabId} className="idt-demo-graph" aria-label="Interactive trust graph simulation">
           <svg className="idt-demo-edges" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
               <linearGradient id={`idt-demo-edge-base-gradient-${variant}`} x1="0%" y1="0%" x2="100%" y2="100%">
@@ -2354,12 +2389,12 @@ function FaqPage() {
 
 function HomePage() {
   const seo: SeoConfig = {
-    title: 'Open-Source Machine Identity Security | Identrail',
+    title: 'Machine Identity Trust Graph | AWS IAM, Kubernetes, OIDC | Identrail',
     description:
-      'Identrail scans GitHub, AWS, and Kubernetes to show which machine identity paths can reach sensitive resources, with evidence your team can act on.',
+      'Identrail is the trust graph for machine identity security across AWS IAM, Kubernetes, GitHub/OIDC, and repository exposure signals with read-only evidence and safe remediation.',
     path: '/',
     keywords:
-      'machine identity security, AWS IAM, Kubernetes RBAC, GitHub security, trust paths, repository exposure',
+      'machine identity security, AWS IAM trust path analysis, Kubernetes service account risk, OIDC security, cloud identity blast radius reduction, GitHub trust path risk',
     schemaType: 'WebPage'
   };
   useSeo(seo);
@@ -2369,13 +2404,13 @@ function HomePage() {
       <section className="idt-hero">
         <div className="idt-shell idt-hero-grid">
           <div className="idt-hero-copy">
-            <p className="idt-eyebrow">Open-source machine identity security</p>
+            <p className="idt-eyebrow">Machine identity trust graph</p>
             <h1>
-              Find the access paths that can reach <span>production</span>.
+              See every machine identity path before it becomes <span>risk</span>.
             </h1>
             <p className="idt-lead idt-lead-body">
-              Identrail scans GitHub, AWS, and Kubernetes to show which machine identities can reach sensitive resources—then
-              gives your team the evidence to decide what to fix.
+              Identrail connects cloud, cluster, repository, and OIDC identity signals into one live risk graph so teams can
+              prioritize exposure and ship safer access changes.
             </p>
             <div className="idt-inline-actions" data-ab-slot="hero_primary_cta">
               <ScanIntakeCTA className="idt-btn idt-btn-primary" />
@@ -2388,17 +2423,18 @@ function HomePage() {
               </div>
               <div>
                 <dt>Coverage</dt>
-                <dd>GitHub, AWS, Kubernetes</dd>
+                <dd>AWS, K8s, GitHub, OIDC</dd>
               </div>
               <div>
                 <dt>Output</dt>
-                <dd>Evidence-backed findings</dd>
+                <dd>Prioritized risk graph</dd>
               </div>
             </dl>
             <ul className="idt-hero-trust-cues" aria-label="Evaluation trust cues">
-              <li>Open source under Apache-2.0</li>
-              <li>No write access during scans</li>
-              <li>CLI, Docker, and hosted workflows</li>
+              <li>Open-core under Apache-2.0</li>
+              <li>Read-only onboarding model</li>
+              <li>Self-hosted and hosted paths</li>
+              <li>Public docs and release history</li>
             </ul>
           </div>
           <HeroProductReveal />
@@ -2412,22 +2448,47 @@ function HomePage() {
 
         <CommandCenterSection />
 
+        <ProductTourSection />
+
         <HowItWorksSection />
+
+        <DeploymentPathBanner />
+
+        <section className="idt-section idt-home-compare-section">
+          <SectionTitle
+            eyebrow="Comparison"
+            title="Why teams choose Identrail over closed black-box workflows"
+          />
+          <div className="idt-table-wrap idt-home-compare">
+            <table className="idt-compare-table">
+              <thead>
+                <tr>
+                  <th scope="col">Category</th>
+                  <th scope="col">Identrail</th>
+                  <th scope="col">Typical closed alternatives</th>
+                </tr>
+              </thead>
+              <tbody>
+                {DIFFERENTIATION_ROWS.map((row) => (
+                  <tr key={row.area}>
+                    <th scope="row">{row.area}</th>
+                    <td>{row.identrail}</td>
+                    <td>{row.closed}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
 
         <section className="idt-section idt-final-cta idt-home-final-cta" id="enterprise-procurement">
           <SectionTitle
-            eyebrow="Start with one source"
-            title="See what your first finding looks like."
-            body="Connect a repository, AWS account, or Kubernetes cluster in read-only mode. Review the evidence, then choose the right deployment path."
+            eyebrow="Ready to evaluate"
+            title="Map your first production trust path in minutes"
+            body="Start with a read-only scan, review evidence, then decide whether to self-host, use hosted SaaS, or move to enterprise deployment."
           />
           <div className="idt-inline-actions">
-            <ScanIntakeCTA className="idt-btn idt-btn-primary">Request a review</ScanIntakeCTA>
-            <Link to="/docs" className="idt-btn idt-btn-dark">
-              Read the docs
-            </Link>
-            <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-ghost">
-              View on GitHub
-            </SafeLink>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary idt-home-demo-cta">Book Demo</ScanIntakeCTA>
           </div>
         </section>
       </div>
@@ -2809,7 +2870,7 @@ function ScanIntakeModal({ onClose }: { onClose: () => void }) {
                     <ul>
                       <li>Prioritized trust path findings with severity and impact context</li>
                       <li>Reachable blast-radius summary for your selected environment</li>
-                      <li>Evidence-backed remediation starting point</li>
+                      <li>Rollout-safe remediation sequence for first actions</li>
                     </ul>
                   </article>
                 </div>
@@ -2909,7 +2970,7 @@ function ProductPage() {
   useSeo({
     title: 'Product | Identrail Machine Identity Security Platform',
     description:
-      'Scan GitHub, AWS, and Kubernetes with Identrail to map machine identity paths, investigate risk, and hand off evidence-backed fixes.',
+      'Discover machine identities across AWS and Kubernetes, map trust paths, detect risk, and enforce safer authorization controls with Identrail.',
     path: '/product',
     schemaType: 'Product'
   });
@@ -2919,10 +2980,10 @@ function ProductPage() {
       <section className="idt-product-hero-full">
         <div className="idt-product-hero-copy">
           <p className="idt-eyebrow">Product</p>
-          <h1>Machine identity risk, with the path attached</h1>
+          <h1>Machine identity risk, mapped end to end</h1>
           <p>
-            Identrail connects GitHub exposure, AWS IAM relationships, and Kubernetes RBAC into findings your team can
-            investigate and explain.
+            Identrail unifies IAM graph discovery, repository exposure scanning, and rollout-safe authorization
+            workflows into one operator-grade platform.
           </p>
           <div className="idt-inline-actions">
             <ScanIntakeCTA className="idt-btn idt-btn-primary" />
@@ -2937,37 +2998,47 @@ function ProductPage() {
       <section className="idt-product-capability-band" aria-labelledby="product-capabilities-title">
         <div className="idt-product-section-heading">
           <p className="idt-eyebrow">Platform map</p>
-          <h2 id="product-capabilities-title">Three steps from source to decision.</h2>
+          <h2 id="product-capabilities-title">Four product surfaces in one workflow.</h2>
         </div>
         <div className="idt-product-capability-grid">
           <article>
             <span>01</span>
-            <h2>Connect sources</h2>
-            <p>Bring GitHub, AWS, and Kubernetes identity signals together in read-only mode.</p>
+            <h2>Trust Graph Explorer</h2>
+            <p>Interactive mapping of principals, assumptions, actions, and reachable resources across cloud and Kubernetes.</p>
             <ul>
-              <li>Scope the sources you own</li>
-              <li>Keep collection read-only</li>
-              <li>Preserve source evidence</li>
+              <li>Trace blast radius from any machine identity</li>
+              <li>Explain each trust edge with source policy evidence</li>
+              <li>Compare current and proposed policy states</li>
             </ul>
           </article>
           <article>
             <span>02</span>
-            <h2>Trace exposure</h2>
-            <p>Follow the identity path to the resource and see why the finding matters.</p>
+            <h2>Detection and Triage Engine</h2>
+            <p>High-signal detections for overprivileged paths, stale credentials, and risky identity chains.</p>
             <ul>
-              <li>Map identity relationships</li>
-              <li>Attach policy and workload context</li>
-              <li>Prioritize reachable sensitive resources</li>
+              <li>Risk scoring with business context</li>
+              <li>Actionable remediation guidance</li>
+              <li>Ticket and workflow integrations</li>
             </ul>
           </article>
           <article>
             <span>03</span>
-            <h2>Review the fix</h2>
-            <p>Give owners the evidence and next step needed to make a focused change.</p>
+            <h2>Repo Exposure Scanner</h2>
+            <p>Continuously scan source repositories and CI artifacts for leaked credentials and unsafe patterns.</p>
             <ul>
-              <li>Assign the responsible owner</li>
-              <li>Share the source proof</li>
-              <li>Track the next decision</li>
+              <li>Built-in and custom detectors</li>
+              <li>Git-aware triage with finding history</li>
+              <li>Correlates secret leaks to trust paths</li>
+            </ul>
+          </article>
+          <article>
+            <span>04</span>
+            <h2>Rollout-Safe Authorization Controls</h2>
+            <p>Enforce least privilege with policy simulation, staged rollout, and fast rollback safety rails.</p>
+            <ul>
+              <li>Policy impact simulation before deploy</li>
+              <li>Progressive rollout controls</li>
+              <li>Kill switch and audit trail support</li>
             </ul>
           </article>
         </div>
@@ -2976,10 +3047,10 @@ function ProductPage() {
       <section className="idt-product-graph-band">
         <div className="idt-product-section-heading">
           <p className="idt-eyebrow">Hero feature</p>
-          <h2>See the path behind the finding.</h2>
+          <h2>The Trust Graph is the control plane for machine identity risk.</h2>
           <p>
-            Investigate the relationship from source identity to sensitive resource with explainable graph evidence and
-            owner context.
+            Investigate every risky path from source identity to sensitive resource with explainable graph evidence and
+            owner-ready remediation.
           </p>
         </div>
         <TrustGraphDemo variant="full" />
@@ -2988,26 +3059,26 @@ function ProductPage() {
       <section className="idt-product-workflow-band" aria-labelledby="product-workflow-title">
         <div className="idt-product-section-heading">
           <p className="idt-eyebrow">Workflow</p>
-          <h2 id="product-workflow-title">From discovery to review without losing context.</h2>
+          <h2 id="product-workflow-title">From discovery to fix without collapsing the context.</h2>
         </div>
         <div className="idt-product-workflow-grid">
           <article>
-            <span>Connect</span>
-            <strong>Collect GitHub, AWS, and Kubernetes identity metadata in read-only mode.</strong>
+            <span>Discover</span>
+            <strong>Map the reachable identity graph across repositories, cloud roles, and Kubernetes workloads.</strong>
           </article>
           <article>
-            <span>Investigate</span>
-            <strong>Separate noisy permissions from paths that can reach sensitive resources.</strong>
+            <span>Prioritize</span>
+            <strong>Separate noisy permissions from the paths that can actually reach sensitive resources.</strong>
           </article>
           <article>
-            <span>Review</span>
-            <strong>Share source evidence and ownership context before making the next change.</strong>
+            <span>Control</span>
+            <strong>Ship least-privilege fixes with simulation, audit history, and rollback-ready guardrails.</strong>
           </article>
         </div>
         <div className="idt-product-cta-row">
           <div>
             <p className="idt-eyebrow">Technical walkthrough</p>
-            <h2>Bring one source. Leave with a finding you can explain.</h2>
+            <h2>Bring one risky path. Leave with the evidence and rollout plan.</h2>
           </div>
           <div className="idt-inline-actions">
             <ScanIntakeCTA className="idt-btn idt-btn-primary" />
@@ -3025,7 +3096,7 @@ function FeaturesPage() {
   useSeo({
     title: 'Features | AWS IAM, Kubernetes RBAC, Git Scanner, Trust Graph',
     description:
-      'Explore Identrail coverage for AWS machine identities, Kubernetes RBAC exposure, GitHub repository scanning, and trust-path analysis.',
+      'Explore Identrail features for AWS machine identities, Kubernetes RBAC visibility, Git exposure scanning, and interactive trust graph analysis.',
     path: '/features'
   });
 
@@ -3049,7 +3120,7 @@ function FeaturesPage() {
       bullets: [
         'Identify namespace and cluster-level privilege escalation paths',
         'Trace service account to cloud-role federation',
-        'Review RBAC exposure with cluster and workload context'
+        'Simulate RBAC control tightening before rollout'
       ]
     },
     {
@@ -3060,7 +3131,7 @@ function FeaturesPage() {
       bullets: [
         'Continuous and historical scan support',
         'Policy-backed detector tuning',
-        'Findings linked directly to trust-path context'
+        'Findings linked directly to trust graph context'
       ]
     },
     {
@@ -3080,8 +3151,8 @@ function FeaturesPage() {
     <div className="idt-marketing-page idt-modern-public-page idt-features-page">
       <PageHero
         eyebrow="Features"
-        title="Focused coverage for machine identity risk"
-        body="Connect GitHub, AWS, and Kubernetes signals, then investigate the paths that matter."
+        title="Built for cloud-native machine identity security at scale"
+        body="Deep technical workflows for security and platform teams, from discovery to rollout-safe control."
         variant="product"
         actions={
           <>
@@ -3139,7 +3210,7 @@ function FeatureDetailPage({ page }: { page: (typeof FEATURE_DEEP_PAGES)[number]
               View Docs
             </Link>
             <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-ghost">
-              View on GitHub
+              Star on GitHub
             </SafeLink>
           </>
         }
@@ -3175,35 +3246,35 @@ function FeatureDetailPage({ page }: { page: (typeof FEATURE_DEEP_PAGES)[number]
 
 function SolutionsPage() {
   useSeo({
-    title: 'Solutions | Security and Platform Teams | Identrail',
+    title: 'Solutions | AWS, Kubernetes, Multi-cloud, Security and Platform Teams',
     description:
-      'Current solution patterns for teams investigating machine identity paths across GitHub, AWS, and Kubernetes.',
+      'Solution patterns for AWS IAM, Kubernetes RBAC, multi-cloud identities, platform engineering teams, and security operations.',
     path: '/solutions'
   });
 
   const solutions = [
     {
       title: 'AWS Security Teams',
-      body: 'Reduce IAM blast radius with trust-path evidence, role-chain analysis, and clear ownership.',
-      metric: 'Faster triage with the affected path attached',
+      body: 'Reduce IAM blast radius with trust path evidence, role chain analysis, and policy simulations.',
+      metric: 'Cut overprivileged role exposure by 60-90%',
       href: '/solutions/aws'
     },
     {
       title: 'Kubernetes Platform Teams',
-      body: 'Understand service-account privileges and RBAC exposure with workload context.',
-      metric: 'Review cluster findings with source evidence',
+      body: 'Gain visibility into service account privileges and prevent RBAC drift before incidents happen.',
+      metric: 'Reduce cluster authz incidents with staged controls',
       href: '/solutions/kubernetes'
     },
     {
-      title: 'AWS Organizations and shared clusters',
-      body: 'Keep findings consistent across AWS accounts and shared Kubernetes environments.',
-      metric: 'One review model across accounts and clusters',
+      title: 'Multi-cloud Environments',
+      body: 'Normalize machine identity data across providers with one operational control layer.',
+      metric: 'Unify remediation workflows across clouds',
       href: '/solutions/multi-cloud'
     },
     {
       title: 'Platform Engineering',
-      body: 'Give platform teams the path, evidence, and owner context behind each finding.',
-      metric: 'Make focused changes without losing context',
+      body: 'Ship authorization changes faster with simulation, rollout safety, and clear policy traceability.',
+      metric: 'Deliver identity controls without release friction',
       href: '/solutions/platform-engineering'
     },
     {
@@ -3629,9 +3700,9 @@ function DeploymentModelsPage() {
 
 function IntegrationsPage() {
   useSeo({
-    title: 'Integrations | GitHub, AWS, and Kubernetes | Identrail',
+    title: 'Integrations | Machine Identity Signal Coverage',
     description:
-      'Connect GitHub, AWS IAM, and Kubernetes to map machine identity paths and review evidence in one workflow.',
+      'Review Identrail integration coverage across AWS IAM, Kubernetes, GitHub, OpenID Connect, and Prometheus with depth and signal details.',
     path: '/integrations'
   });
 
@@ -3639,8 +3710,8 @@ function IntegrationsPage() {
     <div className="idt-marketing-page idt-modern-public-page idt-integrations-page">
       <PageHero
         eyebrow="Integrations"
-        title="Connect the sources behind machine identity risk"
-        body="Identrail collects GitHub, AWS IAM, and Kubernetes signals in read-only mode, then links them into findings your team can review."
+        title="Identity signal coverage across cloud, cluster, and code workflows"
+        body="Identrail unifies machine identity telemetry into one trust-path analysis model. Use this page to verify connector depth before rollout."
         variant="product"
         actions={
           <>

--- a/web/src/components/home/CommandCenterSection.tsx
+++ b/web/src/components/home/CommandCenterSection.tsx
@@ -4,53 +4,53 @@ const COMMAND_VIEWS = [
   {
     id: 'triage',
     label: 'Triage',
-    eyebrow: 'Findings queue',
-    title: 'Start with the path that matters most.',
-    metricLabel: 'Reachable target',
-    metricValue: 'Production database',
-    secondaryLabel: 'Connected signals',
-    secondaryValue: 'GitHub workflow + AWS role + Kubernetes workload',
+    eyebrow: 'Exposure triage',
+    title: 'Turn scattered identity signals into one owner-ready queue.',
+    metricLabel: 'Primary risk path',
+    metricValue: 'Production database reachable',
+    secondaryLabel: 'Signal match',
+    secondaryValue: 'AWS role + K8s service account + OIDC claim drift',
     confidence: 'High confidence',
     evidence: [
-      'AWS trust policy accepts a broad workflow subject claim',
-      'Kubernetes binding reaches the workload namespace',
-      'The target is tagged production and regulated'
+      'Trust policy allows broad workflow subject claims',
+      'ClusterRoleBinding grants namespace-spanning workload access',
+      'Reachable resource is tagged production and regulated'
     ],
-    playbook: ['Confirm owner', 'Review evidence', 'Choose first fix']
+    playbook: ['Confirm owner', 'Review evidence bundle', 'Prioritize first fix']
   },
   {
     id: 'simulate',
-    label: 'Evidence',
-    eyebrow: 'Explain the finding',
-    title: 'Show why the path is risky before asking for a change.',
-    metricLabel: 'Evidence attached',
-    metricValue: 'Trust policy + workload context',
-    secondaryLabel: 'Decision context',
-    secondaryValue: 'Identity, relationship, target, and owner',
-    confidence: 'Evidence ready',
+    label: 'Simulate',
+    eyebrow: 'Policy simulation',
+    title: 'Preview access hardening before anything changes in production.',
+    metricLabel: 'Projected breakage',
+    metricValue: 'No critical workload impact',
+    secondaryLabel: 'Recommended change',
+    secondaryValue: 'Scope OIDC subject claims and split shared platform role',
+    confidence: 'Simulation ready',
     evidence: [
-      'Workflow subject claim is wider than the repository scope',
-      'Workload binding crosses the expected namespace boundary',
-      'The affected resource and owner are attached to the finding'
+      'No active workloads require the broad subject wildcard',
+      'Two service accounts can move to namespace-scoped bindings',
+      'Rollback path preserves current role until validation passes'
     ],
-    playbook: ['Review source proof', 'Confirm affected workload', 'Choose next action']
+    playbook: ['Model policy change', 'Review affected workloads', 'Stage rollout']
   },
   {
     id: 'report',
-    label: 'Review',
-    eyebrow: 'Review package',
-    title: 'Give the next team enough context to act.',
-    metricLabel: 'Source proof',
-    metricValue: 'Affected resource and owner',
-    secondaryLabel: 'Handoff',
-    secondaryValue: 'Evidence, decision, and next remediation step',
-    confidence: 'Ready to share',
+    label: 'Report',
+    eyebrow: 'Executive report',
+    title: 'Package remediation progress for security, platform, and leadership.',
+    metricLabel: 'Risk narrative',
+    metricValue: 'Clear path from source to sensitive target',
+    secondaryLabel: 'Artifacts',
+    secondaryValue: 'Evidence export, timeline, owner notes, and residual risk',
+    confidence: 'Audit ready',
     evidence: [
       'Every finding keeps source system evidence attached',
-      'Owner handoff includes the first action and expected outcome',
-      'The review record keeps the decision and exception context'
+      'Owner handoff includes first action and expected outcome',
+      'Remediation timeline captures decisions and exceptions'
     ],
-    playbook: ['Export evidence', 'Assign owner', 'Track next decision']
+    playbook: ['Export packet', 'Share owner plan', 'Track closure']
   }
 ] as const;
 
@@ -66,11 +66,11 @@ export function CommandCenterSection() {
     <section className="idt-section idt-command-center" aria-labelledby="command-center-title">
       <div className="idt-command-center-grid">
         <div className="idt-command-copy">
-          <p className="idt-eyebrow">Product proof</p>
-          <h2 id="command-center-title">One finding, with the whole path attached.</h2>
+          <p className="idt-eyebrow">Trust operations layer</p>
+          <h2 id="command-center-title">One operating view for machine identity risk.</h2>
           <p>
-            Identrail joins identity signals, reachable resources, evidence, and owner context so security and platform
-            teams can work from the same finding.
+            Identrail gives security and platform teams the same operating picture: live trust paths, policy evidence,
+            blast-radius context, and a practical next step for each owner.
           </p>
 
           <div className="idt-command-tabs" role="tablist" aria-label="Command center views">

--- a/web/src/components/home/HeroOpenSourceProofPills.test.tsx
+++ b/web/src/components/home/HeroOpenSourceProofPills.test.tsx
@@ -74,9 +74,5 @@ describe('HeroOpenSourceProofPills', () => {
     await waitFor(() => expect(screen.getByText('2.4k+')).toBeInTheDocument());
     expect(screen.queryByText('GitHub stars')).not.toBeInTheDocument();
     expect(fetchedHostnames).not.toContain('api.github.com');
-    expect(screen.getByRole('link', { name: 'View Identrail on GitHub' })).toHaveAttribute(
-      'href',
-      'https://github.com/identrail/identrail'
-    );
   });
 });

--- a/web/src/components/home/HeroOpenSourceProofPills.tsx
+++ b/web/src/components/home/HeroOpenSourceProofPills.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { projectMetricsSource, siteLinks } from '../../siteConfig';
 import { SafeLink } from '../SafeLink';
 
@@ -93,23 +93,29 @@ export function HeroOpenSourceProofPills() {
     return () => controller.abort();
   }, []);
 
+  const proofItems = useMemo(
+    () => [
+      {
+        label: 'Docker pulls',
+        value: formatMetric(stats.pulls),
+        href: siteLinks.quickstartDocker,
+        icon: '/brand-logos/docker.svg'
+      }
+    ],
+    [stats.pulls]
+  );
+
   return (
     <div className="idt-hero-proof-pills" aria-label="Open source project activity">
-      <SafeLink className="idt-hero-proof-pill" href={siteLinks.quickstartDocker}>
-        <img src="/brand-logos/docker.svg" alt="" aria-hidden="true" loading="lazy" />
-        <span>
-          <strong>{formatMetric(stats.pulls)}</strong>
-          <small>Docker pulls</small>
-        </span>
-      </SafeLink>
-      <SafeLink
-        className="idt-hero-proof-github"
-        href={siteLinks.github}
-        aria-label="View Identrail on GitHub"
-        title="View Identrail on GitHub"
-      >
-        <img src="/brand-logos/github.svg" alt="" aria-hidden="true" loading="lazy" />
-      </SafeLink>
+      {proofItems.map((item) => (
+        <SafeLink className="idt-hero-proof-pill" href={item.href} key={item.label}>
+          <img src={item.icon} alt="" aria-hidden="true" loading="lazy" />
+          <span>
+            <strong>{item.value}</strong>
+            <small>{item.label}</small>
+          </span>
+        </SafeLink>
+      ))}
     </div>
   );
 }

--- a/web/src/components/home/HeroProductReveal.tsx
+++ b/web/src/components/home/HeroProductReveal.tsx
@@ -45,7 +45,7 @@ const KUBERNETES_STEPS = [
   },
   {
     title: 'Evidence ready',
-    detail: 'Owner note drafted with the next review step'
+    detail: 'Owner note drafted with first safe fix'
   }
 ] as const;
 const MOBILE_REVIEW_STEPS = KUBERNETES_STEPS.slice(0, 3);
@@ -163,9 +163,9 @@ export function HeroProductReveal() {
                 <small>prod-billing / read-write eligible path</small>
               </div>
               <div>
-                Review next action
+                Owner-ready fix
                 <span>Restrict `sub` and namespace tags</span>
-                <small>Source evidence attached for owner review</small>
+                <small>Simulation reports no workload breakage</small>
               </div>
             </div>
 

--- a/web/src/components/home/HowItWorksSection.tsx
+++ b/web/src/components/home/HowItWorksSection.tsx
@@ -1,21 +1,27 @@
 const WORKFLOW_STEPS = [
   {
-    stage: 'Connect',
-    title: 'Link the sources you own',
-    description: 'Start with a read-only GitHub, AWS, or Kubernetes connection.',
-    output: 'Output: source inventory and identity metadata'
+    stage: 'Discover',
+    title: 'Build the trust graph',
+    description: 'Collect AWS IAM, Kubernetes, GitHub, and OIDC identity metadata in read-only mode.',
+    output: 'Output: identity graph snapshot with source evidence links'
   },
   {
-    stage: 'Investigate',
-    title: 'See the path behind the finding',
-    description: 'Trace identities, relationships, and reachable resources with source evidence attached.',
-    output: 'Output: prioritized finding with owner context'
+    stage: 'Prioritize',
+    title: 'Rank reachable risk paths',
+    description: 'Score findings by severity, privilege depth, and production blast-radius potential.',
+    output: 'Output: ranked findings queue with owner-ready context'
   },
   {
-    stage: 'Act',
-    title: 'Hand off a fix people can explain',
-    description: 'Assign ownership, share evidence, and track the next remediation decision.',
-    output: 'Output: review package and decision history'
+    stage: 'Simulate',
+    title: 'Preview hardening safely',
+    description: 'Preview trust-policy changes and estimate affected workloads before enforcement.',
+    output: 'Output: remediation plan with expected impact summary'
+  },
+  {
+    stage: 'Operate',
+    title: 'Roll out with controls',
+    description: 'Deploy in stages with rollback options and track resolution outcomes.',
+    output: 'Output: audit-ready remediation timeline and status history'
   }
 ] as const;
 
@@ -23,9 +29,9 @@ export function HowItWorksSection() {
   return (
     <section className="idt-section idt-workflow-section" aria-labelledby="workflow-title">
       <div className="idt-section-title">
-        <p className="idt-eyebrow">How it works</p>
-        <h2 id="workflow-title">From source connection to owner-ready evidence</h2>
-        <p>Every step leaves a useful artifact for the next person in the review.</p>
+        <p className="idt-eyebrow">Operational Workflow</p>
+        <h2 id="workflow-title">From read-only discovery to safe enforcement</h2>
+        <p>Each stage produces a concrete artifact security and platform teams can review before taking action.</p>
       </div>
 
       <ol className="idt-steps idt-workflow-track">

--- a/web/src/components/home/ProblemFramingSection.tsx
+++ b/web/src/components/home/ProblemFramingSection.tsx
@@ -18,19 +18,19 @@ const identitySignals = [
 
 const storyStages = [
   {
-    label: 'Separate findings',
-    title: 'Each system reports its own permissions',
-    detail: 'The path between a repository, workload, role, and sensitive resource stays hidden.'
+    label: 'Before',
+    title: 'Isolated alerts',
+    detail: 'Each control plane looks acceptable until the machine identity path crosses boundaries.'
   },
   {
-    label: 'Evidence connected',
-    title: 'Join the identity signals',
-    detail: 'Identrail correlates GitHub, AWS, and Kubernetes evidence into one machine identity path.'
+    label: 'During',
+    title: 'Evidence stitching',
+    detail: 'Identity collection joins IAM, Kubernetes, repository, and OIDC signals into one chain.'
   },
   {
-    label: 'A fix you can explain',
-    title: 'Hand off the next decision',
-    detail: 'Owners get the affected resource, source evidence, and a clear remediation starting point.'
+    label: 'After',
+    title: 'Safe remediation',
+    detail: 'Owners get the affected workload, blast-radius context, and a recommended next step.'
   }
 ];
 
@@ -39,11 +39,12 @@ export function ProblemFramingSection() {
     <section className="idt-section idt-problem-frame" aria-labelledby="problem-frame-title">
       <div className="idt-problem-frame-grid">
         <div className="idt-problem-copy">
-          <p className="idt-eyebrow">The problem</p>
-          <h2 id="problem-frame-title">A role, repo, or service account is only part of the story.</h2>
+          <p className="idt-eyebrow">Why teams miss machine identity risk</p>
+          <h2 id="problem-frame-title">Signals only matter when they reveal the path.</h2>
           <p>
-            Identrail connects GitHub workflow exposure, AWS IAM relationships, and Kubernetes RBAC so teams can see
-            which machine identity paths reach sensitive resources. Start with evidence, then decide what to fix.
+            IAM policies, Kubernetes RBAC, repository exposure, and OIDC workflow identities are reviewed in separate
+            tools. Identrail connects them into one operating view, then shows blast radius, ownership, and the next
+            action.
           </p>
         </div>
 

--- a/web/src/components/home/TrustProofStrip.tsx
+++ b/web/src/components/home/TrustProofStrip.tsx
@@ -10,13 +10,35 @@ const TRUST_LOGOS = [
   {
     name: 'GitHub',
     icon: '/brand-logos/github.svg'
+  },
+  {
+    name: 'OpenID',
+    icon: '/brand-logos/openid.svg'
+  },
+  {
+    name: 'Terraform',
+    icon: '/brand-logos/terraform.svg'
+  },
+  {
+    name: 'Docker',
+    icon: '/brand-logos/docker.svg'
+  },
+  {
+    name: 'PostgreSQL',
+    icon: '/brand-logos/postgresql.svg'
+  },
+  {
+    name: 'Prometheus',
+    icon: '/brand-logos/prometheus.svg'
   }
 ] as const;
 
 export function TrustProofStrip() {
+  const logoGroups = [0, 1] as const;
+
   return (
     <section className="idt-trust-strip" aria-label="Identity ecosystem signals">
-      <p className="idt-logo-cloud-label">Connect the sources that matter</p>
+      <p className="idt-logo-cloud-label">Reviewed across your identity stack</p>
       <ul className="idt-logo-cloud-accessible">
         {TRUST_LOGOS.map((logo) => (
           <li key={logo.name}>{logo.name}</li>
@@ -24,14 +46,16 @@ export function TrustProofStrip() {
       </ul>
       <div className="idt-logo-cloud" aria-hidden="true">
         <div className="idt-logo-cloud-track">
-          <div className="idt-logo-cloud-group">
-            {TRUST_LOGOS.map((logo) => (
-              <span className="idt-logo-cloud-item" key={logo.name}>
-                <img src={logo.icon} alt="" aria-hidden="true" loading="lazy" />
-                <span>{logo.name}</span>
-              </span>
-            ))}
-          </div>
+          {logoGroups.map((group) => (
+            <div className="idt-logo-cloud-group" key={group}>
+              {TRUST_LOGOS.map((logo) => (
+                <span className="idt-logo-cloud-item" key={`${logo.name}-${group}`}>
+                  <img src={logo.icon} alt="" aria-hidden="true" loading="lazy" />
+                  <span>{logo.name}</span>
+                </span>
+              ))}
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/web/src/content/resources.ts
+++ b/web/src/content/resources.ts
@@ -32,7 +32,7 @@ export const HOME_FAQ_ITEMS: FaqItem[] = [
   {
     question: 'Is the scan read-only?',
     answer:
-      'Yes. Identrail discovery connectors collect identity and trust-path metadata without mutating your cloud, cluster, or repository state.'
+      'Yes. Identrail discovery connectors are built for read-only collection of identity and trust-path metadata. You control write actions separately through staged policy workflows.'
   },
   {
     question: 'How does Identrail access AWS, Kubernetes, and GitHub data?',
@@ -50,14 +50,14 @@ export const HOME_FAQ_ITEMS: FaqItem[] = [
       'Yes. The open-source core is designed for self-hosted evaluation and production environments. Teams can later adopt hosted SaaS or enterprise deployment models without re-platforming.'
   },
   {
-    question: 'How does Identrail keep scans safe?',
+    question: 'How does policy simulation avoid breaking production?',
     answer:
-      'Identrail keeps discovery read-only. It collects the metadata needed to analyze identity paths and leaves access changes to your existing change-control process.'
+      'Policy simulation shows which workloads and trust paths would be affected before enforcement. Teams can roll out in stages, monitor impact, and use rollback controls if needed.'
   },
   {
     question: 'What integrations are supported?',
     answer:
-      'Identrail supports AWS IAM, Kubernetes identities and RBAC, and GitHub repository and workflow telemetry, including the OIDC relationships used by GitHub Actions.'
+      'Identrail supports AWS IAM, Kubernetes identities and RBAC, OIDC trust relationships, and Git-based repository/workflow telemetry. Enterprise workflows can connect ticketing and operational controls.'
   }
 ];
 
@@ -203,7 +203,7 @@ export const BLOG_POSTS: BlogPost[] = [
     title: 'Kubernetes Machine Identity: RBAC Risk Paths You Can Actually Fix',
     slug: 'kubernetes-machine-identity-rbac-risk-paths',
     description:
-      'How to map service-account privilege paths and give owners the evidence to make focused RBAC changes.',
+      'How to map service account privilege escalations and implement rollout-safe policy tightening without downtime.',
     category: 'Kubernetes Security',
     readTime: '9 min',
     intro: [
@@ -395,7 +395,7 @@ export const BLOG_POSTS: BlogPost[] = [
     title: 'How to Prove Least Privilege for Non-Human Identities to Auditors',
     slug: 'least-privilege-evidence-for-non-human-identities',
     description:
-      'Generate evidence for SOC 2 and ISO 27001 with trust-path snapshots, ownership records, and remediation trails.',
+      'Generate evidence for SOC 2 and ISO 27001 with trust graph snapshots, policy simulations, and remediation trails.',
     category: 'Compliance',
     readTime: '11 min',
     intro: [
@@ -406,7 +406,7 @@ export const BLOG_POSTS: BlogPost[] = [
       {
         heading: 'What evidence is actually useful',
         paragraphs: [
-          'Useful least-privilege evidence combines current state, ownership, and proof of review. A trust graph snapshot shows current reachability. Source policy and workload context explain why the path exists. A remediation trail shows the finding was closed intentionally rather than accidentally disappearing from a dashboard.',
+          'Useful least-privilege evidence combines current state, change control, and proof of review. A trust graph snapshot shows current reachability. A simulation or validation artifact shows how a change was tested before rollout. A remediation trail shows the finding was closed intentionally rather than accidentally disappearing from a dashboard.',
           'This is why flat entitlement exports are rarely persuasive on their own. They list permissions, but they do not show the path from identity to sensitive target or the operational process used to reduce that path.'
         ],
         bullets: [
@@ -424,17 +424,17 @@ export const BLOG_POSTS: BlogPost[] = [
         ]
       },
       {
-        heading: 'Why evidence matters',
+        heading: 'Why simulation matters',
         paragraphs: [
-          'Auditors increasingly care about control effectiveness, not just the existence of a policy. If a team can show the identity path, reachable resource, owner, and review decision, that demonstrates a stronger control process than a one-time manual edit.',
-          'It also makes the evidence more believable. Least privilege is easier to defend when the organization can explain what it found, what it changed, and why the remaining access is intentional.'
+          'Auditors increasingly care about control effectiveness, not just the existence of a policy. If a team can show that a trust change was simulated, staged, and reviewed before enforcement, that demonstrates a stronger control process than a one-time manual edit.',
+          'It also makes the evidence more believable. Least privilege is easier to defend when you can show how the organization reduces access without breaking production.'
         ]
       },
       {
         heading: 'Where Identrail fits',
         paragraphs: [
-          'Identrail turns least-privilege evidence into an operational artifact. It shows which machine identity path exists today, why it is risky, and which owner has the context to review the next change.',
-          'Security gets defensible evidence, while platform teams get a focused starting point for tightening access through their existing change process.'
+          'Identrail turns least-privilege evidence into an operational artifact. It shows which machine identity path exists today, why it is risky, and what control change is being proposed before the change is enforced.',
+          'That makes the same system useful for both sides of the house: security gets defensible evidence, and platform teams get a safer workflow for tightening access over time.'
         ]
       }
     ],
@@ -461,7 +461,7 @@ export const BLOG_POSTS: BlogPost[] = [
     title: 'Designing Rollout-Safe Authorization Controls for Platform Teams',
     slug: 'rollout-safe-authorization-controls',
     description:
-      'Evidence, ownership, and review patterns that help platform teams reduce authorization risk in production.',
+      'Staged policy rollouts, simulation gates, and kill-switch patterns that reduce authz outage risk in production.',
     category: 'Platform Engineering',
     readTime: '8 min',
     intro: [
@@ -499,8 +499,8 @@ export const BLOG_POSTS: BlogPost[] = [
       {
         heading: 'Where Identrail fits',
         paragraphs: [
-          'Identrail gives teams the evidence needed before a control change: the identity path, reachable resource, source context, and responsible owner. It helps security and platform teams agree on the next action without losing the original finding context.',
-          'That matters because the hardest part of authorization is not seeing the risk. It is making a focused change without breaking the system that depends on it.'
+          'Identrail is designed around rollout-safe control changes. It does not stop at surfacing a risky path. It helps teams inspect the path, understand the likely impact of tightening it, and sequence the remediation in a way engineering can actually execute.',
+          'That matters because the hardest part of authorization is not seeing the risk. It is removing the risk without breaking the system that depends on it.'
         ]
       }
     ],

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15599,7 +15599,7 @@ html[data-theme='light'] .idt-problem-map-core div span {
   }
 
   .idt-hero-copy h1 {
-    max-width: 18ch;
+    max-width: 8.7ch;
     font-size: clamp(3.05rem, 15.1vw, 4.35rem);
   }
 
@@ -15754,7 +15754,7 @@ html[data-theme='light'] .idt-problem-map-core div span {
 
 @media (max-width: 520px) {
   .idt-hero-copy h1 {
-    max-width: 18ch;
+    max-width: 8.45ch;
   }
 
   .idt-hero-admin-window {
@@ -19501,7 +19501,7 @@ html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-inline-l
 @media (max-width: 820px) {
   .idt-hero-copy h1,
   html[data-theme='light'] .idt-hero-copy h1 {
-    max-width: 18ch;
+    max-width: 9.6ch;
     font-size: clamp(2.65rem, 12vw, 3.35rem);
     line-height: 1;
   }
@@ -33224,69 +33224,6 @@ html[data-theme='light'] .idt-danger-modal-body {
 
 html[data-theme='light'] .idt-danger-modal .idt-danger-modal-help {
   color: #e0e4ec;
-}
-
-/* Keep the open-source proof compact: one metric plus a quiet GitHub mark. */
-.idt-hero-proof-github {
-  display: inline-grid;
-  width: 3.25rem;
-  min-width: 3.25rem;
-  height: 3.25rem;
-  place-items: center;
-  border: 1px solid rgba(17, 24, 39, 0.1);
-  border-radius: 999px;
-  background: #ffffff;
-  color: #111827;
-  box-shadow: 0 12px 28px rgba(17, 24, 39, 0.06);
-  transition:
-    transform var(--idt-hover-duration) var(--idt-hover-ease),
-    box-shadow var(--idt-hover-duration) var(--idt-hover-ease),
-    border-color var(--idt-hover-duration) var(--idt-hover-ease);
-}
-
-.idt-hero-proof-github img {
-  width: 1.16rem;
-  height: 1.16rem;
-}
-
-.idt-hero-proof-github:hover,
-.idt-hero-proof-github:focus-visible {
-  transform: translateY(-1px);
-  border-color: rgba(17, 24, 39, 0.24);
-  box-shadow: 0 16px 30px rgba(17, 24, 39, 0.12);
-}
-
-.idt-logo-cloud-track {
-  width: 100%;
-  justify-content: center;
-  animation: none;
-}
-
-.idt-logo-cloud-group {
-  width: 100%;
-  justify-content: center;
-  padding-right: 0;
-}
-
-@media (max-width: 720px) {
-  .idt-hero-proof-pills {
-    display: flex;
-    align-items: stretch;
-    gap: 0.55rem;
-  }
-
-  .idt-hero-proof-pill {
-    flex: 1 1 auto;
-  }
-
-  .idt-hero-proof-github {
-    flex: 0 0 3.25rem;
-  }
-
-  .idt-logo-cloud-group {
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
 }
 
 html[data-theme='light'] .idt-danger-modal-typed input {


### PR DESCRIPTION
Reverts identrail/identrail#1791

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the broader “machine identity trust graph” marketing experience with new product surfaces, rollout‑safe control messaging, and updated CTAs. Expands integrations and visuals, and aligns tests and SEO with the reverted direction.

- **New Features**
  - Home: added Product Tour, Comparison table, and Deployment Path banner; final CTA now “Book Demo”.
  - Trust strip: expanded logos (GitHub, OpenID, Terraform, Docker, PostgreSQL, Prometheus) with looping two‑group logo cloud.
  - Product: introduced four product surfaces (Explorer, Detection/Triage, Repo Scanner, Rollout‑Safe Controls) and “Trust Graph as control plane.”
  - Workflow: new 4‑stage flow (Discover → Prioritize → Simulate → Operate).
  - Integrations: added OpenID Connect and Prometheus; updated Integrations page copy.

- **Refactors**
  - Site‑wide copy focuses on read‑only onboarding, policy simulation, staged rollout, and open‑core transparency; updated SEO titles/descriptions/keywords.
  - Hero: revised headline/lead, updated trust cues, removed GitHub proof chip; CSS tweaks to hero width.
  - Command Center wording shifted to Exposure Triage, Policy Simulation, and Executive Report.
  - Tests updated for new headings, CTAs, and trust strip structure.

<sup>Written for commit 92788d049c8e642585cd282acdfe724d4409757c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

