### PR TITLE
Allow automatic AWS connector role validation

### DIFF
--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -83,7 +83,15 @@ through a dedicated one-off migration step before deploying or upgrading the
 service.
 The task role includes the read-only IAM discovery calls required by that live
 collector. Optional `sts:AssumeRole` access is limited to ARNs listed in
-`api_connector_role_arns`.
+`api_connector_role_arns`. When automatic AWS CloudFormation connector
+registration is enabled through the configured
+`IDENTRAIL_AWS_REGISTRATION_TOPIC_ARNS` map, the API and worker task roles also
+receive a cross-account role-resource grant so newly created customer
+connector roles can be validated without redeploying Identrail. That grant is
+conditioned on a non-empty STS external ID and the automatic-registration tag
+applied by the published template. The customer role trust policy must still
+match the connector-specific external ID exactly, so the runtime grant does not
+make arbitrary manually configured roles assumable by Identrail on its own.
 Hosted API plans create and wire `IDENTRAIL_USER_DATA_EXPORT_S3_*` settings by
 default so "Download my data" can store bundles in S3 instead of local task
 disk. The API and worker task roles can access only objects under the configured
@@ -296,9 +304,11 @@ Do not run `terraform apply` until the database, runtime secrets, container
 image tag, health checks, rollback plan, and DNS cutover plan have all been
 reviewed.
 
-Keep `api_connector_role_arns=[]` until reviewed AWS connector roles exist. Add
-only those connector role ARNs when the hosted API should validate connector
-setup or run recurring scans through assumed roles.
+Keep `api_connector_role_arns=[]` unless the hosted API needs access to
+additional explicitly managed connector roles. Automatic CloudFormation
+registration adds its runtime role grant automatically; the customer role's
+trust policy and exact external ID are still required before any role can be
+assumed.
 
 Set `api_private_subnet_egress_ready=true` only after the private task subnets
 have NAT egress or private VPC endpoints for the services Fargate needs at

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -53,6 +53,17 @@ locals {
   api_secret_resource_arns = toset([
     for value_from in values(var.api_secrets) : join(":", slice(split(":", value_from), 0, 7))
   ])
+  api_automatic_connector_registration_enabled = trimspace(lookup(local.api_runtime_environment_variables, "IDENTRAIL_AWS_REGISTRATION_TOPIC_ARNS", "")) != ""
+  # Automatic CloudFormation registration creates connector roles in customer
+  # accounts at runtime, so their ARNs cannot be enumerated at deployment
+  # time. The topic map may come from this root or from separately provisioned
+  # regional providers consumed through api_environment_variables. Keep this
+  # grant separate from explicitly configured connector role ARNs so the
+  # automatic path can require an external ID without changing existing
+  # connectors.
+  api_automatic_connector_role_arns = local.api_automatic_connector_registration_enabled ? [
+    "arn:${data.aws_partition.current.partition}:iam::*:role/*"
+  ] : []
   api_runtime_cors_allowed_origins = compact([
     for origin in split(",", lookup(local.api_runtime_environment_variables, "IDENTRAIL_CORS_ALLOWED_ORIGINS", "")) : trimspace(origin)
   ])
@@ -375,6 +386,32 @@ data "aws_iam_policy_document" "api_task_aws_collector" {
     content {
       actions   = ["sts:AssumeRole"]
       resources = var.api_connector_role_arns
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(local.api_automatic_connector_role_arns) > 0 ? [1] : []
+
+    content {
+      actions   = ["sts:AssumeRole"]
+      resources = local.api_automatic_connector_role_arns
+
+      # Connector validation always supplies a connector-specific external ID.
+      # Keep the runtime identity grant from assuming an unguarded role even
+      # when a customer role's trust policy is broader than the published
+      # Identrail template. The exact external-ID match remains enforced by
+      # the target role trust policy.
+      condition {
+        test     = "StringLike"
+        variable = "sts:ExternalId"
+        values   = ["?*"]
+      }
+
+      condition {
+        test     = "StringEquals"
+        variable = "iam:ResourceTag/IdentrailConnectorMode"
+        values   = ["automatic"]
+      }
     }
   }
 }

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -368,7 +368,7 @@ variable "api_secret_kms_key_arns" {
 }
 
 variable "api_connector_role_arns" {
-  description = "AWS connector role ARNs the hosted API task may assume for connector validation and recurring scans. Leave empty until connector roles are ready."
+  description = "Additional AWS connector role ARNs the hosted API and worker tasks may assume for connector validation and recurring scans. Automatic CloudFormation registration adds a separately tagged runtime role grant."
   type        = list(string)
   default     = []
   validation {

--- a/deploy/connectors/aws/identrail-readonly.yaml
+++ b/deploy/connectors/aws/identrail-readonly.yaml
@@ -200,6 +200,16 @@ Resources:
       RoleName:
         Ref: RoleName
       Description: Read-only role used by Identrail to build machine identity trust graphs.
+      Tags:
+        - Key: IdentrailConnectorMode
+          Value:
+            Fn::If:
+              - UseAutomaticRegistration
+              - automatic
+              - Fn::If:
+                  - UseRolloutRegistration
+                  - automatic
+                  - manual
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/internal/connectors/aws/cfn_test.go
+++ b/internal/connectors/aws/cfn_test.go
@@ -40,6 +40,19 @@ func TestReadOnlyTemplateAutomaticRegistrationContract(t *testing.T) {
 	if registration["Type"] != "Custom::IdentrailAWSConnectorRegistration" || registration["DependsOn"] == nil {
 		t.Fatalf("registration must wait for the role: %+v", registration)
 	}
+	role := requireYAMLMap(t, resources, "IdentrailReadOnlyRole")
+	roleProperties := requireYAMLMap(t, role, "Properties")
+	tags, ok := roleProperties["Tags"].([]any)
+	if !ok || len(tags) != 1 {
+		t.Fatalf("role must carry one registration-mode tag: %#v", roleProperties["Tags"])
+	}
+	tag, ok := tags[0].(map[string]any)
+	if !ok || tag["Key"] != "IdentrailConnectorMode" {
+		t.Fatalf("role registration-mode tag is malformed: %#v", tags[0])
+	}
+	if _, ok := tag["Value"].(map[string]any); !ok {
+		t.Fatalf("role registration-mode tag must be conditional: %#v", tag["Value"])
+	}
 	if _, leaksToken := registrationProperties["RegistrationToken"]; leaksToken {
 		t.Fatal("registration phase must use the stack-bound bootstrap result, not replay the launch token")
 	}


### PR DESCRIPTION
## What changed

- Grant the hosted API and worker task roles a cross-account `sts:AssumeRole` resource pattern when automatic AWS CloudFormation connector registration is enabled.
- Keep explicitly configured connector role ARNs supported for other connector flows.
- Document that the customer role trust policy and connector-specific external ID remain mandatory.

## Root cause

The customer CloudFormation stack created the correct trust policy, but the Identrail runtime task role had no identity-policy permission to call `sts:AssumeRole` for customer-created connector roles. AWS therefore rejected validation and the UI reported `Assume Role Failed`.

Fixes #1787

## Validation

- `terraform validate`
- `terraform fmt -check -recursive deploy/aws/terraform`
- `bash scripts/prepare_aws_api_deploy_test.sh`
- `go test ./internal/api ./internal/providers/aws`
