### PR TITLE
feat: provision template policy setup role

### DIFF
--- a/.github/workflows/aws-cfn-template-bucket-policy.yml
+++ b/.github/workflows/aws-cfn-template-bucket-policy.yml
@@ -70,10 +70,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          oidc_audience="sts.amazonaws.com"
+          if [[ "${AWS_REGION}" == cn-* ]]; then
+            oidc_audience="sts.amazonaws.com.cn"
+          fi
           token_response="$(
             curl -fsSL \
               -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com"
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${oidc_audience}"
           )"
           oidc_token="$(jq -r '.value // empty' <<< "${token_response}")"
           if [ -z "${oidc_token}" ]; then

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -7,12 +7,15 @@ The AWS module is intentionally safe by default:
 - It validates AWS provider wiring and naming conventions.
 - It defines production-adjacent primitives needed by later API hosting work.
 - It does not create foundation resources unless `create_foundation_resources=true`.
+- It does not create the template-policy setup role unless
+  `create_cfn_template_policy_setup_role=true`.
 - It does not create the API hosting layer unless `create_api_hosting_resources=true`.
 - It does not deploy the worker, database, or public domains yet.
 
 ## Current Scope
 
 - Terraform foundation: `terraform/`
+- Template bucket policy setup role: `terraform/cfn_template_policy_setup.tf`
 - API hosting plan: `terraform/api_hosting.tf`
 - GitHub OIDC role verification: `.github/workflows/aws-oidc-verification.yml`
 - Dev-only foundation plan workflow: `.github/workflows/aws-deployment-foundation.yml`

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -147,6 +147,11 @@ the protected `AWS Template Bucket Policy Setup` workflow from `dev` with the
 confirmation `configure-cfn-template-bucket`, then retry the production
 release.
 
+The role trust policy derives the GitHub OIDC audience from the active AWS
+partition: `sts.amazonaws.com.cn` for AWS China and `sts.amazonaws.com` for
+the commercial and GovCloud partitions. The OIDC provider ARN must belong to
+that same partition.
+
 ## Local Validation
 
 ```bash

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -12,6 +12,14 @@ When `create_foundation_resources=true`, the root can create:
 - CloudWatch log groups for API and worker workloads.
 - A Secrets Manager secret metadata record for future runtime configuration.
 
+When `create_cfn_template_policy_setup_role=true`, the root can also create:
+
+- a dedicated GitHub OIDC role for the protected CloudFormation template
+  bucket policy setup workflow;
+- an inline policy limited to the configured template bucket, its
+  `connectors/aws/sha256/*` listing prefix, account-level S3 public-access
+  inspection, and caller identity.
+
 When `create_api_hosting_resources=true`, the root can also create:
 
 - an ECS/Fargate cluster, task definition, service, and autoscaling policy for
@@ -88,6 +96,7 @@ or session ID hashes.
 ## Safe Defaults
 
 The default configuration sets `create_foundation_resources=false`,
+`create_cfn_template_policy_setup_role=false`,
 `create_api_hosting_resources=false`, and
 `create_worker_hosting_resources=false`, so CI and pull requests can run
 `terraform init`, `terraform validate`, and `terraform plan` without creating
@@ -97,6 +106,46 @@ The checked-in root stays backendless for validation-only plans. The manual
 GitHub Actions deploy workflow writes a temporary S3 backend file at runtime and
 initializes it with the configured S3 state bucket and key before planning or
 applying AWS API hosting.
+
+## Manual Template Policy Setup Role Plan
+
+The GitHub Actions OIDC provider must already exist in the target AWS account;
+the normal `AWS_ROLE_ARN` deployment workflow proves that provider is usable.
+Find its ARN, then plan the dedicated role explicitly:
+
+```bash
+cd deploy/aws/terraform
+oidc_provider_arn="$(aws iam list-open-id-connect-providers \
+  --query 'OpenIDConnectProviderList[?contains(Arn, `token.actions.githubusercontent.com`)].Arn | [0]' \
+  --output text)"
+terraform plan \
+  -input=false \
+  -var-file=environments/dev/terraform.tfvars.example \
+  -var='create_cfn_template_policy_setup_role=true' \
+  -var="cfn_template_policy_setup_oidc_provider_arn=${oidc_provider_arn}" \
+  -var='cfn_template_policy_setup_bucket_name=identrail-cloudformation-templates'
+```
+
+Review the plan, then apply the same inputs. The role ARN is an output, not a
+secret; add it to the repository secret required by the setup workflow:
+
+```bash
+terraform apply \
+  -input=false \
+  -var-file=environments/dev/terraform.tfvars.example \
+  -var='create_cfn_template_policy_setup_role=true' \
+  -var="cfn_template_policy_setup_oidc_provider_arn=${oidc_provider_arn}" \
+  -var='cfn_template_policy_setup_bucket_name=identrail-cloudformation-templates'
+gh secret set AWS_CFN_TEMPLATE_SETUP_ROLE_ARN \
+  --repo identrail/identrail \
+  --body "$(terraform output -raw cfn_template_policy_setup_role_arn)"
+```
+
+The Terraform resource is disabled by default and does not modify the normal
+deployment role or the external bucket policy. After the secret is set, run
+the protected `AWS Template Bucket Policy Setup` workflow from `dev` with the
+confirmation `configure-cfn-template-bucket`, then retry the production
+release.
 
 ## Local Validation
 

--- a/deploy/aws/terraform/cfn_template_policy_setup.tf
+++ b/deploy/aws/terraform/cfn_template_policy_setup.tf
@@ -1,0 +1,95 @@
+data "aws_iam_policy_document" "cfn_template_policy_setup_assume_role" {
+  count = var.create_cfn_template_policy_setup_role ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [trimspace(var.cfn_template_policy_setup_oidc_provider_arn)]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:identrail/identrail:ref:refs/heads/dev"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cfn_template_policy_setup" {
+  count = var.create_cfn_template_policy_setup_role ? 1 : 0
+
+  statement {
+    sid = "ManageExactTemplateBucketPolicy"
+
+    actions = [
+      "s3:GetBucketPolicy",
+      "s3:PutBucketPolicy",
+      "s3:GetBucketPublicAccessBlock",
+    ]
+    resources = [local.cfn_template_policy_setup_bucket_arn]
+  }
+
+  statement {
+    sid       = "ListOnlyTemplateDigestPrefix"
+    actions   = ["s3:ListBucket"]
+    resources = [local.cfn_template_policy_setup_bucket_arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["connectors/aws/sha256/*"]
+    }
+  }
+
+  statement {
+    sid = "ReadAccountPublicAccessBlock"
+
+    actions = [
+      "s3:GetAccountPublicAccessBlock",
+      "sts:GetCallerIdentity",
+    ]
+    resources = ["*"]
+  }
+}
+
+locals {
+  cfn_template_policy_setup_bucket_arn = "arn:${data.aws_partition.current.partition}:s3:::${trimspace(var.cfn_template_policy_setup_bucket_name)}"
+}
+
+resource "aws_iam_role" "cfn_template_policy_setup" {
+  count = var.create_cfn_template_policy_setup_role ? 1 : 0
+
+  name               = var.cfn_template_policy_setup_role_name
+  assume_role_policy = data.aws_iam_policy_document.cfn_template_policy_setup_assume_role[0].json
+
+  tags = merge(local.common_tags, {
+    Component = "cfn-template-policy-setup"
+  })
+
+  lifecycle {
+    precondition {
+      condition = can(regex(
+        "^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$",
+        trimspace(var.cfn_template_policy_setup_oidc_provider_arn)
+      ))
+      error_message = "cfn_template_policy_setup_oidc_provider_arn must be the account GitHub Actions OIDC provider ARN when the setup role is enabled."
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "cfn_template_policy_setup" {
+  count = var.create_cfn_template_policy_setup_role ? 1 : 0
+
+  name   = "${var.cfn_template_policy_setup_role_name}-permissions"
+  role   = aws_iam_role.cfn_template_policy_setup[0].id
+  policy = data.aws_iam_policy_document.cfn_template_policy_setup[0].json
+}

--- a/deploy/aws/terraform/cfn_template_policy_setup.tf
+++ b/deploy/aws/terraform/cfn_template_policy_setup.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "cfn_template_policy_setup_assume_role" {
     condition {
       test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:aud"
-      values   = ["sts.amazonaws.com"]
+      values   = [local.cfn_template_policy_setup_oidc_audience]
     }
 
     condition {
@@ -62,7 +62,8 @@ data "aws_iam_policy_document" "cfn_template_policy_setup" {
 }
 
 locals {
-  cfn_template_policy_setup_bucket_arn = "arn:${data.aws_partition.current.partition}:s3:::${trimspace(var.cfn_template_policy_setup_bucket_name)}"
+  cfn_template_policy_setup_oidc_audience = data.aws_partition.current.partition == "aws-cn" ? "sts.amazonaws.com.cn" : "sts.amazonaws.com"
+  cfn_template_policy_setup_bucket_arn    = "arn:${data.aws_partition.current.partition}:s3:::${trimspace(var.cfn_template_policy_setup_bucket_name)}"
 }
 
 resource "aws_iam_role" "cfn_template_policy_setup" {
@@ -78,10 +79,10 @@ resource "aws_iam_role" "cfn_template_policy_setup" {
   lifecycle {
     precondition {
       condition = can(regex(
-        "^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$",
+        "^arn:${data.aws_partition.current.partition}:iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$",
         trimspace(var.cfn_template_policy_setup_oidc_provider_arn)
       ))
-      error_message = "cfn_template_policy_setup_oidc_provider_arn must be the account GitHub Actions OIDC provider ARN when the setup role is enabled."
+      error_message = "cfn_template_policy_setup_oidc_provider_arn must be the account GitHub Actions OIDC provider ARN in the active AWS partition when the setup role is enabled."
     }
   }
 }

--- a/deploy/aws/terraform/environments/dev/terraform.tfvars.example
+++ b/deploy/aws/terraform/environments/dev/terraform.tfvars.example
@@ -7,6 +7,11 @@ create_foundation_resources = false
 create_api_hosting_resources = false
 create_worker_hosting_resources = false
 
+# Enable only when the GitHub OIDC provider already exists in this AWS account.
+# create_cfn_template_policy_setup_role       = true
+# cfn_template_policy_setup_oidc_provider_arn = "arn:aws:iam::<aws-account-id>:oidc-provider/token.actions.githubusercontent.com"
+# cfn_template_policy_setup_bucket_name       = "identrail-cloudformation-templates"
+
 create_runtime_secret = true
 log_retention_days    = 30
 

--- a/deploy/aws/terraform/environments/dev/terraform.tfvars.example
+++ b/deploy/aws/terraform/environments/dev/terraform.tfvars.example
@@ -11,6 +11,7 @@ create_worker_hosting_resources = false
 # create_cfn_template_policy_setup_role       = true
 # cfn_template_policy_setup_oidc_provider_arn = "arn:aws:iam::<aws-account-id>:oidc-provider/token.actions.githubusercontent.com"
 # cfn_template_policy_setup_bucket_name       = "identrail-cloudformation-templates"
+# For AWS China, set aws_region to cn-* and use the arn:aws-cn OIDC provider ARN.
 
 create_runtime_secret = true
 log_retention_days    = 30

--- a/deploy/aws/terraform/outputs.tf
+++ b/deploy/aws/terraform/outputs.tf
@@ -3,6 +3,11 @@ output "foundation_resources_enabled" {
   value       = var.create_foundation_resources
 }
 
+output "cfn_template_policy_setup_role_arn" {
+  description = "ARN of the dedicated GitHub OIDC role for the protected CloudFormation template bucket policy setup workflow."
+  value       = try(aws_iam_role.cfn_template_policy_setup[0].arn, null)
+}
+
 output "log_group_names" {
   description = "CloudWatch log groups for future Identrail services."
   value       = { for name, log_group in aws_cloudwatch_log_group.service : name => log_group.name }

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -34,6 +34,44 @@ variable "create_foundation_resources" {
   default     = false
 }
 
+variable "create_cfn_template_policy_setup_role" {
+  description = "Create the dedicated GitHub OIDC role used by the protected CloudFormation template bucket policy setup workflow."
+  type        = bool
+  default     = false
+}
+
+variable "cfn_template_policy_setup_bucket_name" {
+  description = "Exact operator-owned S3 bucket whose SHA-addressed CloudFormation template policy the setup role may manage."
+  type        = string
+  default     = "identrail-cloudformation-templates"
+
+  validation {
+    condition = (
+      length(trimspace(var.cfn_template_policy_setup_bucket_name)) >= 3 &&
+      length(trimspace(var.cfn_template_policy_setup_bucket_name)) <= 63 &&
+      can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", trimspace(var.cfn_template_policy_setup_bucket_name)))
+    )
+    error_message = "cfn_template_policy_setup_bucket_name must be a 3-63 character lowercase S3 bucket name using letters, numbers, and dashes."
+  }
+}
+
+variable "cfn_template_policy_setup_oidc_provider_arn" {
+  description = "AWS account GitHub Actions OIDC provider ARN used by the dedicated template bucket policy setup role. Required when the role is enabled."
+  type        = string
+  default     = ""
+}
+
+variable "cfn_template_policy_setup_role_name" {
+  description = "IAM role name for the dedicated CloudFormation template bucket policy setup role."
+  type        = string
+  default     = "identrail-cfn-template-policy-setup"
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9+=,.@_-]{1,64}$", var.cfn_template_policy_setup_role_name))
+    error_message = "cfn_template_policy_setup_role_name must be 1-64 characters using IAM role name characters."
+  }
+}
+
 variable "create_runtime_secret" {
   description = "Create the Secrets Manager metadata record for future Identrail runtime configuration."
   type        = bool

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -147,6 +147,26 @@ Repository configuration required before the workflow can plan:
 - secret `API_SESSION_KEY_SECRET_ARN`: Secrets Manager ARN containing
   `IDENTRAIL_SESSION_KEY`
 
+The dedicated setup role can be created by the Terraform root instead of by
+hand. The role is opt-in and disabled by default; enable
+`create_cfn_template_policy_setup_role` with the existing account OIDC provider
+ARN and the exact `AWS_CFN_TEMPLATE_BUCKET` value. Terraform outputs the role
+ARN, which must then be stored as the repository secret
+`AWS_CFN_TEMPLATE_SETUP_ROLE_ARN`. Terraform does not write GitHub secrets.
+
+The OIDC provider ARN can be found with:
+
+```bash
+aws iam list-open-id-connect-providers \
+  --query 'OpenIDConnectProviderList[?contains(Arn, `token.actions.githubusercontent.com`)].Arn | [0]' \
+  --output text
+```
+
+See `deploy/aws/terraform/README.md` for the exact plan, apply, and
+`gh secret set` commands. Do not point this workflow at the normal
+`AWS_ROLE_ARN`; its intentionally narrower permissions do not include bucket
+policy mutation.
+
 The template bucket name must use lowercase letters, numbers, and hyphens only;
 dotted S3 names are rejected because the release uses a virtual-hosted HTTPS
 URL whose wildcard certificate does not cover dotted bucket hostnames. The


### PR DESCRIPTION
## Summary

PR #1807 installed the protected template-bucket policy workflow, but the external GitHub OIDC setup role and repository secret were never provisioned. The first dispatch failed before AWS access because `AWS_CFN_TEMPLATE_SETUP_ROLE_ARN` was missing.

This follow-up:

- adds an opt-in Terraform resource for the dedicated GitHub OIDC setup role;
- restricts trust to `repo:identrail/identrail:ref:refs/heads/dev` and audience `sts.amazonaws.com`;
- restricts `s3:GetBucketPolicy`, `s3:PutBucketPolicy`, and bucket public-access inspection to the exact template bucket;
- limits `s3:ListBucket` to the `connectors/aws/sha256/*` prefix condition;
- outputs the role ARN without writing GitHub secrets from Terraform;
- documents how to apply the role and set `AWS_CFN_TEMPLATE_SETUP_ROLE_ARN`;
- carries the unmerged workflow probe fixes: no free-form target overrides, China S3 endpoints, and authenticated prefix listing to distinguish missing digests from public-read failures.

The normal `AWS_ROLE_ARN` deployment role remains unchanged and does not receive bucket-policy mutation permissions. Terraform creation is disabled by default.

## Operator steps after merge

1. Run Terraform with `create_cfn_template_policy_setup_role=true`, the existing GitHub OIDC provider ARN, and the exact `identrail-cloudformation-templates` bucket name.
2. Store `terraform output -raw cfn_template_policy_setup_role_arn` as the repository secret `AWS_CFN_TEMPLATE_SETUP_ROLE_ARN`.
3. Dispatch `AWS Template Bucket Policy Setup` from `dev` with `configure-cfn-template-bucket`.
4. Rerun the production release.

No AWS resources were created by this PR or by the failed setup dispatch.

## Validation

- `actionlint`
- Terraform format and validation
- Terraform enabled plan: 2 resources, exact trust and permissions
- Bash syntax and ShellCheck for the existing policy helper
- Public API URL regression tests
- Repository pre-commit and push hooks

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: none
- Areas where used: none
- Human verification performed: not applicable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in Terraform-provisioned IAM setup role and updates the protected workflow to configure the CloudFormation template bucket policy. Unblocks first run by setting `AWS_CFN_TEMPLATE_SETUP_ROLE_ARN`, derives the GitHub OIDC audience per AWS partition (including China), tightens S3 permissions, and improves docs.

- **New Features**
  - Terraform adds `terraform/cfn_template_policy_setup.tf` to create the dedicated GitHub OIDC role (off by default) with trust `repo:identrail/identrail:ref:refs/heads/dev` and audience derived from the active partition.
  - Workflow now requests the Actions OIDC token with `sts.amazonaws.com` or `sts.amazonaws.com.cn` based on region.
  - Least-privilege inline policy: exact-bucket policy get/put, `s3:ListBucket` only for `connectors/aws/sha256/*`, account public-access check, and caller identity; role ARN output via `cfn_template_policy_setup_role_arn`.
  - Docs add plan/apply and `gh secret set` commands, OIDC provider ARN discovery, and partition/audience guidance; probe fixes retained (scoped digest listing, China S3 endpoints, no free-form overrides).

- **Migration**
  - Enable `create_cfn_template_policy_setup_role=true` with `cfn_template_policy_setup_oidc_provider_arn` and the exact template bucket name.
  - Apply Terraform, then set repo secret `AWS_CFN_TEMPLATE_SETUP_ROLE_ARN` from `terraform output -raw cfn_template_policy_setup_role_arn`.
  - From `dev`, run `AWS Template Bucket Policy Setup` with confirmation `configure-cfn-template-bucket`, then retry the production release.

<sup>Written for commit 498476708a85ed5a2cce5b4e9307334a796ac816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

