### PR TITLE
Revert "Redesign AWS connection setup"

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1840,8 +1840,8 @@ describe('App', () => {
 
     expect(await screen.findByRole('heading', { level: 2, name: /Connect AWS/i })).toBeInTheDocument();
     expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/aws/connect');
-    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /AWS overview/i })).not.toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /AWS overview/i })).toHaveAttribute('href', '/app/tenant-a/workspace-a/aws?environment=project-1');
     expect(screen.queryByLabelText('AWS source')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Source types')).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', { level: 3, name: 'AWS' })).not.toBeInTheDocument();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8332,31 +8332,14 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
-    const setup = screen.getByRole('region', { name: 'AWS account setup' });
-    expect(within(setup).getByRole('heading', { level: 3, name: 'Connect this environment' })).toBeInTheDocument();
-    expect(within(setup).queryByText('Connect your AWS environment')).not.toBeInTheDocument();
-    const coverageGroup = screen.getByRole('radiogroup', { name: 'AWS coverage scope' });
-    expect(coverageGroup).toHaveTextContent('One account');
-    expect(screen.getByRole('list', { name: 'AWS connection safeguards' })).toHaveTextContent(
-      'No access keysRead-only permissionsNo workload changes'
-    );
-    expect(within(coverageGroup).getAllByRole('radio')).toHaveLength(3);
-    expect(within(coverageGroup).getByRole('radio', { name: /One account/i })).toHaveAttribute('tabindex', '0');
-    fireEvent.keyDown(within(coverageGroup).getByRole('radio', { name: /One account/i }), { key: 'ArrowRight' });
-    expect(within(coverageGroup).getByRole('radio', { name: /OUs or accounts/i })).toHaveFocus();
-    fireEvent.keyDown(within(coverageGroup).getByRole('radio', { name: /OUs or accounts/i }), { key: 'Home' });
-    expect(within(coverageGroup).getByRole('radio', { name: /All accounts/i })).toHaveFocus();
-    fireEvent.keyDown(within(coverageGroup).getByRole('radio', { name: /All accounts/i }), { key: 'ArrowRight' });
-    expect(within(coverageGroup).getByRole('radio', { name: /One account/i })).toHaveFocus();
-    expect(screen.queryByRole('region', { name: 'AWS setup summary' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /AWS overview/i })).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
+  expect(screen.getByRole('list', { name: 'AWS setup scope options' })).toHaveTextContent('This AWS account');
+  expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
   expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('Connection name'), { target: { value: 'Production AWS' } });
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Production AWS' } });
     fireEvent.change(screen.getByLabelText('Home region'), { target: { value: 'ap-south-1' } });
-    fireEvent.click(within(setup).getByRole('button', { name: /^Connect$/i }));
+    fireEvent.click(screen.getAllByRole('button', { name: /Connect AWS/i })[0]);
 
     await waitFor(() =>
       expect(api.apiClient.startAWSConnector).toHaveBeenCalledWith(
@@ -8369,7 +8352,7 @@ describe('Domain-first app routes', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
-    expect(await screen.findAllByRole('link', { name: /^Continue in AWS$/i })).toHaveLength(1);
+  expect(await screen.findAllByRole('link', { name: /^Open AWS$/i })).toHaveLength(1);
     expect(screen.getByLabelText('Role ARN')).toHaveValue('');
   });
 
@@ -8440,8 +8423,8 @@ describe('Domain-first app routes', () => {
 
     const setup = await screen.findByRole('region', { name: 'AWS account setup' });
     expect(screen.getByRole('region', { name: 'AWS connector disconnected' })).toBeInTheDocument();
-    expect(screen.getByLabelText('Connection name')).toHaveValue('');
-    fireEvent.click(within(setup).getByRole('button', { name: /^Connect$/i }));
+    expect(screen.getByLabelText('Display name')).toHaveValue('');
+    fireEvent.click(within(setup).getByRole('button', { name: /^Connect AWS$/i }));
 
     await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
     expect(startAWSConnector.mock.calls[0]?.[0]).toMatchObject({
@@ -8560,7 +8543,7 @@ describe('Domain-first app routes', () => {
     const summary = await screen.findByRole('region', { name: 'AWS connected summary' });
     fireEvent.click(within(summary).getByRole('button', { name: /Manage connection/i }));
     const setup = await screen.findByRole('region', { name: 'AWS account setup' });
-    fireEvent.click(within(setup).getByRole('button', { name: /^Connect$/i }));
+    fireEvent.click(within(setup).getByRole('button', { name: /^Connect AWS$/i }));
     await waitFor(() => expect(startAWSConnector).toHaveBeenCalledTimes(1));
 
     fireEvent.click(within(screen.getByRole('region', { name: 'AWS connected summary' })).getByRole('button', { name: /^Disconnect$/i }));
@@ -8691,8 +8674,8 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click((await screen.findAllByRole('button', { name: /^Connect$/i }))[0]);
-    expect(await screen.findAllByRole('link', { name: /^Continue in AWS$/i })).toHaveLength(1);
+    fireEvent.click((await screen.findAllByRole('button', { name: /Connect AWS/i }))[0]);
+  expect(await screen.findAllByRole('link', { name: /^Open AWS$/i })).toHaveLength(1);
 
     fireEvent.click(screen.getByRole('button', { name: /Existing IAM role/i }));
 
@@ -8791,7 +8774,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
 
@@ -8913,7 +8896,7 @@ describe('Domain-first app routes', () => {
     );
   });
 
-  it('keeps manual setup intact until the explicit CloudFormation control is used', async () => {
+  it('lets operators return to CloudFormation after generating a manual External ID', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
     const api = await import('./api/client');
@@ -8977,17 +8960,10 @@ describe('Domain-first app routes', () => {
     fireEvent.click(screen.getByRole('button', { name: /Generate External ID/i }));
     expect(await screen.findByLabelText('External ID')).toHaveValue('manual-external-id-to-clear');
 
-    const singleAccountCoverage = screen.getByRole('radio', { name: /One account/i });
-    expect(singleAccountCoverage).toHaveAttribute('aria-checked', 'true');
-    fireEvent.click(singleAccountCoverage);
+    fireEvent.click(screen.getByRole('button', { name: /This AWS account/i }));
 
-    expect(screen.getByRole('heading', { level: 4, name: /Use an existing IAM role/i })).toBeInTheDocument();
-    expect(screen.getByLabelText('External ID')).toHaveValue('manual-external-id-to-clear');
-
-    fireEvent.click(screen.getByRole('button', { name: /Use CloudFormation instead/i }));
-
-    expect(screen.getByRole('heading', { level: 4, name: /Approve the stack/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^Connect$/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 4, name: /Connect this account/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Connect AWS/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue('manual-external-id-to-clear')).not.toBeInTheDocument();
   });
@@ -9153,7 +9129,7 @@ describe('Domain-first app routes', () => {
 
     expect(screen.getByRole('heading', { level: 4, name: /Use an existing IAM role/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Generate External ID/i })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /^Connect$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Connect AWS/i })).not.toBeInTheDocument();
   });
 
   it('clears manual AWS setup secrets when switching environments', async () => {
@@ -9276,11 +9252,11 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 4, name: /Approve the stack/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 4, name: /Connect this account/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /^Connect$/i }));
+    fireEvent.click(screen.getAllByRole('button', { name: /Connect AWS/i })[0]);
 
     expect(await screen.findAllByText(/AWS account connection is not enabled for this deployment/i)).toHaveLength(1);
     expect(upsertAWSProjectConnection).not.toHaveBeenCalled();
@@ -9371,8 +9347,6 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    const lifecycleSummary = await screen.findByRole('region', { name: 'AWS connected summary' });
-    expect(within(lifecycleSummary).getByRole('button', { name: /^Disconnect$/i })).toBeInTheDocument();
     expect(await screen.findByRole('heading', { name: /Next setup action/i })).toBeInTheDocument();
     expect(screen.getByText(/Primary blocker/i)).toBeInTheDocument();
     const repairList = screen.getByLabelText('AWS guided repair actions');
@@ -9492,7 +9466,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click((await screen.findAllByRole('button', { name: /^Connect$/i }))[0]);
+    fireEvent.click((await screen.findAllByRole('button', { name: /Connect AWS/i }))[0]);
 
     expect(await screen.findAllByText('project not found')).toHaveLength(1);
     expect(screen.queryByText(/AWS account connection is not enabled for this deployment/i)).not.toBeInTheDocument();
@@ -9533,7 +9507,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click((await screen.findAllByRole('button', { name: /^Connect$/i }))[0]);
+    fireEvent.click((await screen.findAllByRole('button', { name: /Connect AWS/i }))[0]);
 
     expect(await screen.findAllByText(/AWS CloudFormation setup is not configured for this deployment/i)).toHaveLength(1);
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
@@ -9626,7 +9600,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
     expect(screen.getByRole('heading', { level: 4, name: /Set the coverage scope/i })).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/Target regions/i), { target: { value: 'us-east-1, us-west-2' } });
@@ -9733,7 +9707,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /Selected scope/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
     fireEvent.change(screen.getByLabelText(/Target OU IDs/i), { target: { value: 'ou-1234-abcd5678' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -9825,7 +9799,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /Selected scope/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
     fireEvent.click(screen.getByRole('tab', { name: /Account IDs/i }));
     fireEvent.change(screen.getByLabelText(/Target account IDs/i), {
       target: { value: '111111111111, 222222222222' }
@@ -9881,7 +9855,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /Selected scope/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
     fireEvent.click(screen.getByRole('tab', { name: /Account IDs/i }));
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -9972,7 +9946,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10060,7 +10034,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10110,7 +10084,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10213,7 +10187,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10292,7 +10266,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /Selected scope/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Selected scope/i }));
     fireEvent.change(screen.getByLabelText(/Target OU IDs/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10377,7 +10351,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10423,11 +10397,11 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
-    fireEvent.click(screen.getByRole('radio', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
 
     await act(async () => {
       pendingStart.resolve({
@@ -10625,7 +10599,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -10837,7 +10811,7 @@ describe('Domain-first app routes', () => {
     // Kick off a fresh StackSet setup in staging — the hidden StackSet name
     // must come from the wizard default, not leak from the production
     // environment's custom name.
-    fireEvent.click(screen.getByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(screen.getByRole('button', { name: /AWS Organization/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -11145,7 +11119,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
 
@@ -11221,7 +11195,7 @@ describe('Domain-first app routes', () => {
 
     await openAWSConnectionManagement();
     expect(await screen.findByText(/Persisted organization recovery action/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('radio', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
     expect(screen.queryByText(/Persisted organization recovery action/i)).not.toBeInTheDocument();
   });
 
@@ -11287,7 +11261,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /AWS Organization/i }));
     fireEvent.change(screen.getByLabelText(/Organization root ID/i), { target: { value: 'r-abcd' } });
     fireEvent.change(screen.getByLabelText(/Target regions/i), { target: { value: 'us-east-1, us-west-2' } });
     fireEvent.click(screen.getByRole('button', { name: /Launch StackSet setup/i }));
@@ -11367,11 +11341,11 @@ describe('Domain-first app routes', () => {
     const initialCallCount = getStackSetOnboarding.mock.calls.length;
 
     // Switch away from the connector's scope.
-    fireEvent.click(screen.getByRole('radio', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
     expect(screen.queryByText(/Persisted recovery action to restore/i)).not.toBeInTheDocument();
 
     // Switch back to the connector's scope — panel should reappear via a fresh refetch.
-    fireEvent.click(screen.getByRole('radio', { name: /All accounts/i }));
+    fireEvent.click(screen.getByRole('button', { name: /AWS Organization/i }));
     expect(await screen.findByText(/Persisted recovery action to restore/i)).toBeInTheDocument();
     expect(getStackSetOnboarding.mock.calls.length).toBeGreaterThan(initialCallCount);
   });
@@ -11425,7 +11399,7 @@ describe('Domain-first app routes', () => {
     await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
 
-    fireEvent.click(screen.getByRole('radio', { name: /One account/i }));
+    fireEvent.click(screen.getByRole('button', { name: /This AWS account/i }));
 
     // Under Single account, the persisted StackSet launch URL must not surface.
     const links = screen.queryAllByRole('link', { name: /Open AWS|Open StackSet(?: in AWS)?/i });
@@ -11481,7 +11455,7 @@ describe('Domain-first app routes', () => {
 
     await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
-    fireEvent.click(screen.getByRole('radio', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
 
     // Selected OUs shares the stackset_ deployment method with organization,
     // but the scope type differs — the persisted URL must not leak through.
@@ -11753,7 +11727,7 @@ describe('Domain-first app routes', () => {
     await openAWSConnectionManagement();
     await screen.findByRole('region', { name: /StackSet onboarding progress/i });
 
-    fireEvent.click(screen.getByRole('radio', { name: /Selected scope/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Selected scope/i }));
     fireEvent.change(await screen.findByLabelText(/Target OU IDs/i), {
       target: { value: 'ou-1234-abcd5678' }
     });
@@ -11962,9 +11936,9 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByRole('region', { name: 'AWS connected summary' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /Manage connection/i }));
-    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /^Validate role$/i })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /^Validate role$/i })).not.toBeInTheDocument();
     expect(screen.getByText(/Start CloudFormation setup to move it onto the connector flow/i)).toBeInTheDocument();
     expect(validateAWSConnector).not.toHaveBeenCalled();
   });
@@ -12539,10 +12513,10 @@ describe('Domain-first app routes', () => {
       });
     });
 
-    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Role ARN')).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Connection name')).toHaveValue('');
+    expect(screen.getByLabelText('Display name')).toHaveValue('');
     expect(screen.getByLabelText('Home region')).toHaveValue('us-east-1');
 
     await act(async () => {
@@ -12595,7 +12569,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    const launchButton = (await screen.findAllByRole('button', { name: /^Connect$/i }))[0];
+    const launchButton = (await screen.findAllByRole('button', { name: /Connect AWS/i }))[0];
     fireEvent.click(launchButton);
     await waitFor(() =>
       expect(api.apiClient.startAWSConnector).toHaveBeenCalledWith(
@@ -12685,7 +12659,7 @@ describe('Domain-first app routes', () => {
     );
 
     await openAWSConnectionManagement();
-    expect(await screen.findByRole('heading', { level: 3, name: /Where should we scan?/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /Choose coverage/i })).toBeInTheDocument();
     const refreshButton = within(screen.getByLabelText('AWS account setup')).getByRole('button', {
       name: /Refresh/i
     });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8,7 +8,6 @@ import type {
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router';
 import {
   BarChart3,
-  Check,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
@@ -651,27 +650,27 @@ function stackSetContractsMatch(a: AWSStackSetContractSnapshot, b: AWSStackSetCo
 
 const AWS_SCOPE_OPTION_LABELS: Record<AWSSetupMode, { title: string; kicker: string; blurb: string }> = {
   cloudformation: {
-    kicker: 'This account',
-    title: 'One account',
-    blurb: 'Recommended · CloudFormation'
+    kicker: 'Single account',
+    title: 'This AWS account',
+    blurb: 'One-click CloudFormation'
   },
   organization: {
-    kicker: 'Organization',
+    kicker: 'AWS Organization',
     title: 'All accounts',
-    blurb: 'Best for teams'
+    blurb: 'Recommended for teams'
   },
   selected_ous: {
-    kicker: 'Selected scope',
-    title: 'OUs or accounts',
-    blurb: 'Choose a subset'
+    kicker: 'Selected OUs',
+    title: 'Chosen OUs',
+    blurb: 'Pick OUs to onboard'
   },
   selected_accounts: {
-    kicker: 'Selected scope',
-    title: 'OUs or accounts',
-    blurb: 'Choose a subset'
+    kicker: 'Selected accounts',
+    title: 'Chosen accounts',
+    blurb: 'Pick accounts to onboard'
   },
   manual: {
-    kicker: 'Advanced setup',
+    kicker: 'Advanced',
     title: 'Existing IAM role',
     blurb: 'Use your change process'
   }
@@ -22262,7 +22261,6 @@ export function ProductAWSConnectPage() {
   const awsLifecycleRequestRef = useRef(0);
   const awsSetupModeTouchedRef = useRef(false);
   const awsSetupModeRef = useRef<AWSSetupMode>('cloudformation');
-  const awsCoverageOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const awsCloudFormationStartRef = useRef<AWSConnectorStartResponse | null>(null);
   awsCloudFormationStartRef.current = awsCloudFormationStart;
   const activeConnectorIDRef = useRef('');
@@ -23039,9 +23037,6 @@ export function ProductAWSConnectPage() {
 
   const chooseAWSSetupMode = (mode: AWSSetupMode) => {
     const previousMode = awsSetupModeRef.current;
-    if (previousMode === mode) {
-      return;
-    }
     awsSetupModeTouchedRef.current = true;
     awsSetupModeRef.current = mode;
     setAWSSetupMode(mode);
@@ -23081,40 +23076,6 @@ export function ProductAWSConnectPage() {
     setErrorMessage('');
     setSuccessMessage('');
     setAWSCopiedField('');
-  };
-
-  const awsCoverageModes: AWSSetupMode[] = ['organization', 'cloudformation', 'selected_ous'];
-  const selectedAWSCoverageMode: AWSSetupMode =
-    awsSetupMode === 'manual' ? 'cloudformation' : awsSetupMode === 'selected_accounts' ? 'selected_ous' : awsSetupMode;
-  const selectAWSCoverageMode = (mode: AWSSetupMode) => {
-    // Manual IAM setup intentionally shares the single-account coverage
-    // choice. Its separate method control is the only way back to
-    // CloudFormation, so clicking the already-checked coverage radio must be
-    // a no-op and must not clear the prepared External ID.
-    if (mode === 'cloudformation' && awsSetupMode === 'manual') {
-      return;
-    }
-    if (mode === 'selected_ous' && awsSetupMode === 'selected_accounts') {
-      return;
-    }
-    chooseAWSSetupMode(mode);
-  };
-  const handleAWSCoverageKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>, index: number) => {
-    const key = event.key;
-    const isNext = key === 'ArrowRight' || key === 'ArrowDown';
-    const isPrevious = key === 'ArrowLeft' || key === 'ArrowUp';
-    if (!isNext && !isPrevious && key !== 'Home' && key !== 'End') {
-      return;
-    }
-    event.preventDefault();
-    const nextIndex =
-      key === 'Home'
-        ? 0
-        : key === 'End'
-          ? awsCoverageModes.length - 1
-          : (index + (isNext ? 1 : -1) + awsCoverageModes.length) % awsCoverageModes.length;
-    selectAWSCoverageMode(awsCoverageModes[nextIndex]);
-    awsCoverageOptionRefs.current[nextIndex]?.focus();
   };
 
   const handleAWSCloudFormationStart = async () => {
@@ -23662,14 +23623,7 @@ export function ProductAWSConnectPage() {
       return 'Pick an environment to connect.';
     }
     if (!connectedNow) {
-      const setupStatus = connection?.onboarding_status ?? awsCloudFormationStart?.onboarding_status;
-      if (setupStatus === 'waiting_for_aws' || setupStatus === 'launch_ready') {
-        return 'Continue in AWS to approve read-only access.';
-      }
-      if (setupStatus === 'registering' || setupStatus === 'validating') {
-        return 'Verifying read-only access for this environment.';
-      }
-      return 'Read-only access to identity and workload metadata.';
+      return 'Not connected for this environment.';
     }
     const bits: string[] = [];
     if (connection?.account_id) {
@@ -23833,7 +23787,7 @@ export function ProductAWSConnectPage() {
       return 'AWS is connected';
     }
     if (onboardingStatus === 'launch_ready') {
-      return 'Continue in AWS';
+      return 'Open the AWS stack';
     }
     if (onboardingStatus === 'waiting_for_aws') {
       return 'Waiting for approval';
@@ -23866,7 +23820,7 @@ export function ProductAWSConnectPage() {
       return 'This connector uses a self-managed StackSet. Manage it through the API, Terraform, or the AWS console — the wizard cannot relaunch self-managed setups.';
     }
     if (isStackSetSetup && stackSetAWSStart?.launch_url && stackSetBlockingPrereqCount === 0) {
-      return 'Continue in AWS to deploy the read-only role, then return here for verification.';
+      return 'Open the StackSet in AWS to deploy the read-only role, then refresh status.';
     }
     if (isStackSetSetup && stackSetAWSStart?.launch_url && stackSetBlockingPrereqCount > 0) {
       return 'Resolve the blocking StackSet prerequisites, then open the StackSet in AWS.';
@@ -23878,7 +23832,7 @@ export function ProductAWSConnectPage() {
       return connection.setup_summary;
     }
     if (launchURL) {
-      return 'Approve the read-only stack in AWS, then return here. Identrail will verify the connection automatically.';
+      return 'Approve the stack in AWS. Identrail will verify the connection automatically.';
     }
     if (hasConnectorSetup) {
       return 'Identrail is waiting for AWS.';
@@ -23886,9 +23840,7 @@ export function ProductAWSConnectPage() {
     return 'Create one read-only CloudFormation stack for this environment.';
   })();
   const onboardingInProgress = ['launch_ready', 'waiting_for_aws', 'registering', 'validating'].includes(onboardingStatus);
-  const showSetupSummary =
-    !connectedNow &&
-    (onboardingInProgress || Boolean(awsCloudFormationStart || awsStackSetOnboarding || manualAWSStart));
+  const wizardHealth = connection?.health_status;
 
   return (
     <DomainPageShell
@@ -23901,7 +23853,7 @@ export function ProductAWSConnectPage() {
       scope={<ProductEnvironmentSelector state={environmentScope} onChange={handleEnvironmentChange} />}
       statusTone={statusTone}
       primaryAction={
-        awaitingFirstConnectLoad || !connectedNow
+        awaitingFirstConnectLoad
           ? undefined
           : { label: 'AWS overview', to: controlPath, variant: 'primary' as const }
       }
@@ -23965,9 +23917,15 @@ export function ProductAWSConnectPage() {
             ) : null}
 
             {disconnectedConnector ? (
-              <section className="idt-aws-connect-notice" aria-label="AWS connector disconnected">
-                <DomainStatusBadge variant="disconnected" label="Disconnected" />
-                <p>Reconnect with a fresh read-only setup. Provider cleanup remains pending until it is verified.</p>
+              <section className="idt-source-config idt-aws-connect-panel" aria-label="AWS connector disconnected">
+                <div className="idt-source-config-header">
+                  <div>
+                    <p className="idt-app-kicker">Disconnected</p>
+                    <h3>AWS connector is disconnected</h3>
+                    <p>New scans are stopped and provider cleanup remains pending until it is verified.</p>
+                  </div>
+                  <DomainStatusBadge variant="disconnected" detail="disconnected" />
+                </div>
               </section>
             ) : null}
 
@@ -23991,165 +23949,117 @@ export function ProductAWSConnectPage() {
             ) : null}
 
             {showAWSSetupControls ? (
-              <section
-                className={`idt-source-config idt-aws-connect-panel idt-aws-scope-wizard ${
-                  connectedNow ? 'is-manage-mode' : 'is-first-connect'
-                }`}
-                aria-label="AWS account setup"
-              >
+              <section className="idt-source-config idt-aws-connect-panel idt-aws-scope-wizard" aria-label="AWS account setup">
                 <div className="idt-source-config-header idt-aws-wizard-header">
                   <div className="idt-source-config-title">
                     <SourceLogoMark provider="aws" className="is-hero" />
                     <div>
-                      <p className="idt-app-kicker">{connectedNow ? 'Manage connection' : 'Read-only setup'}</p>
-                      <h3>{connectedNow ? 'Manage this connection' : 'Connect this environment'}</h3>
-                      <p>
-                        {connectedNow
-                          ? 'Change coverage or connection method for this environment.'
-                          : 'Start with a scoped, read-only connection.'}
-                      </p>
+                      <h3>Choose coverage</h3>
+                      <p>Connect one account or select a broader scope.</p>
                     </div>
                   </div>
                   <DomainStatusBadge
                     variant={onboardingInProgress ? 'running-scan' : awsStatusVariant(connection)}
-                    label={onboardingInProgress ? 'Connecting' : connectedNow ? 'Connected' : 'Read-only'}
-                    detail={onboardingInProgress ? setupSummaryTitle : undefined}
+                    label={onboardingInProgress ? 'Connecting' : undefined}
+                    detail={onboardingInProgress ? setupSummaryTitle : wizardHealth && wizardHealth !== 'unknown' ? wizardHealth : undefined}
                   />
                 </div>
 
-                {hasRoleOnlyConnection ? (
-                  <p className="idt-aws-setup-note idt-aws-legacy-role-note">
-                    Start CloudFormation setup to move it onto the connector flow.
-                  </p>
-                ) : null}
+                <div className="idt-aws-scope-options" role="list" aria-label="AWS setup scope options">
+              <div className="idt-aws-scope-option-shell" role="listitem">
+                <button
+                  className={`idt-aws-scope-option ${awsSetupMode === 'organization' ? 'is-selected' : ''}`}
+                  type="button"
+                  aria-current={awsSetupMode === 'organization' ? 'true' : undefined}
+                  onClick={() => chooseAWSSetupMode('organization')}
+                >
+                  <span>{AWS_SCOPE_OPTION_LABELS.organization.kicker}</span>
+                  <strong>{AWS_SCOPE_OPTION_LABELS.organization.title}</strong>
+                  <small>{AWS_SCOPE_OPTION_LABELS.organization.blurb}</small>
+                </button>
+              </div>
+              <div className="idt-aws-scope-option-shell" role="listitem">
+                <button
+                  className={`idt-aws-scope-option ${awsSetupMode === 'cloudformation' ? 'is-selected' : ''}`}
+                  type="button"
+                  aria-current={awsSetupMode === 'cloudformation' ? 'true' : undefined}
+                  onClick={() => chooseAWSSetupMode('cloudformation')}
+                >
+                  <span>{AWS_SCOPE_OPTION_LABELS.cloudformation.kicker}</span>
+                  <strong>{AWS_SCOPE_OPTION_LABELS.cloudformation.title}</strong>
+                  <small>{AWS_SCOPE_OPTION_LABELS.cloudformation.blurb}</small>
+                </button>
+              </div>
+              <div className="idt-aws-scope-option-shell" role="listitem">
+                <button
+                  className={`idt-aws-scope-option ${
+                    awsSetupMode === 'selected_ous' || awsSetupMode === 'selected_accounts' ? 'is-selected' : ''
+                  }`}
+                  type="button"
+                  aria-current={
+                    awsSetupMode === 'selected_ous' || awsSetupMode === 'selected_accounts' ? 'true' : undefined
+                  }
+                  onClick={() =>
+                    chooseAWSSetupMode(
+                      awsSetupMode === 'selected_accounts' ? 'selected_accounts' : 'selected_ous'
+                    )
+                  }
+                >
+                  <span>Selected scope</span>
+                  <strong>OUs or accounts</strong>
+                  <small>Pick a subset</small>
+                </button>
+              </div>
+              <div className="idt-aws-scope-option-shell" role="listitem">
+                <button
+                  className={`idt-aws-scope-option ${awsSetupMode === 'manual' ? 'is-selected' : ''}`}
+                  type="button"
+                  aria-current={awsSetupMode === 'manual' ? 'true' : undefined}
+                  onClick={() => chooseAWSSetupMode('manual')}
+                >
+                  <span>{AWS_SCOPE_OPTION_LABELS.manual.kicker}</span>
+                  <strong>{AWS_SCOPE_OPTION_LABELS.manual.title}</strong>
+                  <small>{AWS_SCOPE_OPTION_LABELS.manual.blurb}</small>
+                </button>
+              </div>
+            </div>
 
-                {!connectedNow ? (
-                  <ul className="idt-aws-trust-list" aria-label="AWS connection safeguards">
-                    <li><Check size={15} strokeWidth={2.2} aria-hidden="true" />No access keys</li>
-                    <li><Check size={15} strokeWidth={2.2} aria-hidden="true" />Read-only permissions</li>
-                    <li><Check size={15} strokeWidth={2.2} aria-hidden="true" />No workload changes</li>
-                  </ul>
-                ) : null}
-
-                <div className="idt-aws-scope-question">
-                  <div>
-                    <p className="idt-app-kicker">Step 1 · Coverage</p>
-                    <h3>Where should we scan?</h3>
-                    <p>Choose the accounts Identrail should include.</p>
-                  </div>
-                  <div className="idt-aws-scope-options" role="radiogroup" aria-label="AWS coverage scope">
-                    <button
-                      className={`idt-aws-scope-option ${selectedAWSCoverageMode === 'organization' ? 'is-selected' : ''}`}
-                      type="button"
-                      role="radio"
-                      aria-checked={selectedAWSCoverageMode === 'organization'}
-                      tabIndex={selectedAWSCoverageMode === 'organization' ? 0 : -1}
-                      ref={(element) => {
-                        awsCoverageOptionRefs.current[0] = element;
-                      }}
-                      onKeyDown={(event) => handleAWSCoverageKeyDown(event, 0)}
-                      onClick={() => selectAWSCoverageMode('organization')}
-                    >
-                      <span>{AWS_SCOPE_OPTION_LABELS.organization.kicker}</span>
-                      <strong>{AWS_SCOPE_OPTION_LABELS.organization.title}</strong>
-                      <small>{AWS_SCOPE_OPTION_LABELS.organization.blurb}</small>
-                    </button>
-                    <button
-                      className={`idt-aws-scope-option ${selectedAWSCoverageMode === 'cloudformation' ? 'is-selected' : ''}`}
-                      type="button"
-                      role="radio"
-                      aria-checked={selectedAWSCoverageMode === 'cloudformation'}
-                      tabIndex={selectedAWSCoverageMode === 'cloudformation' ? 0 : -1}
-                      ref={(element) => {
-                        awsCoverageOptionRefs.current[1] = element;
-                      }}
-                      onKeyDown={(event) => handleAWSCoverageKeyDown(event, 1)}
-                      onClick={() => selectAWSCoverageMode('cloudformation')}
-                    >
-                      <span>{AWS_SCOPE_OPTION_LABELS.cloudformation.kicker}</span>
-                      <strong>{AWS_SCOPE_OPTION_LABELS.cloudformation.title}</strong>
-                      <small>{AWS_SCOPE_OPTION_LABELS.cloudformation.blurb}</small>
-                    </button>
-                    <button
-                      className={`idt-aws-scope-option ${
-                        selectedAWSCoverageMode === 'selected_ous' ? 'is-selected' : ''
-                      }`}
-                      type="button"
-                      role="radio"
-                      aria-checked={selectedAWSCoverageMode === 'selected_ous'}
-                      tabIndex={selectedAWSCoverageMode === 'selected_ous' ? 0 : -1}
-                      ref={(element) => {
-                        awsCoverageOptionRefs.current[2] = element;
-                      }}
-                      onKeyDown={(event) => handleAWSCoverageKeyDown(event, 2)}
-                      onClick={() => selectAWSCoverageMode('selected_ous')}
-                    >
-                      <span>{AWS_SCOPE_OPTION_LABELS.selected_ous.kicker}</span>
-                      <strong>{AWS_SCOPE_OPTION_LABELS.selected_ous.title}</strong>
-                      <small>{AWS_SCOPE_OPTION_LABELS.selected_ous.blurb}</small>
-                    </button>
-                  </div>
-                </div>
-
-                <div className={`idt-aws-advanced-method ${awsSetupMode === 'manual' ? 'is-active' : ''}`}>
-                  <div>
-                    <strong>{AWS_SCOPE_OPTION_LABELS.manual.title}</strong>
-                    <span>
-                      {awsSetupMode === 'manual'
-                        ? 'Using your existing IAM role and change process.'
-                        : 'For teams that manage IAM outside Identrail.'}
-                    </span>
-                  </div>
-                  <button
-                    className="idt-btn idt-btn-ghost"
-                    type="button"
-                    onClick={() => chooseAWSSetupMode(awsSetupMode === 'manual' ? 'cloudformation' : 'manual')}
-                  >
-                    {awsSetupMode === 'manual' ? 'Use CloudFormation instead' : 'Use an existing IAM role'}
-                  </button>
-                </div>
-
-                <form className="idt-app-form idt-aws-connect-form" onSubmit={handleAWSSubmit}>
-                  <div className="idt-aws-wizard-step">
-                    <div className="idt-aws-step-index" aria-hidden="true">1</div>
-                    <div className="idt-aws-step-body">
-                      <div className="idt-aws-step-heading">
-                        <div>
-                          <h4>Connection details</h4>
-                          <p>Give this connection a name your team will recognize.</p>
-                        </div>
-                        <span>{selectedAWSRegion}</span>
-                      </div>
-                      <div className="idt-source-inline-fields">
-                        <label>
-                          <span className="idt-aws-field-label">
-                            Connection name <span className="idt-aws-optional" aria-hidden="true">Optional</span>
-                          </span>
-                          <input
-                            aria-label="Connection name"
-                            value={awsForm.displayName}
-                            onChange={(event) =>
-                              setAWSForm((current) => ({ ...current, displayName: event.target.value }))
-                            }
-                            placeholder="Production AWS"
-                          />
-                        </label>
-                        {!isStackSetSetup ? (
-                          <label>
-                            Home region
-                            <input
-                              value={awsForm.region}
-                              onChange={(event) =>
-                                setAWSForm((current) => ({ ...current, region: event.target.value }))
-                              }
-                              placeholder="us-east-1"
-                              pattern="[a-z]{2}(-gov)?-[a-z]+-[0-9]"
-                            />
-                          </label>
-                        ) : null}
-                      </div>
+            <form className="idt-app-form idt-aws-connect-form" onSubmit={handleAWSSubmit}>
+              <div className="idt-aws-wizard-step">
+                <div className="idt-aws-step-index" aria-hidden="true">1</div>
+                <div className="idt-aws-step-body">
+                  <div className="idt-aws-step-heading">
+                    <div>
+                      <h4>Name the account</h4>
+                      <p>Use a name your team will recognize.</p>
                     </div>
+                    <span>{selectedAWSRegion}</span>
                   </div>
+                  <div className="idt-source-inline-fields">
+                    <label>
+                      Display name
+                      <input
+                        value={awsForm.displayName}
+                        onChange={(event) => setAWSForm((current) => ({ ...current, displayName: event.target.value }))}
+                        placeholder="Production AWS"
+                      />
+                    </label>
+                    {!isStackSetSetup ? (
+                      <label>
+                        Home region
+                        <input
+                          value={awsForm.region}
+                          onChange={(event) =>
+                            setAWSForm((current) => ({ ...current, region: event.target.value }))
+                          }
+                          placeholder="us-east-1"
+                          pattern="[a-z]{2}(-gov)?-[a-z]+-[0-9]"
+                        />
+                      </label>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
 
               {isStackSetSetup ? (
                 <AWSStackSetScopeStep
@@ -24211,18 +24121,12 @@ export function ProductAWSConnectPage() {
                   <div className="idt-aws-step-body">
                     <div className="idt-aws-step-heading">
                       <div>
-                        <h4>Approve the stack</h4>
-                        <p>
-                          {launchURL
-                            ? 'Continue in AWS, approve the read-only stack, then return here.'
-                            : 'We’ll prepare a read-only CloudFormation stack.'}
-                        </p>
+            <h4>Connect this account</h4>
+            <p>Approve one read-only CloudFormation stack in AWS.</p>
                       </div>
                       {cloudFormationAWSStart ? <span>Launch ready</span> : <span>Read-only</span>}
                     </div>
-                    <p className="idt-aws-access-note">
-                      Reads identity and workload metadata. Cannot write, delete, or remediate.
-                    </p>
+          <p className="idt-aws-access-note">Reads identity and workload metadata. Cannot write, delete, or remediate.</p>
                     {awsSetupMessage ? (
                       <p role="status" className="idt-aws-setup-note">
                         {awsSetupMessage}
@@ -24241,7 +24145,7 @@ export function ProductAWSConnectPage() {
                           target="_blank"
                           rel="noreferrer"
                         >
-                          Continue in AWS
+                          Open AWS
                         </a>
                       ) : (
                         <button
@@ -24250,7 +24154,7 @@ export function ProductAWSConnectPage() {
                           onClick={handleAWSCloudFormationStart}
                           disabled={!canSubmit}
                         >
-                          {submitting ? 'Opening…' : 'Connect'}
+                          {submitting ? 'Opening AWS...' : 'Connect AWS'}
                         </button>
                       )}
                       {awsAutoPollExhausted && activeConnectorID ? (
@@ -24419,7 +24323,7 @@ export function ProductAWSConnectPage() {
                   </div>
                 </div>
               ) : null}
-                </form>
+            </form>
             {isStackSetSetup && (stackSetAWSStart || awsStackSetOnboarding) ? (
               <AWSStackSetProgressPanel
                 start={stackSetAWSStart}
@@ -24460,10 +24364,8 @@ export function ProductAWSConnectPage() {
             ) : null}
           </div>
 
-          {showSetupSummary || guidedRepairItems.length > 0 || showOperationalPanels ? (
           <div className="idt-aws-connect-side">
-            {showSetupSummary ? (
-              <section className="idt-source-config idt-aws-connect-summary" aria-label="AWS setup summary">
+            <section className="idt-source-config idt-aws-connect-summary" aria-label="AWS setup summary">
               <p className="idt-app-kicker">Setup</p>
               <h3>{setupSummaryTitle}</h3>
               <dl className="idt-source-meta">
@@ -24494,8 +24396,7 @@ export function ProductAWSConnectPage() {
                   </a>
         ) : null}
               </div>
-              </section>
-            ) : null}
+            </section>
 
       {guidedRepairItems.length > 0 ? (
               <DomainStatusPanel
@@ -24554,7 +24455,6 @@ export function ProductAWSConnectPage() {
             ) : null}
 
           </div>
-          ) : null}
         </div>
       ) : null}
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -23969,8 +23969,8 @@ html[data-theme='light'] .idt-app-shell-screen select {
 .idt-aws-status-grid,
 .idt-aws-connect-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1.15rem;
+  grid-template-columns: minmax(0, 1.05fr) minmax(18rem, 0.65fr);
+  gap: 1rem;
   align-items: start;
 }
 
@@ -24149,17 +24149,7 @@ html[data-theme='light'] .idt-app-shell-screen select {
 
 .idt-aws-connect-main {
   display: grid;
-  gap: 1.15rem;
-  width: min(100%, 74rem);
-  margin: 0 auto;
-  min-width: 0;
-}
-
-.idt-aws-connect-side {
-  display: grid;
   gap: 1rem;
-  width: min(100%, 74rem);
-  margin: 0 auto;
   min-width: 0;
 }
 
@@ -24172,13 +24162,7 @@ html[data-theme='light'] .idt-app-shell-screen select {
 }
 
 .idt-aws-scope-wizard {
-  gap: 1.25rem;
-  overflow: hidden;
-}
-
-.idt-aws-scope-wizard.is-first-connect {
-  border-color: rgba(126, 105, 255, 0.34);
-  box-shadow: 0 1.5rem 4rem rgba(2, 4, 18, 0.18);
+  gap: 1rem;
 }
 
 .idt-aws-wizard-header {
@@ -24187,8 +24171,8 @@ html[data-theme='light'] .idt-app-shell-screen select {
 
 .idt-aws-scope-options {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.65rem;
 }
 
 .idt-aws-scope-option-shell {
@@ -24204,27 +24188,15 @@ html[data-theme='light'] .idt-app-shell-screen select {
   display: grid;
   gap: 0.22rem;
   min-width: 0;
-  min-height: 7rem;
+  min-height: 6.4rem;
   border: 1px solid var(--app-border-soft);
-  border-radius: 12px;
-  padding: 0.95rem;
-  background: rgba(5, 5, 5, 0.62);
+  border-radius: 8px;
+  padding: 0.72rem;
+  background: #050505;
   color: var(--app-muted);
   cursor: pointer;
   font: inherit;
   text-align: left;
-  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
-}
-
-.idt-aws-scope-option:hover {
-  border-color: rgba(255, 255, 255, 0.32);
-  background: rgba(17, 17, 19, 0.9);
-  transform: translateY(-1px);
-}
-
-.idt-aws-scope-option:focus-visible {
-  outline: 2px solid rgba(159, 144, 255, 0.95);
-  outline-offset: 3px;
 }
 
 .idt-aws-scope-option span,
@@ -24249,8 +24221,8 @@ html[data-theme='light'] .idt-app-shell-screen select {
 
 .idt-aws-scope-option.is-selected {
   border-color: rgba(126, 105, 255, 0.74);
-  background: linear-gradient(145deg, rgba(20, 15, 45, 0.96), rgba(11, 10, 23, 0.96));
-  box-shadow: inset 0 0 0 1px rgba(126, 105, 255, 0.32), 0 0.6rem 1.6rem rgba(71, 52, 180, 0.12);
+  background: #0d0b18;
+  box-shadow: inset 0 0 0 1px rgba(126, 105, 255, 0.32);
 }
 
 .idt-aws-scope-option.is-planned {
@@ -24305,104 +24277,9 @@ html[data-theme='light'] .idt-app-shell-screen select {
   grid-template-columns: 2rem minmax(0, 1fr);
   gap: 0.75rem;
   border: 1px solid var(--app-border-soft);
-  border-radius: 12px;
-  padding: 1rem;
-  background: rgba(8, 8, 9, 0.66);
-}
-
-.idt-aws-scope-question {
-  display: grid;
-  gap: 0.9rem;
-  padding-top: 0.15rem;
-}
-
-.idt-aws-scope-question h3 {
-  margin: 0;
-  color: #ffffff;
-  font-size: 1.2rem;
-}
-
-.idt-aws-scope-question > div:first-child > p:last-child {
-  margin: 0.28rem 0 0;
-  color: var(--app-muted);
-}
-
-.idt-aws-trust-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem 1rem;
-  margin: -0.15rem 0 0;
-  padding: 0;
-  list-style: none;
-  color: #cfc8ff;
-  font-size: 0.84rem;
-  font-weight: 760;
-}
-
-.idt-aws-trust-list li {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.idt-aws-trust-list svg {
-  color: #a79aff;
-}
-
-.idt-aws-advanced-method {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  border-top: 1px solid var(--app-border-soft);
-  padding-top: 1rem;
-}
-
-.idt-aws-advanced-method > div {
-  display: grid;
-  gap: 0.18rem;
-}
-
-.idt-aws-advanced-method strong {
-  color: #ffffff;
-}
-
-.idt-aws-advanced-method span {
-  color: var(--app-muted);
-  font-size: 0.84rem;
-}
-
-.idt-aws-advanced-method.is-active {
-  border-top-color: rgba(126, 105, 255, 0.38);
-}
-
-.idt-aws-optional {
-  color: var(--app-dim);
-  font-size: 0.72rem;
-  font-weight: 700;
-}
-
-.idt-aws-field-label {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0.35rem;
-}
-
-.idt-aws-connect-notice {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  border: 1px solid rgba(255, 153, 0, 0.32);
-  border-radius: 10px;
-  padding: 0.72rem 0.9rem;
-  background: rgba(255, 153, 0, 0.08);
-  color: #ffd08a;
-}
-
-.idt-aws-connect-notice p {
-  margin: 0;
-  color: inherit;
-  font-size: 0.86rem;
+  border-radius: 8px;
+  padding: 0.86rem;
+  background: #080809;
 }
 
 .idt-aws-step-index {
@@ -25536,15 +25413,6 @@ html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge
   .idt-aws-step-heading,
   .idt-aws-copy-row {
     grid-template-columns: 1fr;
-  }
-
-  .idt-aws-advanced-method {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .idt-aws-advanced-method .idt-btn {
-    width: 100%;
   }
 
   .idt-aws-step-heading {


### PR DESCRIPTION
Reverts identrail/identrail#1805

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the AWS connection setup redesign and restores the previous, simpler wizard and copy. Restores button-based coverage selection, consistent “Connect AWS”/“Open AWS” actions, the AWS overview link, and the two-column layout with a persistent setup summary.

- **Refactors**
  - Replace coverage radiogroup with a button list; remove radio keyboard handling.
  - Copy updates: “Choose coverage”, “Display name”, “Connect this account”, “Connect AWS”, “Open AWS”.
  - Always show the “AWS overview” header link after initial load.
  - Always show the setup summary; simplify messages (e.g. “Not connected for this environment.”); include connector health in the status badge; use “Open the AWS stack”/“Open the StackSet in AWS”.
  - Rework the disconnected panel wording and layout.
  - Simplify CSS: drop trust list and advanced method styles; restore two-column layout; unify option cards.
  - Update tests to match the reverted copy, controls, and flows.

<sup>Written for commit 6daed47c96c200293e518cc907b79699517dcba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

