### PR TITLE
Redesign AWS connection setup

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1840,8 +1840,8 @@ describe('App', () => {
 
     expect(await screen.findByRole('heading', { level: 2, name: /Connect AWS/i })).toBeInTheDocument();
     expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/aws/connect');
-    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /AWS overview/i })).toHaveAttribute('href', '/app/tenant-a/workspace-a/aws?environment=project-1');
+    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /AWS overview/i })).not.toBeInTheDocument();
     expect(screen.queryByLabelText('AWS source')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Source types')).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', { level: 3, name: 'AWS' })).not.toBeInTheDocument();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8333,11 +8333,22 @@ describe('Domain-first app routes', () => {
     );
 
     expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
-    expect(screen.getByRole('radiogroup', { name: 'AWS coverage scope' })).toHaveTextContent('One AWS account');
+    const setup = screen.getByRole('region', { name: 'AWS account setup' });
+    expect(within(setup).getByRole('heading', { level: 3, name: 'Connect this environment' })).toBeInTheDocument();
+    expect(within(setup).queryByText('Connect your AWS environment')).not.toBeInTheDocument();
+    const coverageGroup = screen.getByRole('radiogroup', { name: 'AWS coverage scope' });
+    expect(coverageGroup).toHaveTextContent('One account');
     expect(screen.getByRole('list', { name: 'AWS connection safeguards' })).toHaveTextContent(
       'No access keysRead-only permissionsNo workload changes'
     );
-    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    expect(within(coverageGroup).getAllByRole('radio')).toHaveLength(3);
+    expect(within(coverageGroup).getByRole('radio', { name: /One account/i })).toHaveAttribute('tabindex', '0');
+    fireEvent.keyDown(within(coverageGroup).getByRole('radio', { name: /One account/i }), { key: 'ArrowRight' });
+    expect(within(coverageGroup).getByRole('radio', { name: /OUs or accounts/i })).toHaveFocus();
+    fireEvent.keyDown(within(coverageGroup).getByRole('radio', { name: /OUs or accounts/i }), { key: 'Home' });
+    expect(within(coverageGroup).getByRole('radio', { name: /All accounts/i })).toHaveFocus();
+    fireEvent.keyDown(within(coverageGroup).getByRole('radio', { name: /All accounts/i }), { key: 'ArrowRight' });
+    expect(within(coverageGroup).getByRole('radio', { name: /One account/i })).toHaveFocus();
     expect(screen.queryByRole('region', { name: 'AWS setup summary' })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /AWS overview/i })).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
@@ -8345,7 +8356,7 @@ describe('Domain-first app routes', () => {
 
     fireEvent.change(screen.getByLabelText('Connection name'), { target: { value: 'Production AWS' } });
     fireEvent.change(screen.getByLabelText('Home region'), { target: { value: 'ap-south-1' } });
-    fireEvent.click(screen.getAllByRole('button', { name: /Connect AWS/i })[0]);
+    fireEvent.click(within(setup).getByRole('button', { name: /^Connect$/i }));
 
     await waitFor(() =>
       expect(api.apiClient.startAWSConnector).toHaveBeenCalledWith(
@@ -8430,7 +8441,7 @@ describe('Domain-first app routes', () => {
     const setup = await screen.findByRole('region', { name: 'AWS account setup' });
     expect(screen.getByRole('region', { name: 'AWS connector disconnected' })).toBeInTheDocument();
     expect(screen.getByLabelText('Connection name')).toHaveValue('');
-    fireEvent.click(within(setup).getByRole('button', { name: /^Connect AWS$/i }));
+    fireEvent.click(within(setup).getByRole('button', { name: /^Connect$/i }));
 
     await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
     expect(startAWSConnector.mock.calls[0]?.[0]).toMatchObject({
@@ -8549,7 +8560,7 @@ describe('Domain-first app routes', () => {
     const summary = await screen.findByRole('region', { name: 'AWS connected summary' });
     fireEvent.click(within(summary).getByRole('button', { name: /Manage connection/i }));
     const setup = await screen.findByRole('region', { name: 'AWS account setup' });
-    fireEvent.click(within(setup).getByRole('button', { name: /^Connect AWS$/i }));
+    fireEvent.click(within(setup).getByRole('button', { name: /^Connect$/i }));
     await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
 
     fireEvent.click(within(screen.getByRole('region', { name: 'AWS connected summary' })).getByRole('button', { name: /^Disconnect$/i }));
@@ -8680,7 +8691,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click((await screen.findAllByRole('button', { name: /Connect AWS/i }))[0]);
+    fireEvent.click((await screen.findAllByRole('button', { name: /^Connect$/i }))[0]);
     expect(await screen.findAllByRole('link', { name: /^Continue in AWS$/i })).toHaveLength(1);
 
     fireEvent.click(screen.getByRole('button', { name: /Existing IAM role/i }));
@@ -8902,7 +8913,7 @@ describe('Domain-first app routes', () => {
     );
   });
 
-  it('lets operators return to CloudFormation after generating a manual External ID', async () => {
+  it('keeps manual setup intact until the explicit CloudFormation control is used', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
     const api = await import('./api/client');
@@ -8966,10 +8977,17 @@ describe('Domain-first app routes', () => {
     fireEvent.click(screen.getByRole('button', { name: /Generate External ID/i }));
     expect(await screen.findByLabelText('External ID')).toHaveValue('manual-external-id-to-clear');
 
-    fireEvent.click(screen.getByRole('radio', { name: /One AWS account/i }));
+    const singleAccountCoverage = screen.getByRole('radio', { name: /One account/i });
+    expect(singleAccountCoverage).toHaveAttribute('aria-checked', 'true');
+    fireEvent.click(singleAccountCoverage);
 
-    expect(screen.getByRole('heading', { level: 4, name: /Approve in AWS/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Connect AWS/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 4, name: /Use an existing IAM role/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('External ID')).toHaveValue('manual-external-id-to-clear');
+
+    fireEvent.click(screen.getByRole('button', { name: /Use CloudFormation instead/i }));
+
+    expect(screen.getByRole('heading', { level: 4, name: /Approve the stack/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Connect$/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue('manual-external-id-to-clear')).not.toBeInTheDocument();
   });
@@ -9135,7 +9153,7 @@ describe('Domain-first app routes', () => {
 
     expect(screen.getByRole('heading', { level: 4, name: /Use an existing IAM role/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Generate External ID/i })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Connect AWS/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Connect$/i })).not.toBeInTheDocument();
   });
 
   it('clears manual AWS setup secrets when switching environments', async () => {
@@ -9258,11 +9276,11 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 4, name: /Approve in AWS/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 4, name: /Approve the stack/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getAllByRole('button', { name: /Connect AWS/i })[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^Connect$/i }));
 
     expect(await screen.findAllByText(/AWS account connection is not enabled for this deployment/i)).toHaveLength(1);
     expect(upsertAWSProjectConnection).not.toHaveBeenCalled();
@@ -9353,6 +9371,8 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
+    const lifecycleSummary = await screen.findByRole('region', { name: 'AWS connected summary' });
+    expect(within(lifecycleSummary).getByRole('button', { name: /^Disconnect$/i })).toBeInTheDocument();
     expect(await screen.findByRole('heading', { name: /Next setup action/i })).toBeInTheDocument();
     expect(screen.getByText(/Primary blocker/i)).toBeInTheDocument();
     const repairList = screen.getByLabelText('AWS guided repair actions');
@@ -9472,7 +9492,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click((await screen.findAllByRole('button', { name: /Connect AWS/i }))[0]);
+    fireEvent.click((await screen.findAllByRole('button', { name: /^Connect$/i }))[0]);
 
     expect(await screen.findAllByText('project not found')).toHaveLength(1);
     expect(screen.queryByText(/AWS account connection is not enabled for this deployment/i)).not.toBeInTheDocument();
@@ -9513,7 +9533,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click((await screen.findAllByRole('button', { name: /Connect AWS/i }))[0]);
+    fireEvent.click((await screen.findAllByRole('button', { name: /^Connect$/i }))[0]);
 
     expect(await screen.findAllByText(/AWS CloudFormation setup is not configured for this deployment/i)).toHaveLength(1);
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
@@ -11405,7 +11425,7 @@ describe('Domain-first app routes', () => {
     await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
 
-    fireEvent.click(screen.getByRole('radio', { name: /One AWS account/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /One account/i }));
 
     // Under Single account, the persisted StackSet launch URL must not surface.
     const links = screen.queryAllByRole('link', { name: /Open AWS|Open StackSet(?: in AWS)?/i });
@@ -12575,7 +12595,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    const launchButton = (await screen.findAllByRole('button', { name: /Connect AWS/i }))[0];
+    const launchButton = (await screen.findAllByRole('button', { name: /^Connect$/i }))[0];
     fireEvent.click(launchButton);
     await waitFor(() =>
       expect(api.apiClient.startAWSConnector).toHaveBeenCalledWith(

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8332,12 +8332,18 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
-  expect(screen.getByRole('list', { name: 'AWS setup scope options' })).toHaveTextContent('This AWS account');
-  expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
+    expect(screen.getByRole('radiogroup', { name: 'AWS coverage scope' })).toHaveTextContent('One AWS account');
+    expect(screen.getByRole('list', { name: 'AWS connection safeguards' })).toHaveTextContent(
+      'No access keysRead-only permissionsNo workload changes'
+    );
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    expect(screen.queryByRole('region', { name: 'AWS setup summary' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /AWS overview/i })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
   expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Production AWS' } });
+    fireEvent.change(screen.getByLabelText('Connection name'), { target: { value: 'Production AWS' } });
     fireEvent.change(screen.getByLabelText('Home region'), { target: { value: 'ap-south-1' } });
     fireEvent.click(screen.getAllByRole('button', { name: /Connect AWS/i })[0]);
 
@@ -8352,7 +8358,7 @@ describe('Domain-first app routes', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
-  expect(await screen.findAllByRole('link', { name: /^Open AWS$/i })).toHaveLength(1);
+    expect(await screen.findAllByRole('link', { name: /^Continue in AWS$/i })).toHaveLength(1);
     expect(screen.getByLabelText('Role ARN')).toHaveValue('');
   });
 
@@ -8423,7 +8429,7 @@ describe('Domain-first app routes', () => {
 
     const setup = await screen.findByRole('region', { name: 'AWS account setup' });
     expect(screen.getByRole('region', { name: 'AWS connector disconnected' })).toBeInTheDocument();
-    expect(screen.getByLabelText('Display name')).toHaveValue('');
+    expect(screen.getByLabelText('Connection name')).toHaveValue('');
     fireEvent.click(within(setup).getByRole('button', { name: /^Connect AWS$/i }));
 
     await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
@@ -8675,7 +8681,7 @@ describe('Domain-first app routes', () => {
     );
 
     fireEvent.click((await screen.findAllByRole('button', { name: /Connect AWS/i }))[0]);
-  expect(await screen.findAllByRole('link', { name: /^Open AWS$/i })).toHaveLength(1);
+    expect(await screen.findAllByRole('link', { name: /^Continue in AWS$/i })).toHaveLength(1);
 
     fireEvent.click(screen.getByRole('button', { name: /Existing IAM role/i }));
 
@@ -8774,7 +8780,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
 
@@ -8960,9 +8966,9 @@ describe('Domain-first app routes', () => {
     fireEvent.click(screen.getByRole('button', { name: /Generate External ID/i }));
     expect(await screen.findByLabelText('External ID')).toHaveValue('manual-external-id-to-clear');
 
-    fireEvent.click(screen.getByRole('button', { name: /This AWS account/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /One AWS account/i }));
 
-    expect(screen.getByRole('heading', { level: 4, name: /Connect this account/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 4, name: /Approve in AWS/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Connect AWS/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue('manual-external-id-to-clear')).not.toBeInTheDocument();
@@ -9252,7 +9258,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 4, name: /Connect this account/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 4, name: /Approve in AWS/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
 
@@ -9600,7 +9606,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
     expect(screen.getByRole('heading', { level: 4, name: /Set the coverage scope/i })).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/Target regions/i), { target: { value: 'us-east-1, us-west-2' } });
@@ -9707,7 +9713,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /Selected scope/i }));
     fireEvent.change(screen.getByLabelText(/Target OU IDs/i), { target: { value: 'ou-1234-abcd5678' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -9799,7 +9805,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /Selected scope/i }));
     fireEvent.click(screen.getByRole('tab', { name: /Account IDs/i }));
     fireEvent.change(screen.getByLabelText(/Target account IDs/i), {
       target: { value: '111111111111, 222222222222' }
@@ -9855,7 +9861,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /Selected scope/i }));
     fireEvent.click(screen.getByRole('tab', { name: /Account IDs/i }));
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -9946,7 +9952,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10034,7 +10040,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10084,7 +10090,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10187,7 +10193,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10266,7 +10272,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /Selected scope/i }));
     fireEvent.change(screen.getByLabelText(/Target OU IDs/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10351,7 +10357,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10397,11 +10403,11 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
-    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /Selected scope/i }));
 
     await act(async () => {
       pendingStart.resolve({
@@ -10599,7 +10605,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10811,7 +10817,7 @@ describe('Domain-first app routes', () => {
     // Kick off a fresh StackSet setup in staging — the hidden StackSet name
     // must come from the wizard default, not leak from the production
     // environment's custom name.
-    fireEvent.click(screen.getByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /All accounts/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -11119,7 +11125,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -11195,7 +11201,7 @@ describe('Domain-first app routes', () => {
 
     await openAWSConnectionManagement();
     expect(await screen.findByText(/Persisted organization recovery action/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /Selected scope/i }));
     expect(screen.queryByText(/Persisted organization recovery action/i)).not.toBeInTheDocument();
   });
 
@@ -11261,7 +11267,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.change(screen.getByLabelText(/Target regions/i), { target: { value: 'us-east-1, us-west-2' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
@@ -11341,11 +11347,11 @@ describe('Domain-first app routes', () => {
     const initialCallCount = getStackSetOnboarding.mock.calls.length;
 
     // Switch away from the connector's scope.
-    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /Selected scope/i }));
     expect(screen.queryByText(/Persisted recovery action to restore/i)).not.toBeInTheDocument();
 
     // Switch back to the connector's scope — panel should reappear via a fresh refetch.
-    fireEvent.click(screen.getByRole('button', { name: /AWS Organization/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /All accounts/i }));
     expect(await screen.findByText(/Persisted recovery action to restore/i)).toBeInTheDocument();
     expect(getStackSetOnboarding.mock.calls.length).toBeGreaterThan(initialCallCount);
   });
@@ -11399,7 +11405,7 @@ describe('Domain-first app routes', () => {
     await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
 
-    fireEvent.click(screen.getByRole('button', { name: /This AWS account/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /One AWS account/i }));
 
     // Under Single account, the persisted StackSet launch URL must not surface.
     const links = screen.queryAllByRole('link', { name: /Open AWS|Open StackSet(?: in AWS)?/i });
@@ -11455,7 +11461,7 @@ describe('Domain-first app routes', () => {
 
     await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
-    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /Selected scope/i }));
 
     // Selected OUs shares the stackset_ deployment method with organization,
     // but the scope type differs — the persisted URL must not leak through.
@@ -11727,7 +11733,7 @@ describe('Domain-first app routes', () => {
     await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
 
-    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /Selected scope/i }));
     fireEvent.change(await screen.findByLabelText(/Target OU IDs/i), {
       target: { value: 'ou-1234-abcd5678' }
     });
@@ -11936,9 +11942,9 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByRole('region', { name: 'AWS connected summary' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /Manage connection/i }));
-    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: /^Validate role$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Validate role$/i })).not.toBeInTheDocument();
     expect(screen.getByText(/Start CloudFormation setup to move it onto the connector flow/i)).toBeInTheDocument();
     expect(validateAWSConnector).not.toHaveBeenCalled();
   });
@@ -12513,10 +12519,10 @@ describe('Domain-first app routes', () => {
       });
     });
 
-    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Display name')).toHaveValue('');
+    expect(screen.getByLabelText('Connection name')).toHaveValue('');
     expect(screen.getByLabelText('Home region')).toHaveValue('us-east-1');
 
     await act(async () => {
@@ -12659,7 +12665,7 @@ describe('Domain-first app routes', () => {
     );
 
     await openAWSConnectionManagement();
-    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
     const refreshButton = within(screen.getByLabelText('AWS account setup')).getByRole('button', {
       name: /Refresh/i
     });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8,6 +8,7 @@ import type {
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router';
 import {
   BarChart3,
+  Check,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
@@ -650,27 +651,27 @@ function stackSetContractsMatch(a: AWSStackSetContractSnapshot, b: AWSStackSetCo
 
 const AWS_SCOPE_OPTION_LABELS: Record<AWSSetupMode, { title: string; kicker: string; blurb: string }> = {
   cloudformation: {
-    kicker: 'Single account',
-    title: 'This AWS account',
-    blurb: 'One-click CloudFormation'
+    kicker: 'This account',
+    title: 'One AWS account',
+    blurb: 'Recommended · CloudFormation'
   },
   organization: {
     kicker: 'AWS Organization',
     title: 'All accounts',
-    blurb: 'Recommended for teams'
+    blurb: 'Best for teams'
   },
   selected_ous: {
-    kicker: 'Selected OUs',
-    title: 'Chosen OUs',
-    blurb: 'Pick OUs to onboard'
+    kicker: 'Selected scope',
+    title: 'OUs or accounts',
+    blurb: 'Choose a subset'
   },
   selected_accounts: {
-    kicker: 'Selected accounts',
-    title: 'Chosen accounts',
-    blurb: 'Pick accounts to onboard'
+    kicker: 'Selected scope',
+    title: 'OUs or accounts',
+    blurb: 'Choose a subset'
   },
   manual: {
-    kicker: 'Advanced',
+    kicker: 'Advanced setup',
     title: 'Existing IAM role',
     blurb: 'Use your change process'
   }
@@ -23623,7 +23624,14 @@ export function ProductAWSConnectPage() {
       return 'Pick an environment to connect.';
     }
     if (!connectedNow) {
-      return 'Not connected for this environment.';
+      const setupStatus = connection?.onboarding_status ?? awsCloudFormationStart?.onboarding_status;
+      if (setupStatus === 'waiting_for_aws' || setupStatus === 'launch_ready') {
+        return 'Continue in AWS to approve read-only access.';
+      }
+      if (setupStatus === 'registering' || setupStatus === 'validating') {
+        return 'Verifying read-only access for this environment.';
+      }
+      return 'Read-only access to identity and workload metadata.';
     }
     const bits: string[] = [];
     if (connection?.account_id) {
@@ -23787,7 +23795,7 @@ export function ProductAWSConnectPage() {
       return 'AWS is connected';
     }
     if (onboardingStatus === 'launch_ready') {
-      return 'Open the AWS stack';
+      return 'Continue in AWS';
     }
     if (onboardingStatus === 'waiting_for_aws') {
       return 'Waiting for approval';
@@ -23820,7 +23828,7 @@ export function ProductAWSConnectPage() {
       return 'This connector uses a self-managed StackSet. Manage it through the API, Terraform, or the AWS console — the wizard cannot relaunch self-managed setups.';
     }
     if (isStackSetSetup && stackSetAWSStart?.launch_url && stackSetBlockingPrereqCount === 0) {
-      return 'Open the StackSet in AWS to deploy the read-only role, then refresh status.';
+      return 'Continue in AWS to deploy the read-only role, then return here for verification.';
     }
     if (isStackSetSetup && stackSetAWSStart?.launch_url && stackSetBlockingPrereqCount > 0) {
       return 'Resolve the blocking StackSet prerequisites, then open the StackSet in AWS.';
@@ -23832,7 +23840,7 @@ export function ProductAWSConnectPage() {
       return connection.setup_summary;
     }
     if (launchURL) {
-      return 'Approve the stack in AWS. Identrail will verify the connection automatically.';
+      return 'Approve the read-only stack in AWS, then return here. Identrail will verify the connection automatically.';
     }
     if (hasConnectorSetup) {
       return 'Identrail is waiting for AWS.';
@@ -23840,7 +23848,9 @@ export function ProductAWSConnectPage() {
     return 'Create one read-only CloudFormation stack for this environment.';
   })();
   const onboardingInProgress = ['launch_ready', 'waiting_for_aws', 'registering', 'validating'].includes(onboardingStatus);
-  const wizardHealth = connection?.health_status;
+  const showSetupSummary =
+    !connectedNow &&
+    (onboardingInProgress || Boolean(awsCloudFormationStart || awsStackSetOnboarding || manualAWSStart));
 
   return (
     <DomainPageShell
@@ -23853,7 +23863,7 @@ export function ProductAWSConnectPage() {
       scope={<ProductEnvironmentSelector state={environmentScope} onChange={handleEnvironmentChange} />}
       statusTone={statusTone}
       primaryAction={
-        awaitingFirstConnectLoad
+        awaitingFirstConnectLoad || !connectedNow
           ? undefined
           : { label: 'AWS overview', to: controlPath, variant: 'primary' as const }
       }
@@ -23917,21 +23927,13 @@ export function ProductAWSConnectPage() {
             ) : null}
 
             {disconnectedConnector ? (
-              <section className="idt-source-config idt-aws-connect-panel" aria-label="AWS connector disconnected">
-                <div className="idt-source-config-header">
-                  <div>
-                    <p className="idt-app-kicker">Disconnected</p>
-                    <h3>AWS connector is disconnected</h3>
-                    <p>New scans are stopped and provider cleanup remains pending until it is verified.</p>
-                  </div>
-                  <DomainStatusBadge variant="disconnected" detail="disconnected" />
-                </div>
+              <section className="idt-aws-connect-notice" aria-label="AWS connector disconnected">
+                <DomainStatusBadge variant="disconnected" label="Disconnected" />
+                <p>Reconnect with a fresh read-only setup. Provider cleanup remains pending until it is verified.</p>
               </section>
             ) : null}
 
-            {connection &&
-            !disconnectedConnector &&
-            (connectedNow || Boolean(connection.connector_id && !connection.disabled)) ? (
+            {connection && !disconnectedConnector && connectedNow ? (
               <AWSConnectedSuccessPanel
                 scope={scope}
                 environmentID={selectedEnvironmentID}
@@ -23949,117 +23951,154 @@ export function ProductAWSConnectPage() {
             ) : null}
 
             {showAWSSetupControls ? (
-              <section className="idt-source-config idt-aws-connect-panel idt-aws-scope-wizard" aria-label="AWS account setup">
+              <section
+                className={`idt-source-config idt-aws-connect-panel idt-aws-scope-wizard ${
+                  connectedNow ? 'is-manage-mode' : 'is-first-connect'
+                }`}
+                aria-label="AWS account setup"
+              >
                 <div className="idt-source-config-header idt-aws-wizard-header">
                   <div className="idt-source-config-title">
                     <SourceLogoMark provider="aws" className="is-hero" />
                     <div>
-                      <h3>Choose coverage</h3>
-                      <p>Connect one account or select a broader scope.</p>
+                      <p className="idt-app-kicker">{connectedNow ? 'Manage connection' : 'Connect AWS'}</p>
+                      <h3>{connectedNow ? 'Manage your AWS connection' : 'Connect your AWS environment'}</h3>
+                      <p>
+                        {connectedNow
+                          ? 'Change coverage or connection method for this environment.'
+                          : 'Connect a read-only source to begin.'}
+                      </p>
                     </div>
                   </div>
                   <DomainStatusBadge
                     variant={onboardingInProgress ? 'running-scan' : awsStatusVariant(connection)}
-                    label={onboardingInProgress ? 'Connecting' : undefined}
-                    detail={onboardingInProgress ? setupSummaryTitle : wizardHealth && wizardHealth !== 'unknown' ? wizardHealth : undefined}
+                    label={onboardingInProgress ? 'Connecting' : connectedNow ? 'Connected' : 'Read-only'}
+                    detail={onboardingInProgress ? setupSummaryTitle : undefined}
                   />
                 </div>
 
-                <div className="idt-aws-scope-options" role="list" aria-label="AWS setup scope options">
-              <div className="idt-aws-scope-option-shell" role="listitem">
-                <button
-                  className={`idt-aws-scope-option ${awsSetupMode === 'organization' ? 'is-selected' : ''}`}
-                  type="button"
-                  aria-current={awsSetupMode === 'organization' ? 'true' : undefined}
-                  onClick={() => chooseAWSSetupMode('organization')}
-                >
-                  <span>{AWS_SCOPE_OPTION_LABELS.organization.kicker}</span>
-                  <strong>{AWS_SCOPE_OPTION_LABELS.organization.title}</strong>
-                  <small>{AWS_SCOPE_OPTION_LABELS.organization.blurb}</small>
-                </button>
-              </div>
-              <div className="idt-aws-scope-option-shell" role="listitem">
-                <button
-                  className={`idt-aws-scope-option ${awsSetupMode === 'cloudformation' ? 'is-selected' : ''}`}
-                  type="button"
-                  aria-current={awsSetupMode === 'cloudformation' ? 'true' : undefined}
-                  onClick={() => chooseAWSSetupMode('cloudformation')}
-                >
-                  <span>{AWS_SCOPE_OPTION_LABELS.cloudformation.kicker}</span>
-                  <strong>{AWS_SCOPE_OPTION_LABELS.cloudformation.title}</strong>
-                  <small>{AWS_SCOPE_OPTION_LABELS.cloudformation.blurb}</small>
-                </button>
-              </div>
-              <div className="idt-aws-scope-option-shell" role="listitem">
-                <button
-                  className={`idt-aws-scope-option ${
-                    awsSetupMode === 'selected_ous' || awsSetupMode === 'selected_accounts' ? 'is-selected' : ''
-                  }`}
-                  type="button"
-                  aria-current={
-                    awsSetupMode === 'selected_ous' || awsSetupMode === 'selected_accounts' ? 'true' : undefined
-                  }
-                  onClick={() =>
-                    chooseAWSSetupMode(
-                      awsSetupMode === 'selected_accounts' ? 'selected_accounts' : 'selected_ous'
-                    )
-                  }
-                >
-                  <span>Selected scope</span>
-                  <strong>OUs or accounts</strong>
-                  <small>Pick a subset</small>
-                </button>
-              </div>
-              <div className="idt-aws-scope-option-shell" role="listitem">
-                <button
-                  className={`idt-aws-scope-option ${awsSetupMode === 'manual' ? 'is-selected' : ''}`}
-                  type="button"
-                  aria-current={awsSetupMode === 'manual' ? 'true' : undefined}
-                  onClick={() => chooseAWSSetupMode('manual')}
-                >
-                  <span>{AWS_SCOPE_OPTION_LABELS.manual.kicker}</span>
-                  <strong>{AWS_SCOPE_OPTION_LABELS.manual.title}</strong>
-                  <small>{AWS_SCOPE_OPTION_LABELS.manual.blurb}</small>
-                </button>
-              </div>
-            </div>
+                {hasRoleOnlyConnection ? (
+                  <p className="idt-aws-setup-note idt-aws-legacy-role-note">
+                    Start CloudFormation setup to move it onto the connector flow.
+                  </p>
+                ) : null}
 
-            <form className="idt-app-form idt-aws-connect-form" onSubmit={handleAWSSubmit}>
-              <div className="idt-aws-wizard-step">
-                <div className="idt-aws-step-index" aria-hidden="true">1</div>
-                <div className="idt-aws-step-body">
-                  <div className="idt-aws-step-heading">
-                    <div>
-                      <h4>Name the account</h4>
-                      <p>Use a name your team will recognize.</p>
-                    </div>
-                    <span>{selectedAWSRegion}</span>
+                {!connectedNow ? (
+                  <ul className="idt-aws-trust-list" aria-label="AWS connection safeguards">
+                    <li><Check size={15} strokeWidth={2.2} aria-hidden="true" />No access keys</li>
+                    <li><Check size={15} strokeWidth={2.2} aria-hidden="true" />Read-only permissions</li>
+                    <li><Check size={15} strokeWidth={2.2} aria-hidden="true" />No workload changes</li>
+                  </ul>
+                ) : null}
+
+                <div className="idt-aws-scope-question">
+                  <div>
+                    <p className="idt-app-kicker">Step 1 · Coverage</p>
+                    <h3>Where should we scan?</h3>
+                    <p>Choose the AWS accounts Identrail should include.</p>
                   </div>
-                  <div className="idt-source-inline-fields">
-                    <label>
-                      Display name
-                      <input
-                        value={awsForm.displayName}
-                        onChange={(event) => setAWSForm((current) => ({ ...current, displayName: event.target.value }))}
-                        placeholder="Production AWS"
-                      />
-                    </label>
-                    {!isStackSetSetup ? (
-                      <label>
-                        Home region
-                        <input
-                          value={awsForm.region}
-                          onChange={(event) =>
-                            setAWSForm((current) => ({ ...current, region: event.target.value }))
-                          }
-                          placeholder="us-east-1"
-                          pattern="[a-z]{2}(-gov)?-[a-z]+-[0-9]"
-                        />
-                      </label>
-                    ) : null}
+                  <div className="idt-aws-scope-options" role="radiogroup" aria-label="AWS coverage scope">
+                    <button
+                      className={`idt-aws-scope-option ${awsSetupMode === 'organization' ? 'is-selected' : ''}`}
+                      type="button"
+                      role="radio"
+                      aria-checked={awsSetupMode === 'organization'}
+                      onClick={() => chooseAWSSetupMode('organization')}
+                    >
+                      <span>{AWS_SCOPE_OPTION_LABELS.organization.kicker}</span>
+                      <strong>{AWS_SCOPE_OPTION_LABELS.organization.title}</strong>
+                      <small>{AWS_SCOPE_OPTION_LABELS.organization.blurb}</small>
+                    </button>
+                    <button
+                      className={`idt-aws-scope-option ${awsSetupMode === 'cloudformation' || awsSetupMode === 'manual' ? 'is-selected' : ''}`}
+                      type="button"
+                      role="radio"
+                      aria-checked={awsSetupMode === 'cloudformation' || awsSetupMode === 'manual'}
+                      onClick={() => chooseAWSSetupMode('cloudformation')}
+                    >
+                      <span>{AWS_SCOPE_OPTION_LABELS.cloudformation.kicker}</span>
+                      <strong>{AWS_SCOPE_OPTION_LABELS.cloudformation.title}</strong>
+                      <small>{AWS_SCOPE_OPTION_LABELS.cloudformation.blurb}</small>
+                    </button>
+                    <button
+                      className={`idt-aws-scope-option ${
+                        awsSetupMode === 'selected_ous' || awsSetupMode === 'selected_accounts' ? 'is-selected' : ''
+                      }`}
+                      type="button"
+                      role="radio"
+                      aria-checked={awsSetupMode === 'selected_ous' || awsSetupMode === 'selected_accounts'}
+                      onClick={() =>
+                        chooseAWSSetupMode(
+                          awsSetupMode === 'selected_accounts' ? 'selected_accounts' : 'selected_ous'
+                        )
+                      }
+                    >
+                      <span>{AWS_SCOPE_OPTION_LABELS.selected_ous.kicker}</span>
+                      <strong>{AWS_SCOPE_OPTION_LABELS.selected_ous.title}</strong>
+                      <small>{AWS_SCOPE_OPTION_LABELS.selected_ous.blurb}</small>
+                    </button>
                   </div>
                 </div>
-              </div>
+
+                <div className={`idt-aws-advanced-method ${awsSetupMode === 'manual' ? 'is-active' : ''}`}>
+                  <div>
+                    <strong>{AWS_SCOPE_OPTION_LABELS.manual.title}</strong>
+                    <span>
+                      {awsSetupMode === 'manual'
+                        ? 'Using your existing IAM role and change process.'
+                        : 'For teams that manage IAM outside Identrail.'}
+                    </span>
+                  </div>
+                  <button
+                    className="idt-btn idt-btn-ghost"
+                    type="button"
+                    onClick={() => chooseAWSSetupMode(awsSetupMode === 'manual' ? 'cloudformation' : 'manual')}
+                  >
+                    {awsSetupMode === 'manual' ? 'Use CloudFormation instead' : 'Use an existing IAM role'}
+                  </button>
+                </div>
+
+                <form className="idt-app-form idt-aws-connect-form" onSubmit={handleAWSSubmit}>
+                  <div className="idt-aws-wizard-step">
+                    <div className="idt-aws-step-index" aria-hidden="true">1</div>
+                    <div className="idt-aws-step-body">
+                      <div className="idt-aws-step-heading">
+                        <div>
+                          <h4>Connection details</h4>
+                          <p>Give this connection a name your team will recognize.</p>
+                        </div>
+                        <span>{selectedAWSRegion}</span>
+                      </div>
+                      <div className="idt-source-inline-fields">
+                        <label>
+                          <span className="idt-aws-field-label">
+                            Connection name <span className="idt-aws-optional" aria-hidden="true">Optional</span>
+                          </span>
+                          <input
+                            aria-label="Connection name"
+                            value={awsForm.displayName}
+                            onChange={(event) =>
+                              setAWSForm((current) => ({ ...current, displayName: event.target.value }))
+                            }
+                            placeholder="Production AWS"
+                          />
+                        </label>
+                        {!isStackSetSetup ? (
+                          <label>
+                            Home region
+                            <input
+                              value={awsForm.region}
+                              onChange={(event) =>
+                                setAWSForm((current) => ({ ...current, region: event.target.value }))
+                              }
+                              placeholder="us-east-1"
+                              pattern="[a-z]{2}(-gov)?-[a-z]+-[0-9]"
+                            />
+                          </label>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
 
               {isStackSetSetup ? (
                 <AWSStackSetScopeStep
@@ -24121,12 +24160,18 @@ export function ProductAWSConnectPage() {
                   <div className="idt-aws-step-body">
                     <div className="idt-aws-step-heading">
                       <div>
-            <h4>Connect this account</h4>
-            <p>Approve one read-only CloudFormation stack in AWS.</p>
+                        <h4>Approve in AWS</h4>
+                        <p>
+                          {launchURL
+                            ? 'Continue in AWS, approve the read-only stack, then return here.'
+                            : 'We’ll prepare a read-only CloudFormation stack in AWS.'}
+                        </p>
                       </div>
                       {cloudFormationAWSStart ? <span>Launch ready</span> : <span>Read-only</span>}
                     </div>
-          <p className="idt-aws-access-note">Reads identity and workload metadata. Cannot write, delete, or remediate.</p>
+                    <p className="idt-aws-access-note">
+                      Reads identity and workload metadata. Cannot write, delete, or remediate.
+                    </p>
                     {awsSetupMessage ? (
                       <p role="status" className="idt-aws-setup-note">
                         {awsSetupMessage}
@@ -24145,7 +24190,7 @@ export function ProductAWSConnectPage() {
                           target="_blank"
                           rel="noreferrer"
                         >
-                          Open AWS
+                          Continue in AWS
                         </a>
                       ) : (
                         <button
@@ -24323,7 +24368,7 @@ export function ProductAWSConnectPage() {
                   </div>
                 </div>
               ) : null}
-            </form>
+                </form>
             {isStackSetSetup && (stackSetAWSStart || awsStackSetOnboarding) ? (
               <AWSStackSetProgressPanel
                 start={stackSetAWSStart}
@@ -24364,8 +24409,10 @@ export function ProductAWSConnectPage() {
             ) : null}
           </div>
 
+          {showSetupSummary || guidedRepairItems.length > 0 || showOperationalPanels ? (
           <div className="idt-aws-connect-side">
-            <section className="idt-source-config idt-aws-connect-summary" aria-label="AWS setup summary">
+            {showSetupSummary ? (
+              <section className="idt-source-config idt-aws-connect-summary" aria-label="AWS setup summary">
               <p className="idt-app-kicker">Setup</p>
               <h3>{setupSummaryTitle}</h3>
               <dl className="idt-source-meta">
@@ -24396,7 +24443,8 @@ export function ProductAWSConnectPage() {
                   </a>
         ) : null}
               </div>
-            </section>
+              </section>
+            ) : null}
 
       {guidedRepairItems.length > 0 ? (
               <DomainStatusPanel
@@ -24455,6 +24503,7 @@ export function ProductAWSConnectPage() {
             ) : null}
 
           </div>
+          ) : null}
         </div>
       ) : null}
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -652,11 +652,11 @@ function stackSetContractsMatch(a: AWSStackSetContractSnapshot, b: AWSStackSetCo
 const AWS_SCOPE_OPTION_LABELS: Record<AWSSetupMode, { title: string; kicker: string; blurb: string }> = {
   cloudformation: {
     kicker: 'This account',
-    title: 'One AWS account',
+    title: 'One account',
     blurb: 'Recommended · CloudFormation'
   },
   organization: {
-    kicker: 'AWS Organization',
+    kicker: 'Organization',
     title: 'All accounts',
     blurb: 'Best for teams'
   },
@@ -22262,6 +22262,7 @@ export function ProductAWSConnectPage() {
   const awsLifecycleRequestRef = useRef(0);
   const awsSetupModeTouchedRef = useRef(false);
   const awsSetupModeRef = useRef<AWSSetupMode>('cloudformation');
+  const awsCoverageOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const awsCloudFormationStartRef = useRef<AWSConnectorStartResponse | null>(null);
   awsCloudFormationStartRef.current = awsCloudFormationStart;
   const activeConnectorIDRef = useRef('');
@@ -23038,6 +23039,9 @@ export function ProductAWSConnectPage() {
 
   const chooseAWSSetupMode = (mode: AWSSetupMode) => {
     const previousMode = awsSetupModeRef.current;
+    if (previousMode === mode) {
+      return;
+    }
     awsSetupModeTouchedRef.current = true;
     awsSetupModeRef.current = mode;
     setAWSSetupMode(mode);
@@ -23077,6 +23081,40 @@ export function ProductAWSConnectPage() {
     setErrorMessage('');
     setSuccessMessage('');
     setAWSCopiedField('');
+  };
+
+  const awsCoverageModes: AWSSetupMode[] = ['organization', 'cloudformation', 'selected_ous'];
+  const selectedAWSCoverageMode: AWSSetupMode =
+    awsSetupMode === 'manual' ? 'cloudformation' : awsSetupMode === 'selected_accounts' ? 'selected_ous' : awsSetupMode;
+  const selectAWSCoverageMode = (mode: AWSSetupMode) => {
+    // Manual IAM setup intentionally shares the single-account coverage
+    // choice. Its separate method control is the only way back to
+    // CloudFormation, so clicking the already-checked coverage radio must be
+    // a no-op and must not clear the prepared External ID.
+    if (mode === 'cloudformation' && awsSetupMode === 'manual') {
+      return;
+    }
+    if (mode === 'selected_ous' && awsSetupMode === 'selected_accounts') {
+      return;
+    }
+    chooseAWSSetupMode(mode);
+  };
+  const handleAWSCoverageKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>, index: number) => {
+    const key = event.key;
+    const isNext = key === 'ArrowRight' || key === 'ArrowDown';
+    const isPrevious = key === 'ArrowLeft' || key === 'ArrowUp';
+    if (!isNext && !isPrevious && key !== 'Home' && key !== 'End') {
+      return;
+    }
+    event.preventDefault();
+    const nextIndex =
+      key === 'Home'
+        ? 0
+        : key === 'End'
+          ? awsCoverageModes.length - 1
+          : (index + (isNext ? 1 : -1) + awsCoverageModes.length) % awsCoverageModes.length;
+    selectAWSCoverageMode(awsCoverageModes[nextIndex]);
+    awsCoverageOptionRefs.current[nextIndex]?.focus();
   };
 
   const handleAWSCloudFormationStart = async () => {
@@ -23933,7 +23971,9 @@ export function ProductAWSConnectPage() {
               </section>
             ) : null}
 
-            {connection && !disconnectedConnector && connectedNow ? (
+            {connection &&
+            !disconnectedConnector &&
+            (connectedNow || Boolean(connection.connector_id && !connection.disabled)) ? (
               <AWSConnectedSuccessPanel
                 scope={scope}
                 environmentID={selectedEnvironmentID}
@@ -23961,12 +24001,12 @@ export function ProductAWSConnectPage() {
                   <div className="idt-source-config-title">
                     <SourceLogoMark provider="aws" className="is-hero" />
                     <div>
-                      <p className="idt-app-kicker">{connectedNow ? 'Manage connection' : 'Connect AWS'}</p>
-                      <h3>{connectedNow ? 'Manage your AWS connection' : 'Connect your AWS environment'}</h3>
+                      <p className="idt-app-kicker">{connectedNow ? 'Manage connection' : 'Read-only setup'}</p>
+                      <h3>{connectedNow ? 'Manage this connection' : 'Connect this environment'}</h3>
                       <p>
                         {connectedNow
                           ? 'Change coverage or connection method for this environment.'
-                          : 'Connect a read-only source to begin.'}
+                          : 'Start with a scoped, read-only connection.'}
                       </p>
                     </div>
                   </div>
@@ -23995,26 +24035,36 @@ export function ProductAWSConnectPage() {
                   <div>
                     <p className="idt-app-kicker">Step 1 · Coverage</p>
                     <h3>Where should we scan?</h3>
-                    <p>Choose the AWS accounts Identrail should include.</p>
+                    <p>Choose the accounts Identrail should include.</p>
                   </div>
                   <div className="idt-aws-scope-options" role="radiogroup" aria-label="AWS coverage scope">
                     <button
-                      className={`idt-aws-scope-option ${awsSetupMode === 'organization' ? 'is-selected' : ''}`}
+                      className={`idt-aws-scope-option ${selectedAWSCoverageMode === 'organization' ? 'is-selected' : ''}`}
                       type="button"
                       role="radio"
-                      aria-checked={awsSetupMode === 'organization'}
-                      onClick={() => chooseAWSSetupMode('organization')}
+                      aria-checked={selectedAWSCoverageMode === 'organization'}
+                      tabIndex={selectedAWSCoverageMode === 'organization' ? 0 : -1}
+                      ref={(element) => {
+                        awsCoverageOptionRefs.current[0] = element;
+                      }}
+                      onKeyDown={(event) => handleAWSCoverageKeyDown(event, 0)}
+                      onClick={() => selectAWSCoverageMode('organization')}
                     >
                       <span>{AWS_SCOPE_OPTION_LABELS.organization.kicker}</span>
                       <strong>{AWS_SCOPE_OPTION_LABELS.organization.title}</strong>
                       <small>{AWS_SCOPE_OPTION_LABELS.organization.blurb}</small>
                     </button>
                     <button
-                      className={`idt-aws-scope-option ${awsSetupMode === 'cloudformation' || awsSetupMode === 'manual' ? 'is-selected' : ''}`}
+                      className={`idt-aws-scope-option ${selectedAWSCoverageMode === 'cloudformation' ? 'is-selected' : ''}`}
                       type="button"
                       role="radio"
-                      aria-checked={awsSetupMode === 'cloudformation' || awsSetupMode === 'manual'}
-                      onClick={() => chooseAWSSetupMode('cloudformation')}
+                      aria-checked={selectedAWSCoverageMode === 'cloudformation'}
+                      tabIndex={selectedAWSCoverageMode === 'cloudformation' ? 0 : -1}
+                      ref={(element) => {
+                        awsCoverageOptionRefs.current[1] = element;
+                      }}
+                      onKeyDown={(event) => handleAWSCoverageKeyDown(event, 1)}
+                      onClick={() => selectAWSCoverageMode('cloudformation')}
                     >
                       <span>{AWS_SCOPE_OPTION_LABELS.cloudformation.kicker}</span>
                       <strong>{AWS_SCOPE_OPTION_LABELS.cloudformation.title}</strong>
@@ -24022,16 +24072,17 @@ export function ProductAWSConnectPage() {
                     </button>
                     <button
                       className={`idt-aws-scope-option ${
-                        awsSetupMode === 'selected_ous' || awsSetupMode === 'selected_accounts' ? 'is-selected' : ''
+                        selectedAWSCoverageMode === 'selected_ous' ? 'is-selected' : ''
                       }`}
                       type="button"
                       role="radio"
-                      aria-checked={awsSetupMode === 'selected_ous' || awsSetupMode === 'selected_accounts'}
-                      onClick={() =>
-                        chooseAWSSetupMode(
-                          awsSetupMode === 'selected_accounts' ? 'selected_accounts' : 'selected_ous'
-                        )
-                      }
+                      aria-checked={selectedAWSCoverageMode === 'selected_ous'}
+                      tabIndex={selectedAWSCoverageMode === 'selected_ous' ? 0 : -1}
+                      ref={(element) => {
+                        awsCoverageOptionRefs.current[2] = element;
+                      }}
+                      onKeyDown={(event) => handleAWSCoverageKeyDown(event, 2)}
+                      onClick={() => selectAWSCoverageMode('selected_ous')}
                     >
                       <span>{AWS_SCOPE_OPTION_LABELS.selected_ous.kicker}</span>
                       <strong>{AWS_SCOPE_OPTION_LABELS.selected_ous.title}</strong>
@@ -24160,11 +24211,11 @@ export function ProductAWSConnectPage() {
                   <div className="idt-aws-step-body">
                     <div className="idt-aws-step-heading">
                       <div>
-                        <h4>Approve in AWS</h4>
+                        <h4>Approve the stack</h4>
                         <p>
                           {launchURL
                             ? 'Continue in AWS, approve the read-only stack, then return here.'
-                            : 'We’ll prepare a read-only CloudFormation stack in AWS.'}
+                            : 'We’ll prepare a read-only CloudFormation stack.'}
                         </p>
                       </div>
                       {cloudFormationAWSStart ? <span>Launch ready</span> : <span>Read-only</span>}
@@ -24199,7 +24250,7 @@ export function ProductAWSConnectPage() {
                           onClick={handleAWSCloudFormationStart}
                           disabled={!canSubmit}
                         >
-                          {submitting ? 'Opening AWS...' : 'Connect AWS'}
+                          {submitting ? 'Opening…' : 'Connect'}
                         </button>
                       )}
                       {awsAutoPollExhausted && activeConnectorID ? (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -23969,8 +23969,8 @@ html[data-theme='light'] .idt-app-shell-screen select {
 .idt-aws-status-grid,
 .idt-aws-connect-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(18rem, 0.65fr);
-  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.15rem;
   align-items: start;
 }
 
@@ -24149,7 +24149,17 @@ html[data-theme='light'] .idt-app-shell-screen select {
 
 .idt-aws-connect-main {
   display: grid;
+  gap: 1.15rem;
+  width: min(100%, 74rem);
+  margin: 0 auto;
+  min-width: 0;
+}
+
+.idt-aws-connect-side {
+  display: grid;
   gap: 1rem;
+  width: min(100%, 74rem);
+  margin: 0 auto;
   min-width: 0;
 }
 
@@ -24162,7 +24172,13 @@ html[data-theme='light'] .idt-app-shell-screen select {
 }
 
 .idt-aws-scope-wizard {
-  gap: 1rem;
+  gap: 1.25rem;
+  overflow: hidden;
+}
+
+.idt-aws-scope-wizard.is-first-connect {
+  border-color: rgba(126, 105, 255, 0.34);
+  box-shadow: 0 1.5rem 4rem rgba(2, 4, 18, 0.18);
 }
 
 .idt-aws-wizard-header {
@@ -24171,8 +24187,8 @@ html[data-theme='light'] .idt-app-shell-screen select {
 
 .idt-aws-scope-options {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.65rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
 }
 
 .idt-aws-scope-option-shell {
@@ -24188,15 +24204,27 @@ html[data-theme='light'] .idt-app-shell-screen select {
   display: grid;
   gap: 0.22rem;
   min-width: 0;
-  min-height: 6.4rem;
+  min-height: 7rem;
   border: 1px solid var(--app-border-soft);
-  border-radius: 8px;
-  padding: 0.72rem;
-  background: #050505;
+  border-radius: 12px;
+  padding: 0.95rem;
+  background: rgba(5, 5, 5, 0.62);
   color: var(--app-muted);
   cursor: pointer;
   font: inherit;
   text-align: left;
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.idt-aws-scope-option:hover {
+  border-color: rgba(255, 255, 255, 0.32);
+  background: rgba(17, 17, 19, 0.9);
+  transform: translateY(-1px);
+}
+
+.idt-aws-scope-option:focus-visible {
+  outline: 2px solid rgba(159, 144, 255, 0.95);
+  outline-offset: 3px;
 }
 
 .idt-aws-scope-option span,
@@ -24221,8 +24249,8 @@ html[data-theme='light'] .idt-app-shell-screen select {
 
 .idt-aws-scope-option.is-selected {
   border-color: rgba(126, 105, 255, 0.74);
-  background: #0d0b18;
-  box-shadow: inset 0 0 0 1px rgba(126, 105, 255, 0.32);
+  background: linear-gradient(145deg, rgba(20, 15, 45, 0.96), rgba(11, 10, 23, 0.96));
+  box-shadow: inset 0 0 0 1px rgba(126, 105, 255, 0.32), 0 0.6rem 1.6rem rgba(71, 52, 180, 0.12);
 }
 
 .idt-aws-scope-option.is-planned {
@@ -24277,9 +24305,104 @@ html[data-theme='light'] .idt-app-shell-screen select {
   grid-template-columns: 2rem minmax(0, 1fr);
   gap: 0.75rem;
   border: 1px solid var(--app-border-soft);
-  border-radius: 8px;
-  padding: 0.86rem;
-  background: #080809;
+  border-radius: 12px;
+  padding: 1rem;
+  background: rgba(8, 8, 9, 0.66);
+}
+
+.idt-aws-scope-question {
+  display: grid;
+  gap: 0.9rem;
+  padding-top: 0.15rem;
+}
+
+.idt-aws-scope-question h3 {
+  margin: 0;
+  color: #ffffff;
+  font-size: 1.2rem;
+}
+
+.idt-aws-scope-question > div:first-child > p:last-child {
+  margin: 0.28rem 0 0;
+  color: var(--app-muted);
+}
+
+.idt-aws-trust-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 1rem;
+  margin: -0.15rem 0 0;
+  padding: 0;
+  list-style: none;
+  color: #cfc8ff;
+  font-size: 0.84rem;
+  font-weight: 760;
+}
+
+.idt-aws-trust-list li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.idt-aws-trust-list svg {
+  color: #a79aff;
+}
+
+.idt-aws-advanced-method {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--app-border-soft);
+  padding-top: 1rem;
+}
+
+.idt-aws-advanced-method > div {
+  display: grid;
+  gap: 0.18rem;
+}
+
+.idt-aws-advanced-method strong {
+  color: #ffffff;
+}
+
+.idt-aws-advanced-method span {
+  color: var(--app-muted);
+  font-size: 0.84rem;
+}
+
+.idt-aws-advanced-method.is-active {
+  border-top-color: rgba(126, 105, 255, 0.38);
+}
+
+.idt-aws-optional {
+  color: var(--app-dim);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.idt-aws-field-label {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.idt-aws-connect-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border: 1px solid rgba(255, 153, 0, 0.32);
+  border-radius: 10px;
+  padding: 0.72rem 0.9rem;
+  background: rgba(255, 153, 0, 0.08);
+  color: #ffd08a;
+}
+
+.idt-aws-connect-notice p {
+  margin: 0;
+  color: inherit;
+  font-size: 0.86rem;
 }
 
 .idt-aws-step-index {
@@ -25413,6 +25536,15 @@ html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge
   .idt-aws-step-heading,
   .idt-aws-copy-row {
     grid-template-columns: 1fr;
+  }
+
+  .idt-aws-advanced-method {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .idt-aws-advanced-method .idt-btn {
+    width: 100%;
   }
 
   .idt-aws-step-heading {


### PR DESCRIPTION
## Summary
- simplify the first-connect AWS surface into one focused, single-column flow
- separate coverage choice from the advanced IAM-role method
- remove disconnected-state dashboard noise, duplicate setup summary, and premature AWS overview actions
- add clearer read-only trust signals, responsive behavior, and accessible radio semantics
- preserve a clear migration note for legacy role-only connections

## Verification
- `pnpm exec vitest run src/productShell.test.tsx src/App.test.tsx --reporter=dot`
- 397/397 tests passing
- `pnpm build`
- production build and 40 prerendered routes passing
- live browser QA at desktop and mobile breakpoints, including single-account, manual IAM, and organization scope states
- fixed mobile advanced-method CTA wrapping after visual review

## Scope
Frontend-only AWS connect flow and regression coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the AWS connection setup into a focused, single‑column flow that clarifies coverage and read‑only status. Updates copy, actions, and accessibility, and hides the `AWS overview` until a connection exists.

- **New Features**
  - Coverage step “Where should we scan?” with a true radiogroup and keyboard navigation (All accounts, One account, Selected scope).
  - Read‑only trust signals list: No access keys, Read‑only permissions, No workload changes.
  - Clearer copy and CTAs: “Connect this environment” and “Approve the stack”; buttons now read “Connect” and “Continue in AWS”.
  - Advanced IAM role is a separate toggle (“Use an existing IAM role” / “Use CloudFormation instead”); manual mode preserves the External ID until you switch back.
  - Disconnected notice refreshed; optional “Connection name” field with an “Optional” hint; responsive layout fixes.

- **Refactors**
  - Updated headings and labels (“Choose coverage” → “Where should we scan?”, “Connect this account” → “Approve the stack”).
  - Unified status text and badges (“Read‑only”/“Connected”) with clearer in‑progress guidance (e.g., “Continue in AWS to approve read‑only access.”).
  - Setup summary only appears during setup; side panel is conditional; `AWS overview` action appears only after connection.
  - Consolidated layout to a single column and refreshed styles; adjusted tests to new roles, labels, and CTAs.

<sup>Written for commit 51a68fe28e206f84528327e628c727730fdb984e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

