### PR TITLE
ops: gate template bucket policy setup

### DIFF
--- a/.github/workflows/aws-cfn-template-bucket-policy.yml
+++ b/.github/workflows/aws-cfn-template-bucket-policy.yml
@@ -131,19 +131,21 @@ jobs:
           fi
           template_url="https://${AWS_CFN_TEMPLATE_BUCKET}.s3.${AWS_REGION}.${s3_dns_suffix}/${key}"
           downloaded="${RUNNER_TEMP}/identrail-readonly.yaml"
-          head_error="${RUNNER_TEMP}/identrail-readonly-head.err"
-          if aws s3api head-object \
+          list_error="${RUNNER_TEMP}/identrail-readonly-list.err"
+          if ! listed_objects="$(aws s3api list-objects-v2 \
             --bucket "${AWS_CFN_TEMPLATE_BUCKET}" \
-            --key "${key}" \
+            --prefix "${key}" \
+            --max-keys 1 \
             --region "${AWS_REGION}" \
-            >/dev/null 2>"${head_error}"; then
-            object_exists=true
-          elif grep -Eq '(^|[^0-9])(404|Not Found|NoSuchKey)([^0-9]|$)' "${head_error}"; then
-            object_exists=false
-          else
+            --output json 2>"${list_error}")"; then
             echo "Could not determine whether ${key} exists with the authenticated setup role." >&2
-            cat "${head_error}" >&2
+            cat "${list_error}" >&2
             exit 1
+          fi
+          if jq -e --arg key "${key}" 'any(.Contents[]?; .Key == $key)' <<<"${listed_objects}" >/dev/null; then
+            object_exists=true
+          else
+            object_exists=false
           fi
           if ! http_status="$(curl -sS --retry 5 --retry-all-errors \
             -o "${downloaded}" -w '%{http_code}' "${template_url}")"; then

--- a/.github/workflows/aws-cfn-template-bucket-policy.yml
+++ b/.github/workflows/aws-cfn-template-bucket-policy.yml
@@ -7,16 +7,6 @@ on:
         description: "Type configure-cfn-template-bucket to continue."
         required: true
         type: string
-      bucket:
-        description: "Bucket name. Leave blank to use AWS_CFN_TEMPLATE_BUCKET."
-        required: false
-        type: string
-        default: ""
-      region:
-        description: "AWS region. Leave blank to use AWS_REGION."
-        required: false
-        type: string
-        default: ""
 
 permissions:
   contents: read
@@ -46,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      AWS_REGION: ${{ inputs.region || vars.AWS_REGION || 'us-east-1' }}
-      AWS_CFN_TEMPLATE_BUCKET: ${{ inputs.bucket || vars.AWS_CFN_TEMPLATE_BUCKET || 'identrail-cloudformation-templates' }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      AWS_CFN_TEMPLATE_BUCKET: ${{ vars.AWS_CFN_TEMPLATE_BUCKET || 'identrail-cloudformation-templates' }}
       AWS_CFN_TEMPLATE_SETUP_ROLE_ARN: ${{ secrets.AWS_CFN_TEMPLATE_SETUP_ROLE_ARN }}
       CONFIRMATION: ${{ inputs.confirmation }}
     steps:
@@ -135,8 +125,26 @@ jobs:
           template="deploy/connectors/aws/identrail-readonly.yaml"
           digest="$(sha256sum "${template}" | awk '{print $1}')"
           key="connectors/aws/sha256/${digest}/identrail-readonly.yaml"
-          template_url="https://${AWS_CFN_TEMPLATE_BUCKET}.s3.${AWS_REGION}.amazonaws.com/${key}"
+          s3_dns_suffix="amazonaws.com"
+          if [[ "${AWS_REGION}" == cn-* ]]; then
+            s3_dns_suffix="amazonaws.com.cn"
+          fi
+          template_url="https://${AWS_CFN_TEMPLATE_BUCKET}.s3.${AWS_REGION}.${s3_dns_suffix}/${key}"
           downloaded="${RUNNER_TEMP}/identrail-readonly.yaml"
+          head_error="${RUNNER_TEMP}/identrail-readonly-head.err"
+          if aws s3api head-object \
+            --bucket "${AWS_CFN_TEMPLATE_BUCKET}" \
+            --key "${key}" \
+            --region "${AWS_REGION}" \
+            >/dev/null 2>"${head_error}"; then
+            object_exists=true
+          elif grep -Eq '(^|[^0-9])(404|Not Found|NoSuchKey)([^0-9]|$)' "${head_error}"; then
+            object_exists=false
+          else
+            echo "Could not determine whether ${key} exists with the authenticated setup role." >&2
+            cat "${head_error}" >&2
+            exit 1
+          fi
           if ! http_status="$(curl -sS --retry 5 --retry-all-errors \
             -o "${downloaded}" -w '%{http_code}' "${template_url}")"; then
             echo "Could not probe ${template_url} after configuring the bucket policy." >&2
@@ -152,13 +160,23 @@ jobs:
               echo "Verified anonymous read and SHA-256 for ${template_url}."
               ;;
             404)
+              if [ "${object_exists}" = true ]; then
+                echo "The authenticated setup role sees ${key}, but anonymous read returned 404." >&2
+                echo "The configured bucket policy does not expose the expected object path." >&2
+                exit 1
+              fi
               echo "Anonymous policy reachability returned 404 because the current digest is not published yet."
               echo "The bucket policy is configured; the next production release will publish this digest."
               ;;
             403)
-              echo "The bucket policy was applied, but anonymous read still returned 403." >&2
-              echo "Check account or organization-level S3 Block Public Access settings." >&2
-              exit 1
+              if [ "${object_exists}" = false ]; then
+                echo "Anonymous policy reachability returned 403 because the current digest is not published yet."
+                echo "The bucket policy is configured; the next production release will publish this digest."
+              else
+                echo "The bucket policy was applied, but anonymous read still returned 403." >&2
+                echo "Check account or organization-level S3 Block Public Access settings." >&2
+                exit 1
+              fi
               ;;
             *)
               echo "Anonymous template probe returned unexpected HTTP status ${http_status}." >&2

--- a/.github/workflows/aws-cfn-template-bucket-policy.yml
+++ b/.github/workflows/aws-cfn-template-bucket-policy.yml
@@ -1,0 +1,175 @@
+name: AWS Template Bucket Policy Setup
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: "Type configure-cfn-template-bucket to continue."
+        required: true
+        type: string
+      bucket:
+        description: "Bucket name. Leave blank to use AWS_CFN_TEMPLATE_BUCKET."
+        required: false
+        type: string
+        default: ""
+      region:
+        description: "AWS region. Leave blank to use AWS_REGION."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aws-cfn-template-bucket-policy-setup
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    name: Approve template bucket policy setup
+    if: github.repository == 'identrail/identrail' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - name: Record production approval
+        run: echo "Production approval granted for template bucket policy setup."
+
+  configure:
+    name: Configure template bucket policy
+    needs: approve
+    if: github.repository == 'identrail/identrail' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      AWS_REGION: ${{ inputs.region || vars.AWS_REGION || 'us-east-1' }}
+      AWS_CFN_TEMPLATE_BUCKET: ${{ inputs.bucket || vars.AWS_CFN_TEMPLATE_BUCKET || 'identrail-cloudformation-templates' }}
+      AWS_CFN_TEMPLATE_SETUP_ROLE_ARN: ${{ secrets.AWS_CFN_TEMPLATE_SETUP_ROLE_ARN }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Validate setup inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${CONFIRMATION}" != "configure-cfn-template-bucket" ]; then
+            echo "Type configure-cfn-template-bucket to continue." >&2
+            exit 1
+          fi
+          if ! [[ "${AWS_REGION}" =~ ^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$ ]]; then
+            echo "AWS_REGION must be an AWS region such as us-east-1." >&2
+            exit 1
+          fi
+          if ! [[ "${AWS_CFN_TEMPLATE_BUCKET}" =~ ^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$ ]]; then
+            echo "AWS_CFN_TEMPLATE_BUCKET must use lowercase letters, numbers, and hyphens only." >&2
+            exit 1
+          fi
+          if ! [[ "${AWS_CFN_TEMPLATE_SETUP_ROLE_ARN}" =~ ^arn:aws(-[a-z0-9-]+)?:iam::[0-9]{12}:role/.+$ ]]; then
+            echo "AWS_CFN_TEMPLATE_SETUP_ROLE_ARN must be an IAM role ARN." >&2
+            exit 1
+          fi
+          echo "::add-mask::${AWS_CFN_TEMPLATE_SETUP_ROLE_ARN}"
+
+      - name: Configure AWS credentials from GitHub OIDC
+        shell: bash
+        run: |
+          set -euo pipefail
+          token_response="$(
+            curl -fsSL \
+              -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com"
+          )"
+          oidc_token="$(jq -r '.value // empty' <<< "${token_response}")"
+          if [ -z "${oidc_token}" ]; then
+            echo "GitHub did not return an OIDC token."
+            exit 1
+          fi
+          credentials="$(
+            aws sts assume-role-with-web-identity \
+              --role-arn "${AWS_CFN_TEMPLATE_SETUP_ROLE_ARN}" \
+              --role-session-name "identrail-template-policy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+              --web-identity-token "${oidc_token}" \
+              --duration-seconds 900 \
+              --query Credentials \
+              --output json
+          )"
+          access_key_id="$(jq -r '.AccessKeyId // empty' <<< "${credentials}")"
+          secret_access_key="$(jq -r '.SecretAccessKey // empty' <<< "${credentials}")"
+          session_token="$(jq -r '.SessionToken // empty' <<< "${credentials}")"
+          if [ -z "${access_key_id}" ] || [ -z "${secret_access_key}" ] || [ -z "${session_token}" ]; then
+            echo "AWS did not return complete temporary credentials."
+            exit 1
+          fi
+          echo "::add-mask::${access_key_id}"
+          echo "::add-mask::${secret_access_key}"
+          echo "::add-mask::${session_token}"
+          {
+            echo "AWS_ACCESS_KEY_ID=${access_key_id}"
+            echo "AWS_SECRET_ACCESS_KEY=${secret_access_key}"
+            echo "AWS_SESSION_TOKEN=${session_token}"
+            echo "AWS_DEFAULT_REGION=${AWS_REGION}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Verify setup role identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          identity="$(aws sts get-caller-identity --output json)"
+          echo "Using AWS account $(jq -r '.Account' <<< "${identity}") for the gated template bucket setup."
+          echo "Using role $(jq -r '.Arn' <<< "${identity}") for the gated template bucket setup."
+
+      - name: Apply prefix-scoped bucket policy
+        shell: bash
+        run: ./scripts/configure_cfn_template_bucket_policy.sh
+
+      - name: Verify anonymous template reachability
+        shell: bash
+        run: |
+          set -euo pipefail
+          template="deploy/connectors/aws/identrail-readonly.yaml"
+          digest="$(sha256sum "${template}" | awk '{print $1}')"
+          key="connectors/aws/sha256/${digest}/identrail-readonly.yaml"
+          template_url="https://${AWS_CFN_TEMPLATE_BUCKET}.s3.${AWS_REGION}.amazonaws.com/${key}"
+          downloaded="${RUNNER_TEMP}/identrail-readonly.yaml"
+          if ! http_status="$(curl -sS --retry 5 --retry-all-errors \
+            -o "${downloaded}" -w '%{http_code}' "${template_url}")"; then
+            echo "Could not probe ${template_url} after configuring the bucket policy." >&2
+            exit 1
+          fi
+          case "${http_status}" in
+            200)
+              published_digest="$(sha256sum "${downloaded}" | awk '{print $1}')"
+              if [ "${published_digest}" != "${digest}" ]; then
+                echo "Public template digest ${published_digest} does not match ${digest}." >&2
+                exit 1
+              fi
+              echo "Verified anonymous read and SHA-256 for ${template_url}."
+              ;;
+            404)
+              echo "Anonymous policy reachability returned 404 because the current digest is not published yet."
+              echo "The bucket policy is configured; the next production release will publish this digest."
+              ;;
+            403)
+              echo "The bucket policy was applied, but anonymous read still returned 403." >&2
+              echo "Check account or organization-level S3 Block Public Access settings." >&2
+              exit 1
+              ;;
+            *)
+              echo "Anonymous template probe returned unexpected HTTP status ${http_status}." >&2
+              exit 1
+              ;;
+          esac
+          {
+            echo "## AWS template bucket policy setup"
+            echo
+            echo "- Bucket: \`${AWS_CFN_TEMPLATE_BUCKET}\`"
+            echo "- Region: \`${AWS_REGION}\`"
+            echo "- Policy: prefix-scoped public \`s3:GetObject\`"
+            echo "- Anonymous probe: HTTP \`${http_status}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -366,7 +366,7 @@ jobs:
           downloaded="${RUNNER_TEMP}/identrail-readonly.yaml"
           if ! curl -fsSL --retry 5 --retry-all-errors "${template_url}" -o "${downloaded}"; then
             echo "Template URL ${template_url} is not publicly readable." >&2
-            echo "Configure the documented prefix-scoped bucket policy before retrying the production release." >&2
+            echo "Run the AWS Template Bucket Policy Setup workflow from the dev branch before retrying the production release." >&2
             exit 1
           fi
           published_digest="$(sha256sum "${downloaded}" | awk '{print $1}')"

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -127,6 +127,8 @@ hand.
 Repository configuration required before the workflow can plan:
 
 - secret `AWS_ROLE_ARN`: GitHub OIDC deployment role ARN
+- secret `AWS_CFN_TEMPLATE_SETUP_ROLE_ARN`: dedicated GitHub OIDC role for
+  the protected template bucket policy setup workflow
 - variable `AWS_REGION`: AWS region, such as `us-east-1`
 - variable `AWS_TERRAFORM_STATE_BUCKET`: existing S3 bucket for Terraform state
 - variable `AWS_CFN_TEMPLATE_BUCKET`: private-write/public-read bucket used to
@@ -169,8 +171,21 @@ deployment role needs `s3:PutObject` and `s3:GetObject` on
 `s3:PutObjectAcl`. A setup role needs `s3:GetBucketPolicy`,
 `s3:PutBucketPolicy`, `s3:GetBucketPublicAccessBlock`,
 `s3:GetAccountPublicAccessBlock`, and `sts:GetCallerIdentity` to provision and
-verify the policy. Run the idempotent helper from the repository root after
-setting the bucket and region:
+verify the policy.
+
+The preferred provisioning path is the manually dispatched
+`AWS Template Bucket Policy Setup` workflow
+(`.github/workflows/aws-cfn-template-bucket-policy.yml`) from the `dev`
+branch. Type `configure-cfn-template-bucket` when dispatching it; the
+workflow pauses at the protected `production` environment, assumes only the
+dedicated `AWS_CFN_TEMPLATE_SETUP_ROLE_ARN`, applies the idempotent helper,
+and records an anonymous-read probe in the run summary. The setup role trust
+must be limited to `repo:identrail/identrail:ref:refs/heads/dev`. Keep the
+normal `AWS_ROLE_ARN` deployment role separate and without bucket-policy
+mutation permissions.
+
+For a break-glass or local setup, run the same idempotent helper from the
+repository root after setting the bucket and region:
 
 ```bash
 AWS_CFN_TEMPLATE_BUCKET=identrail-cloudformation-templates \

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -165,7 +165,7 @@ configured bucket name):
 }
 ```
 
-Do not grant `s3:ListBucket` or public write access. The `AWS_ROLE_ARN`
+Do not grant anonymous `s3:ListBucket` or public write access. The `AWS_ROLE_ARN`
 deployment role needs `s3:PutObject` and `s3:GetObject` on
 `connectors/aws/sha256/*/identrail-readonly.yaml`; it does not need
 `s3:PutObjectAcl`. It also remains separate from the setup role below.
@@ -175,9 +175,10 @@ The dedicated setup role needs these least-privilege permissions:
 - `s3:GetBucketPolicy`, `s3:PutBucketPolicy`, and
   `s3:GetBucketPublicAccessBlock` on the exact bucket resource
   `arn:aws:s3:::BUCKET_NAME`;
-- `s3:GetObject` on the exact template prefix
-  `arn:aws:s3:::BUCKET_NAME/connectors/aws/sha256/*`, used only to distinguish
-  a missing digest from a public-read failure;
+- `s3:ListBucket` on the exact bucket resource
+  `arn:aws:s3:::BUCKET_NAME`, conditioned with
+  `StringLike: {"s3:prefix": "connectors/aws/sha256/*"}` so the workflow can
+  distinguish a missing digest from a public-read failure;
 - `s3:GetAccountPublicAccessBlock` and `sts:GetCallerIdentity` on `*`.
 
 Do not grant `s3:PutBucketPolicy` on `*` or on an object ARN: S3 evaluates that

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -168,21 +168,35 @@ configured bucket name):
 Do not grant `s3:ListBucket` or public write access. The `AWS_ROLE_ARN`
 deployment role needs `s3:PutObject` and `s3:GetObject` on
 `connectors/aws/sha256/*/identrail-readonly.yaml`; it does not need
-`s3:PutObjectAcl`. A setup role needs `s3:GetBucketPolicy`,
-`s3:PutBucketPolicy`, `s3:GetBucketPublicAccessBlock`,
-`s3:GetAccountPublicAccessBlock`, and `sts:GetCallerIdentity` to provision and
-verify the policy.
+`s3:PutObjectAcl`. It also remains separate from the setup role below.
+
+The dedicated setup role needs these least-privilege permissions:
+
+- `s3:GetBucketPolicy`, `s3:PutBucketPolicy`, and
+  `s3:GetBucketPublicAccessBlock` on the exact bucket resource
+  `arn:aws:s3:::BUCKET_NAME`;
+- `s3:GetObject` on the exact template prefix
+  `arn:aws:s3:::BUCKET_NAME/connectors/aws/sha256/*`, used only to distinguish
+  a missing digest from a public-read failure;
+- `s3:GetAccountPublicAccessBlock` and `sts:GetCallerIdentity` on `*`.
+
+Do not grant `s3:PutBucketPolicy` on `*` or on an object ARN: S3 evaluates that
+permission against the bucket ARN. Replace `BUCKET_NAME` in the role policy
+with the one configured template bucket.
 
 The preferred provisioning path is the manually dispatched
 `AWS Template Bucket Policy Setup` workflow
 (`.github/workflows/aws-cfn-template-bucket-policy.yml`) from the `dev`
 branch. Type `configure-cfn-template-bucket` when dispatching it; the
-workflow pauses at the protected `production` environment, assumes only the
-dedicated `AWS_CFN_TEMPLATE_SETUP_ROLE_ARN`, applies the idempotent helper,
-and records an anonymous-read probe in the run summary. The setup role trust
-must be limited to `repo:identrail/identrail:ref:refs/heads/dev`. Keep the
-normal `AWS_ROLE_ARN` deployment role separate and without bucket-policy
-mutation permissions.
+workflow reads the bucket and region from the repository variables (it has no
+free-form bucket or region inputs), pauses at the protected `production`
+environment, assumes only the dedicated `AWS_CFN_TEMPLATE_SETUP_ROLE_ARN`,
+applies the idempotent helper, and records an anonymous-read probe in the run
+summary. The setup role trust must be limited to
+`repo:identrail/identrail:ref:refs/heads/dev`, and its bucket-policy mutation
+permission must target only the exact configured bucket. Keep the normal
+`AWS_ROLE_ARN` deployment role separate and without bucket-policy mutation
+permissions.
 
 For a break-glass or local setup, run the same idempotent helper from the
 repository root after setting the bucket and region:


### PR DESCRIPTION
## Summary

The post-merge production release still failed because the external S3 CloudFormation template bucket was never made publicly readable. The existing policy helper was documented, but there was no repeatable, approved way to run it.

This follow-up adds:

- a manually dispatched `AWS Template Bucket Policy Setup` workflow restricted to the upstream `dev` branch;
- a protected `production` environment approval before any bucket-policy mutation;
- a dedicated short-lived GitHub OIDC setup role, kept separate from the normal deployment role;
- exact confirmation input and bucket/region/role validation;
- reuse of the existing idempotent, prefix-scoped policy helper;
- an anonymous-read probe that validates either the current template bytes or the expected not-yet-published `404` state;
- a production release error that directs operators to the setup workflow;
- operator documentation for the required setup role and trust boundary.

The policy remains limited to public `s3:GetObject` under the SHA-addressed connector prefix. No public writes, ACL permissions, bucket listing, or normal deploy-role bucket-policy permissions are added.

## Required repository configuration

Before dispatching the setup workflow, configure:

- secret `AWS_CFN_TEMPLATE_SETUP_ROLE_ARN` for the dedicated setup role;
- trust limited to `repo:identrail/identrail:ref:refs/heads/dev`;
- setup-role permissions documented in `docs/aws-api-hosting.md`;
- approval protection on the `production` environment.

## Validation

- `actionlint` for the new setup workflow and production release workflow
- helper shell syntax and ShellCheck
- public API URL regression test
- Terraform format and validation
- pre-commit hooks and push hooks

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: none
- Areas where used: none
- Human verification performed: not applicable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a gated manual workflow to configure the CloudFormation template S3 bucket policy for public read, with a prefix-scoped probe to validate anonymous access. Updates the production release message and docs so operators can run the setup safely.

- New Features
  - New `AWS Template Bucket Policy Setup` workflow, restricted to `dev` on `identrail/identrail`.
  - Requires protected `production` environment approval; uses short‑lived OIDC setup role (`AWS_CFN_TEMPLATE_SETUP_ROLE_ARN`).
  - Reads bucket/region from repo vars, validates inputs, and applies the prefix‑scoped, idempotent policy (public `s3:GetObject` only).
  - Anonymous probe now uses prefix‑scoped `s3:ListBucket` to tell a missing digest from a policy failure; explains `403` with S3 Block Public Access guidance.
  - Production release now directs operators to run the setup workflow from the `dev` branch.
  - Docs updated with least‑privilege setup role permissions (including conditioned `s3:ListBucket`), trust limits, and run steps.

- Migration
  - Add secret `AWS_CFN_TEMPLATE_SETUP_ROLE_ARN`; trust limited to `repo:identrail/identrail:ref:refs/heads/dev`.
  - Protect the `production` environment with required approval.
  - Ensure the setup role policy includes bucket‑scoped `s3:Get/PutBucketPolicy`, `s3:GetBucketPublicAccessBlock`, conditioned `s3:ListBucket` for the prefix, and `s3:GetAccountPublicAccessBlock`.
  - Run the new setup workflow from `dev` and confirm with “configure-cfn-template-bucket”.

<sup>Written for commit 59cc276ae3439776fd8500322da320a4b275845d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

