### PR TITLE
fix: require policy-backed template access

### DIFF
--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -317,20 +317,57 @@ jobs:
           # Write-once publish. --if-none-match '*' makes the PUT conditional
           # on the key not already existing, so a SHA-addressed object can
           # never be silently overwritten with different bytes after it has
-          # been verified and handed to customers. A PreconditionFailed means
-          # this exact digest was already published (a re-run, or a release
-          # that did not change the template); that is the expected, benign
-          # case and we fall through to verifying the stored bytes.
+          # been verified and handed to customers. The public-read ACL is
+          # required because CloudFormation fetches this URL without the
+          # deploy role's credentials. A PreconditionFailed means this exact
+          # digest was already published (a re-run, or a release that did not
+          # change the template); that path verifies the existing bytes before
+          # repairing the ACL with the same content when an earlier publish
+          # created a private object.
           if aws s3api put-object \
             --bucket "${TEMPLATE_BUCKET}" \
             --key "${key}" \
             --body "${template}" \
             --content-type "application/x-yaml" \
             --if-none-match '*' \
+            --acl "public-read" \
             --cache-control "public,max-age=31536000,immutable" >/dev/null 2>"${RUNNER_TEMP}/put-object.err"; then
             echo "Published ${key}."
           elif grep -qi "PreconditionFailed\|At least one of the pre-conditions" "${RUNNER_TEMP}/put-object.err"; then
-            echo "Object ${key} already exists; verifying stored bytes instead of overwriting."
+            existing="${RUNNER_TEMP}/identrail-existing.yaml"
+            if ! aws s3api get-object \
+              --bucket "${TEMPLATE_BUCKET}" \
+              --key "${key}" \
+              "${existing}" >/dev/null; then
+              echo "Object ${key} already exists, but the deploy role cannot read it for immutable verification." >&2
+              echo "Grant s3:GetObject on the connector template prefix before retrying the production deploy." >&2
+              exit 1
+            fi
+
+            existing_digest="$(sha256sum "${existing}" | awk '{print $1}')"
+            if [ "${existing_digest}" != "${digest}" ]; then
+              echo "Existing template ${key} has digest ${existing_digest}, expected ${digest}." >&2
+              echo "Refusing to overwrite a SHA-addressed object with different bytes." >&2
+              exit 1
+            fi
+
+            # The first self-operating release could create this object
+            # without the ACL needed by CloudFormation. Re-put the verified
+            # bytes with public-read so the repair still uses s3:PutObject,
+            # which the publisher already requires, and preserves the
+            # content-addressed invariant above.
+            if ! aws s3api put-object \
+              --bucket "${TEMPLATE_BUCKET}" \
+              --key "${key}" \
+              --body "${template}" \
+              --content-type "application/x-yaml" \
+              --acl "public-read" \
+              --cache-control "public,max-age=31536000,immutable" >/dev/null; then
+              echo "Existing template ${key} has the expected bytes, but its public-read ACL could not be repaired." >&2
+              echo "Confirm the bucket permits public reads and the deploy role can write the connector template prefix." >&2
+              exit 1
+            fi
+            echo "Object ${key} already existed; verified its bytes and repaired public-read access."
           else
             cat "${RUNNER_TEMP}/put-object.err" >&2
             exit 1

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -317,13 +317,12 @@ jobs:
           # Write-once publish. --if-none-match '*' makes the PUT conditional
           # on the key not already existing, so a SHA-addressed object can
           # never be silently overwritten with different bytes after it has
-          # been verified and handed to customers. A prefix-scoped bucket
-          # policy is preferred because modern S3 buckets may disable ACLs;
-          # the public URL check below falls back to a public-read ACL only
-          # when the bucket's policy does not already expose the object.
-          # A PreconditionFailed means this exact digest was already published
-          # (a re-run, or a release that did not change the template); that
-          # path verifies the existing bytes before any access repair.
+          # been verified and handed to customers. Public access is provided
+          # by the bucket policy documented in aws-api-hosting.md; ACL repair
+          # is deliberately not attempted here. A PreconditionFailed means
+          # this exact digest was already published (a re-run, or a release
+          # that did not change the template), so we fall through to verifying
+          # the bytes served by the public policy.
           if aws s3api put-object \
             --bucket "${TEMPLATE_BUCKET}" \
             --key "${key}" \
@@ -333,24 +332,7 @@ jobs:
             --cache-control "public,max-age=31536000,immutable" >/dev/null 2>"${RUNNER_TEMP}/put-object.err"; then
             echo "Published ${key}."
           elif grep -qi "PreconditionFailed\|At least one of the pre-conditions" "${RUNNER_TEMP}/put-object.err"; then
-            existing="${RUNNER_TEMP}/identrail-existing.yaml"
-            if ! aws s3api get-object \
-              --bucket "${TEMPLATE_BUCKET}" \
-              --key "${key}" \
-              "${existing}" >/dev/null; then
-              echo "Object ${key} already exists, but the deploy role cannot read it for immutable verification." >&2
-              echo "Grant s3:GetObject on the connector template prefix before retrying the production deploy." >&2
-              exit 1
-            fi
-
-            existing_digest="$(sha256sum "${existing}" | awk '{print $1}')"
-            if [ "${existing_digest}" != "${digest}" ]; then
-              echo "Existing template ${key} has digest ${existing_digest}, expected ${digest}." >&2
-              echo "Refusing to overwrite a SHA-addressed object with different bytes." >&2
-              exit 1
-            fi
-
-            echo "Object ${key} already existed; verified its bytes before checking public access."
+            echo "Object ${key} already exists; verifying its bytes through the public bucket policy."
           else
             cat "${RUNNER_TEMP}/put-object.err" >&2
             exit 1
@@ -360,39 +342,16 @@ jobs:
           # digest in the path, whether we just wrote them or found them already
           # present. This is what makes the URL safe to hand to customers.
           downloaded="${RUNNER_TEMP}/identrail-readonly.yaml"
-          public_read_verified=false
-          if curl -fsSL --retry 5 --retry-all-errors "${template_url}" -o "${downloaded}"; then
-            published_digest="$(sha256sum "${downloaded}" | awk '{print $1}')"
-            if [ "${published_digest}" != "${digest}" ]; then
-              echo "Published template digest ${published_digest} does not match ${digest}."
-              echo "The SHA-addressed key holds different bytes than this release's template; refusing to continue."
-              exit 1
-            fi
-            public_read_verified=true
+          if ! curl -fsSL --retry 5 --retry-all-errors "${template_url}" -o "${downloaded}"; then
+            echo "Template URL ${template_url} is not publicly readable." >&2
+            echo "Configure the documented prefix-scoped bucket policy before retrying the production release." >&2
+            exit 1
           fi
-
-          if [ "${public_read_verified}" != "true" ]; then
-            echo "Template URL is not publicly readable; attempting a public-read ACL repair."
-            if ! aws s3api put-object \
-              --bucket "${TEMPLATE_BUCKET}" \
-              --key "${key}" \
-              --body "${template}" \
-              --content-type "application/x-yaml" \
-              --acl "public-read" \
-              --cache-control "public,max-age=31536000,immutable" >/dev/null; then
-              echo "The template URL is not publicly readable and the bucket rejected the ACL repair." >&2
-              echo "Grant public read through a bucket policy for this prefix, or enable object ACLs for the publisher." >&2
-              exit 1
-            fi
-
-            curl -fsSL --retry 5 --retry-all-errors "${template_url}" -o "${downloaded}"
-            published_digest="$(sha256sum "${downloaded}" | awk '{print $1}')"
-            if [ "${published_digest}" != "${digest}" ]; then
-              echo "Repaired template digest ${published_digest} does not match ${digest}."
-              echo "The SHA-addressed key holds different bytes than this release's template; refusing to continue."
-              exit 1
-            fi
-            echo "Repaired public-read access for ${key} after verifying its bytes."
+          published_digest="$(sha256sum "${downloaded}" | awk '{print $1}')"
+          if [ "${published_digest}" != "${digest}" ]; then
+            echo "Published template digest ${published_digest} does not match ${digest}."
+            echo "The SHA-addressed key holds different bytes than this release's template; refusing to continue."
+            exit 1
           fi
 
           {

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -317,24 +317,44 @@ jobs:
           # Write-once publish. --if-none-match '*' makes the PUT conditional
           # on the key not already existing, so a SHA-addressed object can
           # never be silently overwritten with different bytes after it has
-          # been verified and handed to customers. Public access is provided
-          # by the bucket policy documented in aws-api-hosting.md; ACL repair
-          # is deliberately not attempted here. A PreconditionFailed means
-          # this exact digest was already published (a re-run, or a release
-          # that did not change the template), so we fall through to verifying
-          # the bytes served by the public policy.
+          # been verified and handed to customers. Explicit SSE-S3 keeps this
+          # public object readable without an anonymous KMS authorization.
+          # Public access is provided by the bucket policy documented in
+          # aws-api-hosting.md; ACL repair is deliberately not attempted here.
+          # A PreconditionFailed means this exact digest was already published
+          # (a re-run, or a release that did not change the template), so we
+          # fall through to verifying the existing object's metadata and bytes.
           if aws s3api put-object \
             --bucket "${TEMPLATE_BUCKET}" \
             --key "${key}" \
             --body "${template}" \
             --content-type "application/x-yaml" \
             --if-none-match '*' \
+            --server-side-encryption AES256 \
             --cache-control "public,max-age=31536000,immutable" >/dev/null 2>"${RUNNER_TEMP}/put-object.err"; then
             echo "Published ${key}."
           elif grep -qi "PreconditionFailed\|At least one of the pre-conditions" "${RUNNER_TEMP}/put-object.err"; then
             echo "Object ${key} already exists; verifying its bytes through the public bucket policy."
           else
             cat "${RUNNER_TEMP}/put-object.err" >&2
+            exit 1
+          fi
+
+          encryption_error="${RUNNER_TEMP}/head-object.err"
+          if ! server_side_encryption="$(
+            aws s3api head-object \
+              --bucket "${TEMPLATE_BUCKET}" \
+              --key "${key}" \
+              --query ServerSideEncryption \
+              --output text 2>"${encryption_error}"
+          )"; then
+            echo "Could not verify the encryption used for ${key}." >&2
+            cat "${encryption_error}" >&2
+            exit 1
+          fi
+          if [ "${server_side_encryption}" != "AES256" ]; then
+            echo "Object ${key} uses ${server_side_encryption:-no} encryption; expected SSE-S3 (AES256)." >&2
+            echo "Re-encrypt this existing digest with SSE-S3 before retrying; the write-once release path will not overwrite it." >&2
             exit 1
           fi
 

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -317,20 +317,19 @@ jobs:
           # Write-once publish. --if-none-match '*' makes the PUT conditional
           # on the key not already existing, so a SHA-addressed object can
           # never be silently overwritten with different bytes after it has
-          # been verified and handed to customers. The public-read ACL is
-          # required because CloudFormation fetches this URL without the
-          # deploy role's credentials. A PreconditionFailed means this exact
-          # digest was already published (a re-run, or a release that did not
-          # change the template); that path verifies the existing bytes before
-          # repairing the ACL with the same content when an earlier publish
-          # created a private object.
+          # been verified and handed to customers. A prefix-scoped bucket
+          # policy is preferred because modern S3 buckets may disable ACLs;
+          # the public URL check below falls back to a public-read ACL only
+          # when the bucket's policy does not already expose the object.
+          # A PreconditionFailed means this exact digest was already published
+          # (a re-run, or a release that did not change the template); that
+          # path verifies the existing bytes before any access repair.
           if aws s3api put-object \
             --bucket "${TEMPLATE_BUCKET}" \
             --key "${key}" \
             --body "${template}" \
             --content-type "application/x-yaml" \
             --if-none-match '*' \
-            --acl "public-read" \
             --cache-control "public,max-age=31536000,immutable" >/dev/null 2>"${RUNNER_TEMP}/put-object.err"; then
             echo "Published ${key}."
           elif grep -qi "PreconditionFailed\|At least one of the pre-conditions" "${RUNNER_TEMP}/put-object.err"; then
@@ -351,23 +350,7 @@ jobs:
               exit 1
             fi
 
-            # The first self-operating release could create this object
-            # without the ACL needed by CloudFormation. Re-put the verified
-            # bytes with public-read so the repair still uses s3:PutObject,
-            # which the publisher already requires, and preserves the
-            # content-addressed invariant above.
-            if ! aws s3api put-object \
-              --bucket "${TEMPLATE_BUCKET}" \
-              --key "${key}" \
-              --body "${template}" \
-              --content-type "application/x-yaml" \
-              --acl "public-read" \
-              --cache-control "public,max-age=31536000,immutable" >/dev/null; then
-              echo "Existing template ${key} has the expected bytes, but its public-read ACL could not be repaired." >&2
-              echo "Confirm the bucket permits public reads and the deploy role can write the connector template prefix." >&2
-              exit 1
-            fi
-            echo "Object ${key} already existed; verified its bytes and repaired public-read access."
+            echo "Object ${key} already existed; verified its bytes before checking public access."
           else
             cat "${RUNNER_TEMP}/put-object.err" >&2
             exit 1
@@ -377,12 +360,39 @@ jobs:
           # digest in the path, whether we just wrote them or found them already
           # present. This is what makes the URL safe to hand to customers.
           downloaded="${RUNNER_TEMP}/identrail-readonly.yaml"
-          curl -fsSL --retry 5 --retry-all-errors "${template_url}" -o "${downloaded}"
-          published_digest="$(sha256sum "${downloaded}" | awk '{print $1}')"
-          if [ "${published_digest}" != "${digest}" ]; then
-            echo "Published template digest ${published_digest} does not match ${digest}."
-            echo "The SHA-addressed key holds different bytes than this release's template; refusing to continue."
-            exit 1
+          public_read_verified=false
+          if curl -fsSL --retry 5 --retry-all-errors "${template_url}" -o "${downloaded}"; then
+            published_digest="$(sha256sum "${downloaded}" | awk '{print $1}')"
+            if [ "${published_digest}" != "${digest}" ]; then
+              echo "Published template digest ${published_digest} does not match ${digest}."
+              echo "The SHA-addressed key holds different bytes than this release's template; refusing to continue."
+              exit 1
+            fi
+            public_read_verified=true
+          fi
+
+          if [ "${public_read_verified}" != "true" ]; then
+            echo "Template URL is not publicly readable; attempting a public-read ACL repair."
+            if ! aws s3api put-object \
+              --bucket "${TEMPLATE_BUCKET}" \
+              --key "${key}" \
+              --body "${template}" \
+              --content-type "application/x-yaml" \
+              --acl "public-read" \
+              --cache-control "public,max-age=31536000,immutable" >/dev/null; then
+              echo "The template URL is not publicly readable and the bucket rejected the ACL repair." >&2
+              echo "Grant public read through a bucket policy for this prefix, or enable object ACLs for the publisher." >&2
+              exit 1
+            fi
+
+            curl -fsSL --retry 5 --retry-all-errors "${template_url}" -o "${downloaded}"
+            published_digest="$(sha256sum "${downloaded}" | awk '{print $1}')"
+            if [ "${published_digest}" != "${digest}" ]; then
+              echo "Repaired template digest ${published_digest} does not match ${digest}."
+              echo "The SHA-addressed key holds different bytes than this release's template; refusing to continue."
+              exit 1
+            fi
+            echo "Repaired public-read access for ${key} after verifying its bytes."
           fi
 
           {

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -307,6 +307,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if ! [[ "${TEMPLATE_BUCKET}" =~ ^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$ ]]; then
+            echo "AWS_CFN_TEMPLATE_BUCKET must use lowercase letters, numbers, and hyphens only; dotted S3 names are incompatible with the release URL." >&2
+            exit 1
+          fi
           template="deploy/connectors/aws/identrail-readonly.yaml"
           digest="$(sha256sum "${template}" | awk '{print $1}')"
           key="connectors/aws/sha256/${digest}/identrail-readonly.yaml"

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -312,8 +312,6 @@ jobs:
           key="connectors/aws/sha256/${digest}/identrail-readonly.yaml"
           template_url="https://${TEMPLATE_BUCKET}.s3.${AWS_REGION}.amazonaws.com/${key}"
 
-          aws s3api head-bucket --bucket "${TEMPLATE_BUCKET}"
-
           # Write-once publish. --if-none-match '*' makes the PUT conditional
           # on the key not already existing, so a SHA-addressed object can
           # never be silently overwritten with different bytes after it has

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -145,7 +145,10 @@ Repository configuration required before the workflow can plan:
 - secret `API_SESSION_KEY_SECRET_ARN`: Secrets Manager ARN containing
   `IDENTRAIL_SESSION_KEY`
 
-The template bucket is an external, operator-owned prerequisite. Configure S3
+The template bucket name must use lowercase letters, numbers, and hyphens only;
+dotted S3 names are rejected because the release uses a virtual-hosted HTTPS
+URL whose wildcard certificate does not cover dotted bucket hostnames. The
+template bucket is an external, operator-owned prerequisite. Configure S3
 Object Ownership as `Bucket owner enforced`, keep public writes blocked, and
 merge this statement into the bucket policy (replace `BUCKET_NAME` with the
 configured bucket name):
@@ -185,9 +188,10 @@ write-once path. Verify its SHA-256, then perform a controlled one-time
 same-key re-encryption with SSE-S3 before retrying the release. ACLs are
 intentionally not used.
 
-For that one-time migration, verify the authenticated bytes and use the
-current ETag as a compare-and-swap guard before copying the object onto itself
-with SSE-S3:
+For that one-time migration, sample the current ETag first, condition the
+authenticated download on that ETag, verify the downloaded bytes, and use the
+same ETag as the compare-and-swap guard when copying the object onto itself with
+SSE-S3:
 
 ```bash
 key=connectors/aws/sha256/DIGEST/identrail-readonly.yaml
@@ -195,16 +199,17 @@ digest=DIGEST
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
 
-aws s3api get-object \
-  --bucket "$AWS_CFN_TEMPLATE_BUCKET" \
-  --key "$key" \
-  "$tmp" >/dev/null
-test "$(sha256sum "$tmp" | awk '{print $1}')" = "$digest"
 etag="$(aws s3api head-object \
   --bucket "$AWS_CFN_TEMPLATE_BUCKET" \
   --key "$key" \
   --query ETag \
   --output text | tr -d '"')"
+aws s3api get-object \
+  --bucket "$AWS_CFN_TEMPLATE_BUCKET" \
+  --key "$key" \
+  --if-match "$etag" \
+  "$tmp" >/dev/null
+test "$(sha256sum "$tmp" | awk '{print $1}')" = "$digest"
 aws s3api copy-object \
   --bucket "$AWS_CFN_TEMPLATE_BUCKET" \
   --copy-source "$AWS_CFN_TEMPLATE_BUCKET/$key" \

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -147,11 +147,13 @@ Repository configuration required before the workflow can plan:
 
 The `AWS_ROLE_ARN` deployment role must be allowed to read and write
 `connectors/aws/sha256/*/identrail-readonly.yaml` in the template bucket. The
-release workflow publishes those objects with a `public-read` ACL because AWS
-CloudFormation fetches the template without the deploy role's credentials. The
-bucket remains blocked for public writes; only object reads for the published
-template path are public. The bucket must therefore allow public reads for that
-prefix and must not block the ACL used by the publisher.
+release workflow verifies that the published S3 URL is publicly readable so
+AWS CloudFormation can fetch it without the deploy role's credentials. Prefer a
+prefix-scoped bucket policy for public reads; the workflow falls back to a
+`public-read` object ACL only when the URL is not already public, which also
+repairs a private object left by an earlier publish. Buckets with S3 Object
+Ownership set to Bucket owner enforced must use the bucket-policy approach,
+because ACLs are disabled in that mode.
 
 Hosted WorkOS login is optional. Configure these values only when deploying the
 hosted sign-in/sign-up flow:

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -145,11 +145,13 @@ Repository configuration required before the workflow can plan:
 - secret `API_SESSION_KEY_SECRET_ARN`: Secrets Manager ARN containing
   `IDENTRAIL_SESSION_KEY`
 
-The `AWS_ROLE_ARN` deployment role must be allowed to write
+The `AWS_ROLE_ARN` deployment role must be allowed to read and write
 `connectors/aws/sha256/*/identrail-readonly.yaml` in the template bucket. The
+release workflow publishes those objects with a `public-read` ACL because AWS
+CloudFormation fetches the template without the deploy role's credentials. The
 bucket remains blocked for public writes; only object reads for the published
-template path are public so AWS CloudFormation can fetch the template without
-customer credentials.
+template path are public. The bucket must therefore allow public reads for that
+prefix and must not block the ACL used by the publisher.
 
 Hosted WorkOS login is optional. Configure these values only when deploying the
 hosted sign-in/sign-up flow:

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -145,15 +145,38 @@ Repository configuration required before the workflow can plan:
 - secret `API_SESSION_KEY_SECRET_ARN`: Secrets Manager ARN containing
   `IDENTRAIL_SESSION_KEY`
 
-The `AWS_ROLE_ARN` deployment role must be allowed to read and write
-`connectors/aws/sha256/*/identrail-readonly.yaml` in the template bucket. The
-release workflow verifies that the published S3 URL is publicly readable so
-AWS CloudFormation can fetch it without the deploy role's credentials. Prefer a
-prefix-scoped bucket policy for public reads; the workflow falls back to a
-`public-read` object ACL only when the URL is not already public, which also
-repairs a private object left by an earlier publish. Buckets with S3 Object
-Ownership set to Bucket owner enforced must use the bucket-policy approach,
-because ACLs are disabled in that mode.
+The template bucket is an external, operator-owned prerequisite. Configure S3
+Object Ownership as `Bucket owner enforced`, keep public writes blocked, and
+merge this statement into the bucket policy (replace `BUCKET_NAME` with the
+configured bucket name):
+
+```json
+{
+  "Sid": "IdentrailCloudFormationTemplatePublicRead",
+  "Effect": "Allow",
+  "Principal": "*",
+  "Action": "s3:GetObject",
+  "Resource": "arn:aws:s3:::BUCKET_NAME/connectors/aws/sha256/*"
+}
+```
+
+Do not grant `s3:ListBucket` or public write access. The `AWS_ROLE_ARN`
+deployment role only needs to write
+`connectors/aws/sha256/*/identrail-readonly.yaml`; a setup role needs
+`s3:GetBucketPolicy` and `s3:PutBucketPolicy` to provision the policy. Run the
+idempotent helper from the repository root after setting the bucket and region:
+
+```bash
+AWS_CFN_TEMPLATE_BUCKET=identrail-cloudformation-templates \
+AWS_REGION=us-east-1 \
+./scripts/configure_cfn_template_bucket_policy.sh
+```
+
+The helper preserves unrelated bucket-policy statements and replaces only its
+own statement by `Sid`. The release workflow then verifies the public S3 URL
+and its SHA-256 digest before migrations or API deployment begin. This policy
+also makes previously uploaded private objects readable without rewriting their
+content. ACLs are intentionally not used.
 
 Hosted WorkOS login is optional. Configure these values only when deploying the
 hosted sign-in/sign-up flow:

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -161,10 +161,13 @@ configured bucket name):
 ```
 
 Do not grant `s3:ListBucket` or public write access. The `AWS_ROLE_ARN`
-deployment role only needs to write
-`connectors/aws/sha256/*/identrail-readonly.yaml`; a setup role needs
-`s3:GetBucketPolicy` and `s3:PutBucketPolicy` to provision the policy. Run the
-idempotent helper from the repository root after setting the bucket and region:
+deployment role needs `s3:PutObject` and `s3:GetObject` on
+`connectors/aws/sha256/*/identrail-readonly.yaml`; it does not need
+`s3:PutObjectAcl`. A setup role needs `s3:GetBucketPolicy`,
+`s3:PutBucketPolicy`, `s3:GetBucketPublicAccessBlock`,
+`s3:GetAccountPublicAccessBlock`, and `sts:GetCallerIdentity` to provision and
+verify the policy. Run the idempotent helper from the repository root after
+setting the bucket and region:
 
 ```bash
 AWS_CFN_TEMPLATE_BUCKET=identrail-cloudformation-templates \
@@ -174,9 +177,55 @@ AWS_REGION=us-east-1 \
 
 The helper preserves unrelated bucket-policy statements and replaces only its
 own statement by `Sid`. The release workflow then verifies the public S3 URL
-and its SHA-256 digest before migrations or API deployment begin. This policy
-also makes previously uploaded private objects readable without rewriting their
-content. ACLs are intentionally not used.
+and its SHA-256 digest before migrations or API deployment begin. It also
+publishes with and verifies SSE-S3 (`AES256`); do not use SSE-KMS for this
+prefix because the anonymous CloudFormation fetch cannot authorize a KMS key.
+An existing digest encrypted with KMS is rejected and never overwritten by the
+write-once path. Verify its SHA-256, then perform a controlled one-time
+same-key re-encryption with SSE-S3 before retrying the release. ACLs are
+intentionally not used.
+
+For that one-time migration, verify the authenticated bytes and use the
+current ETag as a compare-and-swap guard before copying the object onto itself
+with SSE-S3:
+
+```bash
+key=connectors/aws/sha256/DIGEST/identrail-readonly.yaml
+digest=DIGEST
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+aws s3api get-object \
+  --bucket "$AWS_CFN_TEMPLATE_BUCKET" \
+  --key "$key" \
+  "$tmp" >/dev/null
+test "$(sha256sum "$tmp" | awk '{print $1}')" = "$digest"
+etag="$(aws s3api head-object \
+  --bucket "$AWS_CFN_TEMPLATE_BUCKET" \
+  --key "$key" \
+  --query ETag \
+  --output text | tr -d '"')"
+aws s3api copy-object \
+  --bucket "$AWS_CFN_TEMPLATE_BUCKET" \
+  --copy-source "$AWS_CFN_TEMPLATE_BUCKET/$key" \
+  --key "$key" \
+  --copy-source-if-match "$etag" \
+  --metadata-directive REPLACE \
+  --content-type "application/x-yaml" \
+  --cache-control "public,max-age=31536000,immutable" \
+  --server-side-encryption AES256
+```
+
+This is an operator migration for an already-published object; the release
+workflow itself remains write-once and will not perform this overwrite.
+
+The helper reads the bucket- and account-level S3 Block Public Access settings
+before changing the policy. The effective settings must keep
+`BlockPublicAcls=true` and `IgnorePublicAcls=true`, while allowing this narrow
+public policy with `BlockPublicPolicy=false` and `RestrictPublicBuckets=false`.
+It never changes those settings. If an organization or account policy enforces
+all four blocks, this anonymous S3 URL design is incompatible and the helper
+fails without changing the bucket policy.
 
 Hosted WorkOS login is optional. Configure these values only when deploying the
 hosted sign-in/sign-up flow:

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -216,6 +216,36 @@ aws s3api copy-object \
   --server-side-encryption AES256
 ```
 
+Run this migration with a dedicated, one-time migration role rather than the
+GitHub deployment or bucket-policy setup role. Its temporary permissions should
+be limited to the exact digest object and source KMS key:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "MigrateOneTemplateObject",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "arn:aws:s3:::BUCKET_NAME/connectors/aws/sha256/DIGEST/identrail-readonly.yaml"
+    },
+    {
+      "Sid": "DecryptOneTemplateObject",
+      "Effect": "Allow",
+      "Action": "kms:Decrypt",
+      "Resource": "KMS_KEY_ARN"
+    }
+  ]
+}
+```
+
+The KMS key policy must also allow this migration role to use
+`kms:Decrypt`; an identity policy alone is insufficient when the key policy
+does not delegate access. The SSE-S3 destination does not require
+`kms:Encrypt`. Remove the temporary role permission and key-policy grant after
+the migration, then rerun the release.
+
 This is an operator migration for an already-published object; the release
 workflow itself remains write-once and will not perform this overwrite.
 

--- a/scripts/configure_cfn_template_bucket_policy.sh
+++ b/scripts/configure_cfn_template_bucket_policy.sh
@@ -8,8 +8,8 @@ if [ -z "${bucket}" ]; then
   echo "AWS_CFN_TEMPLATE_BUCKET is required." >&2
   exit 1
 fi
-if ! [[ "${bucket}" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]; then
-  echo "AWS_CFN_TEMPLATE_BUCKET must be a valid S3 bucket name." >&2
+if ! [[ "${bucket}" =~ ^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$ ]]; then
+  echo "AWS_CFN_TEMPLATE_BUCKET must use lowercase letters, numbers, and hyphens only; dotted names are incompatible with the release URL." >&2
   exit 1
 fi
 if ! [[ "${region}" =~ ^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$ ]]; then

--- a/scripts/configure_cfn_template_bucket_policy.sh
+++ b/scripts/configure_cfn_template_bucket_policy.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bucket="${AWS_CFN_TEMPLATE_BUCKET:-}"
+region="${AWS_REGION:-us-east-1}"
+
+if [ -z "${bucket}" ]; then
+  echo "AWS_CFN_TEMPLATE_BUCKET is required." >&2
+  exit 1
+fi
+if ! [[ "${bucket}" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]; then
+  echo "AWS_CFN_TEMPLATE_BUCKET must be a valid S3 bucket name." >&2
+  exit 1
+fi
+if ! [[ "${region}" =~ ^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$ ]]; then
+  echo "AWS_REGION must be an AWS region such as us-east-1." >&2
+  exit 1
+fi
+
+case "${region}" in
+  cn-*) partition="aws-cn" ;;
+  us-gov-*) partition="aws-us-gov" ;;
+  *) partition="aws" ;;
+esac
+
+template_resource="arn:${partition}:s3:::${bucket}/connectors/aws/sha256/*"
+statement_sid="IdentrailCloudFormationTemplatePublicRead"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf -- "${temp_dir}"' EXIT
+
+policy_error="${temp_dir}/get-policy.err"
+if ! policy_json="$(
+  aws s3api get-bucket-policy \
+    --bucket "${bucket}" \
+    --region "${region}" \
+    --query Policy \
+    --output text 2>"${policy_error}"
+)"; then
+  if grep -qi "NoSuchBucketPolicy\|PolicyNotFound\|404" "${policy_error}"; then
+    policy_json='{"Version":"2012-10-17","Statement":[]}'
+  else
+    cat "${policy_error}" >&2
+    exit 1
+  fi
+fi
+
+if ! jq -e 'type == "object"' >/dev/null <<<"${policy_json}"; then
+  echo "The existing bucket policy is not a JSON object; refusing to replace it." >&2
+  exit 1
+fi
+
+merged_policy="${temp_dir}/bucket-policy.json"
+jq \
+  --arg statement_sid "${statement_sid}" \
+  --arg template_resource "${template_resource}" \
+  '
+    .Version = (.Version // "2012-10-17")
+    | .Statement = (
+        if .Statement == null then []
+        elif (.Statement | type) == "array" then .Statement
+        elif (.Statement | type) == "object" then [.Statement]
+        else error("Statement must be an object or array")
+        end
+        | map(select((.Sid // "") != $statement_sid))
+        + [{
+            "Sid": $statement_sid,
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": $template_resource
+          }]
+      )
+  ' <<<"${policy_json}" >"${merged_policy}"
+
+aws s3api put-bucket-policy \
+  --bucket "${bucket}" \
+  --region "${region}" \
+  --policy "file://${merged_policy}"
+
+echo "Configured public read for ${template_resource}."
+echo "Existing bucket policy statements were preserved; ACLs were not changed."

--- a/scripts/configure_cfn_template_bucket_policy.sh
+++ b/scripts/configure_cfn_template_bucket_policy.sh
@@ -28,6 +28,87 @@ statement_sid="IdentrailCloudFormationTemplatePublicRead"
 temp_dir="$(mktemp -d)"
 trap 'rm -rf -- "${temp_dir}"' EXIT
 
+bucket_public_access_block_error="${temp_dir}/get-bucket-public-access-block.err"
+if ! bucket_public_access_block="$(
+  aws s3api get-public-access-block \
+    --bucket "${bucket}" \
+    --region "${region}" \
+    --query PublicAccessBlockConfiguration \
+    --output json 2>"${bucket_public_access_block_error}"
+)"; then
+  if grep -qi "NoSuchPublicAccessBlockConfiguration\|PublicAccessBlockConfigurationNotFound\|404" "${bucket_public_access_block_error}"; then
+    bucket_public_access_block='{}'
+  else
+    cat "${bucket_public_access_block_error}" >&2
+    exit 1
+  fi
+fi
+
+account_id_error="${temp_dir}/get-account-id.err"
+if ! account_id="$(
+  aws sts get-caller-identity \
+    --query Account \
+    --output text 2>"${account_id_error}"
+)"; then
+  cat "${account_id_error}" >&2
+  exit 1
+fi
+if ! [[ "${account_id}" =~ ^[0-9]{12}$ ]]; then
+  echo "AWS did not return a 12-digit account id; refusing to apply a public policy." >&2
+  exit 1
+fi
+
+account_public_access_block_error="${temp_dir}/get-account-public-access-block.err"
+if ! account_public_access_block="$(
+  aws s3control get-public-access-block \
+    --account-id "${account_id}" \
+    --region "${region}" \
+    --query PublicAccessBlockConfiguration \
+    --output json 2>"${account_public_access_block_error}"
+)"; then
+  if grep -qi "NoSuchPublicAccessBlockConfiguration\|PublicAccessBlockConfigurationNotFound\|404" "${account_public_access_block_error}"; then
+    account_public_access_block='{}'
+  else
+    cat "${account_public_access_block_error}" >&2
+    exit 1
+  fi
+fi
+
+if ! jq -e 'type == "object"' >/dev/null <<<"${bucket_public_access_block}" || \
+  ! jq -e 'type == "object"' >/dev/null <<<"${account_public_access_block}"; then
+  echo "S3 returned an invalid public-access-block configuration; refusing to apply a public policy." >&2
+  exit 1
+fi
+
+effective_public_access_block="$(
+  jq -n \
+    --argjson bucket "${bucket_public_access_block}" \
+    --argjson account "${account_public_access_block}" \
+    '
+      def enabled($name): (($bucket[$name] // false) or ($account[$name] // false));
+      {
+        BlockPublicAcls: enabled("BlockPublicAcls"),
+        IgnorePublicAcls: enabled("IgnorePublicAcls"),
+        BlockPublicPolicy: enabled("BlockPublicPolicy"),
+        RestrictPublicBuckets: enabled("RestrictPublicBuckets")
+      }
+    '
+)"
+if ! jq -e '
+  .BlockPublicAcls == true
+  and .IgnorePublicAcls == true
+  and .BlockPublicPolicy == false
+  and .RestrictPublicBuckets == false
+' >/dev/null <<<"${effective_public_access_block}"; then
+  echo "The effective S3 public-access-block settings are incompatible with this scoped public-read policy." >&2
+  echo "Require BlockPublicAcls=true and IgnorePublicAcls=true, while allowing only this policy path with BlockPublicPolicy=false and RestrictPublicBuckets=false." >&2
+  echo "Bucket-level settings:" >&2
+  jq . <<<"${bucket_public_access_block}" >&2
+  echo "Account-level settings:" >&2
+  jq . <<<"${account_public_access_block}" >&2
+  exit 1
+fi
+
 policy_error="${temp_dir}/get-policy.err"
 if ! policy_json="$(
   aws s3api get-bucket-policy \
@@ -78,4 +159,5 @@ aws s3api put-bucket-policy \
   --policy "file://${merged_policy}"
 
 echo "Configured public read for ${template_resource}."
+echo "Verified effective public-access-block settings without weakening ACL protections."
 echo "Existing bucket policy statements were preserved; ACLs were not changed."


### PR DESCRIPTION
## Summary

Make the AWS connector CloudFormation template publish path depend on a documented, prefix-scoped S3 bucket policy and validate every prerequisite needed for anonymous CloudFormation reads while preserving the SHA-addressed write-once contract.

## Why

Run 31279893624 failed in `Publish immutable AWS connector template` (job 93159439957). The object already existed, but the public S3 URL returned HTTP 403 on every retry, so the release stopped before migrations or the API/worker deploy. The workflow had no durable contract for public access, encryption, or account-level S3 public-access controls.

## Long-term fix

- The release performs one conditional `PutObject` with `If-None-Match: *`; an existing digest is never rewritten.
- Public access is provided by a prefix-scoped bucket-policy statement for `connectors/aws/sha256/*`.
- The setup helper reads both bucket- and account-level Block Public Access settings, requires effective ACL protections to remain enabled, and refuses to apply the policy when public policies are blocked or restricted.
- The workflow explicitly publishes with SSE-S3 (`AES256`) and verifies existing objects use SSE-S3 before checking the public URL and SHA-256 bytes.
- Legacy KMS-encrypted digest objects are rejected with remediation guidance and a guarded one-time same-key migration procedure.
- ACLs and `s3:PutObjectAcl` are not required; unrelated bucket-policy statements are preserved.

## Scope

- [x] Focused production-release workflow, setup helper, and operator documentation
- [x] Public read limited to the immutable CloudFormation template prefix
- [x] Write-once, encryption, public-access, and SHA verification preserved
- [x] No secrets, credentials, or sensitive data included

## Validation

- `actionlint .github/workflows/aws-production-release.yml`
- `bash -n scripts/configure_cfn_template_bucket_policy.sh`
- `shellcheck scripts/configure_cfn_template_bucket_policy.sh`
- Helper success and public-access-block refusal tests with mocked AWS responses
- `bash scripts/check_public_api_url_test.sh`
- `git diff --check`
- Commit hooks: YAML validation, gofmt, local token hygiene, and Vercel artifact hygiene

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: none
- Areas where used: none
- Human verification performed: not applicable

## Related Issues

No issue: production deployment fix discovered from the failed production run.