### PR TITLE
Prevent fixture AWS findings in live mode

### DIFF
--- a/internal/api/aws_secret_permission_equivalence.go
+++ b/internal/api/aws_secret_permission_equivalence.go
@@ -161,8 +161,16 @@ func (s *Service) GetAWSSecretPermissionEquivalence(ctx context.Context, workspa
 	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
 	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
 	sourceFixtureState := fixtureState
+	responseFixtureState := fixtureState
+	liveInventoryUnavailable := false
 	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
-		sourceFixtureState = ""
+		// The source inventories currently have fixture builders for their
+		// explicit demo states, but they do not yet have live collectors for
+		// every input required by this correlation. Keep live requests from
+		// promoting those deterministic records into customer findings.
+		sourceFixtureState = "empty"
+		responseFixtureState = ""
+		liveInventoryUnavailable = true
 	}
 
 	sources, err := s.awsSecretPermissionEquivalenceSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
@@ -180,6 +188,26 @@ func (s *Service) GetAWSSecretPermissionEquivalence(ctx context.Context, workspa
 	relationships := awsSecretPermissionEquivalenceRelationships(filtered)
 	diagnostics := awsSecretPermissionEquivalenceDiagnostics(sources)
 	coverageGaps := awsSecretPermissionEquivalenceCoverageGaps(sources)
+	failureReasons := awsSecretPermissionEquivalenceFailureReasons(sources)
+	remediationHints := awsSecretPermissionEquivalenceRemediationHints(sources)
+	if liveInventoryUnavailable {
+		diagnostics = append(diagnostics, AWSSecretPermissionEquivalenceDiagnostic{
+			Collector:   "aws_secret_permission_equivalence",
+			SourceID:    connectorID,
+			Code:        "live_inventory_unavailable",
+			Message:     "Live credential, secret, KMS, and workload inventory is not available yet; deterministic fixture findings were suppressed.",
+			Remediation: "Enable the live AWS inventory collectors before treating an empty equivalence response as proof that no risks exist.",
+			Retryable:   true,
+		})
+		coverageGaps = append(coverageGaps, AWSSecretPermissionEquivalenceCoverageGap{
+			Capability:  "secret_permission_live_inventory",
+			Status:      "unavailable",
+			Reason:      "The connected account does not yet have live source records for every input used by secret-to-permission equivalence.",
+			Remediation: "Run or enable the live credential-reference, Secrets Manager, KMS, and workload inventory collectors for this connector.",
+		})
+		failureReasons = append(failureReasons, "live secret-permission inventory is unavailable")
+		remediationHints = append(remediationHints, "Enable live AWS inventory collectors before interpreting an empty equivalence response as no risk.")
+	}
 	status, confidence := summarizeAWSSecretPermissionEquivalenceStatus(sources, filtered, diagnostics)
 
 	return AWSSecretPermissionEquivalenceResult{
@@ -195,7 +223,7 @@ func (s *Service) GetAWSSecretPermissionEquivalence(ctx context.Context, workspa
 		CurrentIssueRef:    awsIssueRef(awsSecretPermissionEquivalenceCurrentIssue),
 		Version:            awsSecretPermissionEquivalenceVersion,
 		Status:             status,
-		FixtureState:       sourceFixtureState,
+		FixtureState:       responseFixtureState,
 		Confidence:         confidence,
 		CalculationVersion: awsSecretPermissionEquivalenceVersion,
 		AppliedFilters:     applied,
@@ -203,8 +231,8 @@ func (s *Service) GetAWSSecretPermissionEquivalence(ctx context.Context, workspa
 		Findings:           filtered,
 		Relationships:      relationships,
 		Caveats:            awsSecretPermissionEquivalenceCaveats(),
-		FailureReasons:     awsSecretPermissionEquivalenceFailureReasons(sources),
-		RemediationHints:   awsSecretPermissionEquivalenceRemediationHints(sources),
+		FailureReasons:     dedupeStrings(failureReasons),
+		RemediationHints:   dedupeStrings(remediationHints),
 		EvidenceLinks: dedupeStrings([]string{
 			awsIssueURL(awsPlatformDependencyParentIssue),
 			awsIssueURL(awsSecretPermissionEquivalenceCurrentIssue),

--- a/internal/api/aws_secret_permission_equivalence.go
+++ b/internal/api/aws_secret_permission_equivalence.go
@@ -161,6 +161,7 @@ func (s *Service) GetAWSSecretPermissionEquivalence(ctx context.Context, workspa
 	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
 	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
 	sourceFixtureState := fixtureState
+	runtimeFixtureState := fixtureState
 	responseFixtureState := fixtureState
 	liveInventoryUnavailable := false
 	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
@@ -169,11 +170,16 @@ func (s *Service) GetAWSSecretPermissionEquivalence(ctx context.Context, workspa
 		// every input required by this correlation. Keep live requests from
 		// promoting those deterministic records into customer findings.
 		sourceFixtureState = "empty"
+		// Runtime access has a live CloudTrail delivery path when the connector
+		// advertises runtime_evidence. Leave that request unforced so the
+		// runtime collector can choose its live inputs instead of being treated
+		// like a fixture-only inventory.
+		runtimeFixtureState = ""
 		responseFixtureState = ""
 		liveInventoryUnavailable = true
 	}
 
-	sources, err := s.awsSecretPermissionEquivalenceSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	sources, err := s.awsSecretPermissionEquivalenceSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState, runtimeFixtureState)
 	if err != nil {
 		return AWSSecretPermissionEquivalenceResult{}, err
 	}
@@ -268,7 +274,7 @@ func normalizeAWSSecretPermissionEquivalenceFixtureState(requested string, conne
 	}
 }
 
-func (s *Service) awsSecretPermissionEquivalenceSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (awsSecretPermissionEquivalenceSources, error) {
+func (s *Service) awsSecretPermissionEquivalenceSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState, runtimeFixtureState string) (awsSecretPermissionEquivalenceSources, error) {
 	credentials, err := s.GetAWSCredentialReferencesInventory(ctx, workspaceID, projectID, AWSCredentialReferencesInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
 	if err != nil {
 		return awsSecretPermissionEquivalenceSources{}, fmt.Errorf("secret permission equivalence credential references: %w", err)
@@ -281,7 +287,7 @@ func (s *Service) awsSecretPermissionEquivalenceSourceSignals(ctx context.Contex
 	if err != nil {
 		return awsSecretPermissionEquivalenceSources{}, fmt.Errorf("secret permission equivalence kms reachability: %w", err)
 	}
-	runtime, err := s.GetAWSSecretsKMSRuntimeAccess(ctx, workspaceID, projectID, AWSSecretsKMSRuntimeAccessRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	runtime, err := s.GetAWSSecretsKMSRuntimeAccess(ctx, workspaceID, projectID, AWSSecretsKMSRuntimeAccessRequest{ConnectorID: connectorID, FixtureState: runtimeFixtureState})
 	if err != nil {
 		return awsSecretPermissionEquivalenceSources{}, fmt.Errorf("secret permission equivalence runtime access: %w", err)
 	}

--- a/internal/api/aws_secret_permission_equivalence_test.go
+++ b/internal/api/aws_secret_permission_equivalence_test.go
@@ -1,12 +1,15 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/telemetry"
 	"go.uber.org/zap"
 )
@@ -96,6 +99,31 @@ func TestGetAWSSecretPermissionEquivalenceSuppressesFixturesForLiveRequests(t *t
 	}
 	if len(result.CoverageGaps) == 0 || result.CoverageGaps[len(result.CoverageGaps)-1].Capability != "secret_permission_live_inventory" {
 		t.Fatalf("expected a live inventory coverage gap, got %+v", result.CoverageGaps)
+	}
+}
+
+func TestGetAWSSecretPermissionEquivalencePreservesLiveRuntimeInputs(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 21, 13, 3, 0, 0, time.UTC)
+	projectID := "project-secret-permission-equivalence-runtime"
+	seedDefaultProject(t, store, ctx, projectID)
+	seedAWSConnectorForScanTest(t, store, ctx, projectID, "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, projectID, "aws-prod")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	fake := &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{Status: "ready"}}
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, _ AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		return fake, nil
+	}
+
+	_, err := svc.GetAWSSecretPermissionEquivalence(ctx, "default", projectID, AWSSecretPermissionEquivalenceRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get live secret permission equivalence: %v", err)
+	}
+	if fake.calls == 0 {
+		t.Fatalf("live runtime source was forced into fixture mode; delivery factory was never used")
 	}
 }
 

--- a/internal/api/aws_secret_permission_equivalence_test.go
+++ b/internal/api/aws_secret_permission_equivalence_test.go
@@ -72,6 +72,33 @@ func TestGetAWSSecretPermissionEquivalenceBuildsFindingContract(t *testing.T) {
 	}
 }
 
+func TestGetAWSSecretPermissionEquivalenceSuppressesFixturesForLiveRequests(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 2, 0, 0, time.UTC)
+	svc, ws := newSecretPermissionEquivalenceService(t, "project-secret-permission-equivalence-live", now)
+
+	result, err := svc.GetAWSSecretPermissionEquivalence(defaultScopeContext(), ws, "project-secret-permission-equivalence-live", AWSSecretPermissionEquivalenceRequest{
+		ConnectorID: "aws-prod",
+	})
+	if err != nil {
+		t.Fatalf("get live secret permission equivalence: %v", err)
+	}
+	if result.FixtureState != "" {
+		t.Fatalf("live request should not expose a fixture state, got %q", result.FixtureState)
+	}
+	if len(result.Findings) != 0 {
+		t.Fatalf("live request must not surface deterministic fixture findings: %+v", result.Findings)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("live request without source collectors should be degraded, got %q", result.Status)
+	}
+	if len(result.Diagnostics) == 0 || result.Diagnostics[len(result.Diagnostics)-1].Code != "live_inventory_unavailable" {
+		t.Fatalf("expected an explicit live inventory diagnostic, got %+v", result.Diagnostics)
+	}
+	if len(result.CoverageGaps) == 0 || result.CoverageGaps[len(result.CoverageGaps)-1].Capability != "secret_permission_live_inventory" {
+		t.Fatalf("expected a live inventory coverage gap, got %+v", result.CoverageGaps)
+	}
+}
+
 func TestGetAWSSecretPermissionEquivalenceFilters(t *testing.T) {
 	now := time.Date(2026, 6, 21, 13, 5, 0, 0, time.UTC)
 	svc, ws := newSecretPermissionEquivalenceService(t, "project-secret-permission-equivalence-filters", now)

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8134,6 +8134,34 @@ describe('Domain-first app routes', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Evidence' }), { target: { value: 'unavailable' } });
+    await waitFor(() =>
+      expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1', evidence: 'unavailable' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Remediation' }), { target: { value: 'all' } });
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: /Agent provider key equivalence/i })).toBeInTheDocument()
+    );
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Findings search' }), { target: { value: 'openai:api_request' } });
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: /Agent provider key equivalence/i })).toBeInTheDocument()
+    );
+    await waitFor(() =>
+      expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1', search: 'openai:api_request' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
   });
 
   it('shows incomplete live AWS evidence instead of an empty findings result', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8045,8 +8045,8 @@ describe('Domain-first app routes', () => {
       account_id: '123456789012',
       region: 'us-east-1',
       identity_node_id: 'aws:identity:case-triage',
-      agent_id: 'case-triage',
-      agent_name: 'case-triage',
+      agent_id: 'case-triage-id',
+      agent_name: 'Case Triage',
       secret_node_id: 'aws:resource:secret:openai-api-key',
       secret_label: 'openai/api-key',
       provider: 'openai',
@@ -8091,7 +8091,7 @@ describe('Domain-first app routes', () => {
     const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
     expect(within(findingsTable).getByRole('link', { name: /Agent provider key equivalence/i })).toHaveAttribute(
       'href',
-      '/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=case-triage&tab=secrets'
+      '/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=case-triage-id&tab=secrets'
     );
     expect(within(findingsTable).getByText('High')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Review')).toBeInTheDocument();
@@ -8203,6 +8203,38 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent("Couldn't load AWS findings");
     expect(screen.getByText('AWS inventory request failed')).toBeInTheDocument();
     expect(screen.queryByText('No AWS findings')).not.toBeInTheDocument();
+  });
+
+  it('does not show findings as loading when the AWS connector is not ready', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Connect AWS to load operational context')).toBeInTheDocument();
+    expect(screen.queryByText('Loading AWS findings')).not.toBeInTheDocument();
   });
 
   it('keeps AWS resources inventory metadata-only when no environment exists', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -6906,8 +6906,12 @@ describe('Domain-first app routes', () => {
     expect(screen.getByText(/Passrole unscoped trust path/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS cross-account trust findings' })).toBeInTheDocument();
     expect(screen.getByText(/Cross account resource access/i)).toBeInTheDocument();
-    expect(await screen.findByRole('table', { name: 'AWS secret-to-permission equivalence findings' })).toBeInTheDocument();
-    expect(screen.getByText(/Agent provider key equivalence/i)).toBeInTheDocument();
+    const secretPermissionTable = await screen.findByRole('table', { name: 'AWS secret-to-permission equivalence findings' });
+    expect(secretPermissionTable).toBeInTheDocument();
+    expect(within(secretPermissionTable).getByRole('link', { name: /Agent provider key equivalence/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=case-triage&tab=secrets'
+    );
     expect(getLeastPrivilege).toHaveBeenCalledWith(
       'workspace-a',
       'production',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8124,6 +8124,16 @@ describe('Domain-first app routes', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Remediation' }), { target: { value: 'blocked' } });
+    await waitFor(() =>
+      expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1', status: 'blocked' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
   });
 
   it('shows incomplete live AWS evidence instead of an empty findings result', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8035,10 +8035,34 @@ describe('Domain-first app routes', () => {
       ]
     });
     vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const equivalenceFinding = {
+      finding_id: 'aws-secret-permission-equivalence:findings-route',
+      equivalence_type: 'agent_provider_key_equivalence',
+      severity: 'high',
+      status: 'review',
+      score: 82,
+      confidence: 0.9,
+      account_id: '123456789012',
+      region: 'us-east-1',
+      identity_node_id: 'aws:identity:case-triage',
+      agent_id: 'case-triage',
+      agent_name: 'case-triage',
+      secret_node_id: 'aws:resource:secret:openai-api-key',
+      secret_label: 'openai/api-key',
+      provider: 'openai',
+      equivalent_permissions: ['openai:api_request'],
+      source_signals: ['ai_agent_identities'],
+      rationale: 'Agent provider-key metadata is readable.',
+      evidence_boundary: 'metadata_only_no_secret_values_no_payloads',
+      impacted_nodes: ['aws:identity:case-triage', 'aws:resource:secret:openai-api-key'],
+      impacted_path: [],
+      evidence: [],
+      next_action: 'Review the provider credential scope.'
+    } as any;
     const getSecretPermissionEquivalence = vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockResolvedValue({
       findings: {
         status: 'ready',
-        findings: [],
+        findings: [equivalenceFinding],
         summary: {
           external_provider_key_count: 0,
           aws_managed_secret_count: 0,
@@ -8064,6 +8088,14 @@ describe('Domain-first app routes', () => {
     );
 
     expect(await screen.findByRole('heading', { level: 2, name: 'Findings' })).toBeInTheDocument();
+    const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
+    expect(within(findingsTable).getByRole('link', { name: /Agent provider key equivalence/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=case-triage&tab=secrets'
+    );
+    expect(within(findingsTable).getByText('High')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Review')).toBeInTheDocument();
+    expect(screen.queryByRole('table', { name: 'AWS secret-to-permission equivalence findings' })).not.toBeInTheDocument();
     await waitFor(() =>
       expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
         'workspace-a',
@@ -8092,6 +8124,85 @@ describe('Domain-first app routes', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
+  });
+
+  it('shows incomplete live AWS evidence instead of an empty findings result', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockResolvedValue({
+      findings: {
+        status: 'degraded',
+        findings: [],
+        failure_reasons: ['live secret-permission inventory is unavailable'],
+        summary: {},
+        caveats: [],
+        remediation_hints: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Live AWS findings are not available yet')).toBeInTheDocument();
+    expect(screen.getByText('live secret-permission inventory is unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('No AWS findings')).not.toBeInTheDocument();
+  });
+
+  it('shows AWS findings load errors separately from an empty result', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockRejectedValue(new Error('AWS inventory request failed'));
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Couldn't load AWS findings");
+    expect(screen.getByText('AWS inventory request failed')).toBeInTheDocument();
+    expect(screen.queryByText('No AWS findings')).not.toBeInTheDocument();
   });
 
   it('keeps AWS resources inventory metadata-only when no environment exists', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8105,6 +8105,28 @@ describe('Domain-first app routes', () => {
       )
     );
 
+    fireEvent.change(screen.getByRole('combobox', { name: 'Account' }), { target: { value: 'unknown' } });
+    await waitFor(() =>
+      expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(getSecretPermissionEquivalence.mock.lastCall?.[2]?.accountID).toBeUndefined();
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Region' }), { target: { value: 'unknown' } });
+    await waitFor(() =>
+      expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(getSecretPermissionEquivalence.mock.lastCall?.[2]?.region).toBeUndefined();
+
     fireEvent.change(screen.getByRole('combobox', { name: 'Severity' }), { target: { value: 'high' } });
     fireEvent.change(screen.getByRole('combobox', { name: 'Account' }), { target: { value: 'connected' } });
     fireEvent.change(screen.getByRole('combobox', { name: 'Region' }), { target: { value: 'current' } });
@@ -8148,6 +8170,35 @@ describe('Domain-first app routes', () => {
     fireEvent.change(screen.getByRole('combobox', { name: 'Remediation' }), { target: { value: 'all' } });
     await waitFor(() =>
       expect(screen.getByRole('link', { name: /Agent provider key equivalence/i })).toBeInTheDocument()
+    );
+
+    equivalenceFinding.evidence = [
+      {
+        source: 'secrets_kms_runtime_access',
+        evidence_ref: 'runtime-evidence://secret-read',
+        label: 'Runtime secret read',
+        confidence: 0.9,
+        relationship: 'read'
+      },
+      {
+        source: 'kms_key_policy',
+        evidence_ref: 'inventory-evidence://kms-policy',
+        label: 'KMS key policy',
+        confidence: 0.8,
+        relationship: 'decrypt'
+      }
+    ];
+    fireEvent.change(screen.getByRole('combobox', { name: 'Evidence' }), { target: { value: 'inventory-backed' } });
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: /Agent provider key equivalence/i })).toBeInTheDocument()
+    );
+    await waitFor(() =>
+      expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1', evidence: 'inventory-backed' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
     );
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Findings search' }), { target: { value: 'openai:api_request' } });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -17986,7 +17986,7 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
   return {
     id: finding.finding_id,
     title: awsSecretPermissionEquivalenceLabel(finding),
-    category: formatTokenLabel(finding.equivalence_type),
+    category: formatTokenLabel(finding.severity),
     evidence,
     owner: identity || 'Unknown identity',
     blastRadius: `${awsAccountRegionInventoryLabel(finding.account_id, finding.region)} · ${identity || 'Unknown identity'} · ${secret}`,
@@ -17999,7 +17999,7 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
       account: connection?.account_id && connection.account_id === finding.account_id ? 'connected' : 'unknown',
       region: connection?.region && connection.region === finding.region ? 'current' : 'unknown',
       evidence: finding.source_signals.some((source) => source.includes('runtime')) ? 'runtime-backed' : 'inventory-backed',
-      status: 'all'
+      status: awsSecretPermissionEquivalenceFindingStatusFilterToken(finding.status)
     },
     searchText: inventorySearchText([
       finding.finding_id,
@@ -18017,11 +18017,27 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
   };
 }
 
+function awsSecretPermissionEquivalenceFindingStatusFilterToken(value: string | undefined): string {
+  switch (normalizeFilterValue(value ?? '')) {
+    case 'action_required':
+      return 'open';
+    case 'review':
+      return 'queued';
+    case 'blocked':
+      return 'blocked';
+    default:
+      return 'unavailable';
+  }
+}
+
 function AWSFindingsContent({
   findings,
   scope,
   environmentID,
   connection,
+  loading,
+  error,
+  onRetry,
   filters,
   onFiltersChange
 }: {
@@ -18029,38 +18045,56 @@ function AWSFindingsContent({
   scope: ProductSession | null;
   environmentID?: string;
   connection: AWSConnectionStatus | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
   const rows = findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, scope, environmentID, connection)) ?? [];
   const displayedRows = filterAWSInventoryRows(rows, filters);
+  const isLoading = loading || (!findings && !error);
 
   return (
     <>
       <AWSRiskOperationFilterSet routeID="findings" filters={filters} onChange={onFiltersChange} />
-      <DomainDataTable
-        label="AWS findings"
-        rows={displayedRows}
-        getRowKey={(row) => row.id}
-        emptyState={
-          <DomainEmptyState
-            eyebrow={findings?.status === 'degraded' ? 'Evidence incomplete' : 'Empty'}
-            title={findings?.status === 'degraded' ? 'Live AWS findings are not available yet' : 'No AWS findings'}
-            body={
-              findings?.status === 'degraded'
-                ? findings.failure_reasons[0] ?? 'Live AWS inventory is unavailable, so Identrail is not presenting sample findings as customer risk.'
-                : 'No live AWS finding matches this environment yet. Run the collectors or clear filters to load evidence.'
-            }
-          />
-        }
-        columns={[
-          { key: 'title', header: 'Finding', render: (row) => row.detailLink ? <Link to={row.detailLink}>{row.title}</Link> : <strong>{row.title}</strong> },
-          { key: 'category', header: 'Severity', render: (row) => row.category },
-          { key: 'evidence', header: 'Evidence', render: (row) => row.evidence },
-          { key: 'blast', header: 'Blast radius', render: (row) => row.blastRadius },
-          { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={formatTokenLabel(row.status)} /> }
-        ]}
-      />
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS findings"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : isLoading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Loading AWS findings"
+          body="Identrail is retrieving the latest AWS evidence for this environment."
+        />
+      ) : (
+        <DomainDataTable
+          label="AWS findings"
+          rows={displayedRows}
+          getRowKey={(row) => row.id}
+          emptyState={
+            <DomainEmptyState
+              eyebrow={findings?.status === 'degraded' ? 'Evidence incomplete' : 'Empty'}
+              title={findings?.status === 'degraded' ? 'Live AWS findings are not available yet' : 'No AWS findings'}
+              body={
+                findings?.status === 'degraded'
+                  ? findings.failure_reasons[0] ?? 'Live AWS inventory is unavailable, so Identrail is not presenting sample findings as customer risk.'
+                  : 'No live AWS finding matches this environment yet. Run the collectors or clear filters to load evidence.'
+              }
+            />
+          }
+          columns={[
+            { key: 'title', header: 'Finding', render: (row) => row.detailLink ? <Link to={row.detailLink}>{row.title}</Link> : <strong>{row.title}</strong> },
+            { key: 'category', header: 'Severity', render: (row) => row.category },
+            { key: 'evidence', header: 'Evidence', render: (row) => row.evidence },
+            { key: 'blast', header: 'Blast radius', render: (row) => row.blastRadius },
+            { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={formatTokenLabel(row.status)} /> }
+          ]}
+        />
+      )}
     </>
   );
 }
@@ -18419,7 +18453,8 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     setActiveFilters({ ...AWS_RISK_OPERATION_FILTER_DEFAULTS[routeID] });
   }, [routeID]);
 
-  const showSecretPermissionEquivalence = routeID === 'runtime' || routeID === 'findings';
+  const showSecretPermissionEquivalence = routeID === 'runtime';
+  const shouldLoadSecretPermissionEquivalence = routeID === 'runtime' || routeID === 'findings';
 
   const loadGraphExplorer = useCallback(async ({ append = false }: { append?: boolean } = {}) => {
     const requestID = ++graphExplorerRequestRef.current;
@@ -20216,7 +20251,7 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     const requestID = ++secretPermissionEquivalenceRequestRef.current;
     setSecretPermissionEquivalence(null);
     setSecretPermissionEquivalenceError('');
-    if (!showSecretPermissionEquivalence || !scope || !selectedEnvironmentID || !connection?.connected) {
+    if (!shouldLoadSecretPermissionEquivalence || !scope || !selectedEnvironmentID || !connection?.connected) {
       setSecretPermissionEquivalenceLoading(false);
       return;
     }
@@ -20247,7 +20282,7 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       }
     }
   }, [
-    showSecretPermissionEquivalence,
+    shouldLoadSecretPermissionEquivalence,
     scope?.tenantID,
     scope?.workspaceID,
     selectedEnvironmentID,
@@ -20648,6 +20683,9 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             scope={scope}
             environmentID={selectedEnvironmentID}
             connection={connection}
+            loading={secretPermissionEquivalenceLoading}
+            error={secretPermissionEquivalenceError}
+            onRetry={loadSecretPermissionEquivalence}
             filters={activeFilters}
             onFiltersChange={onFiltersChange}
           />

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -17084,17 +17084,19 @@ function awsSecretPermissionEquivalenceEvidenceFilterToken(finding: AWSSecretPer
   if (finding.evidence.length === 0) {
     return 'unavailable';
   }
+  const tokens: string[] = [];
+  if (finding.evidence.some((evidence) => evidence.source.trim().toLowerCase() === 'secrets_kms_runtime_access')) {
+    tokens.push('runtime-backed');
+  }
   if (
     finding.evidence.some(
-      (evidence) => evidence.source.trim().toLowerCase() === 'secrets_kms_runtime_access'
+      (evidence) =>
+        evidence.source.trim().length > 0 && evidence.source.trim().toLowerCase() !== 'secrets_kms_runtime_access'
     )
   ) {
-    return 'runtime-backed';
+    tokens.push('inventory-backed');
   }
-  if (finding.evidence.some((evidence) => evidence.source.trim().length > 0)) {
-    return 'inventory-backed';
-  }
-  return '';
+  return tokens.join(',');
 }
 
 function awsSecretPermissionEquivalenceSearchText(finding: AWSSecretPermissionEquivalenceFinding): string {
@@ -17667,7 +17669,7 @@ function awsSecretPermissionEquivalenceAccountFilterToken(
     case 'connected':
       return connection?.account_id || undefined;
     case 'unknown':
-      return 'unknown';
+      return undefined;
     default:
       return awsSecretPermissionEquivalenceFilterToken(value);
   }
@@ -17681,7 +17683,7 @@ function awsSecretPermissionEquivalenceRegionFilterToken(
     case 'current':
       return connection?.region || undefined;
     case 'unknown':
-      return 'unknown';
+      return undefined;
     default:
       return awsSecretPermissionEquivalenceFilterToken(value);
   }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -13052,6 +13052,7 @@ type AWSRiskOperationTableRow = AWSInventoryFilterable & {
   nextAction: string;
   status: string;
   stage: AWSCapabilityStage;
+  detailLink?: string;
 };
 
 function AWSRiskOperationFilterSet({
@@ -17087,16 +17088,39 @@ function awsSecretPermissionEquivalencePermissionLabel(finding: AWSSecretPermiss
   return `${formatTokenLabel(finding.provider)} · ${permissions.slice(0, 2).join(', ')}${permissions.length > 2 ? ` +${permissions.length - 2}` : ''}`;
 }
 
+function awsSecretPermissionEquivalenceDetailLink(
+  scope: ProductSession | null | undefined,
+  environmentID: string | undefined,
+  finding: AWSSecretPermissionEquivalenceFinding
+): string | undefined {
+  if (!scope || !environmentID) {
+    return undefined;
+  }
+  const agent = finding.agent_name || finding.agent_id;
+  if (agent) {
+    return awsAgentIdentityDetailLink(scope, environmentID, agent, 'secrets');
+  }
+  const identity = finding.principal_arn || finding.workload_id || finding.identity_node_id;
+  if (!identity || identity === '*') {
+    return undefined;
+  }
+  return awsMachineIdentityDetailLink(scope, environmentID, identity, 'secrets');
+}
+
 function AWSSecretPermissionEquivalenceContent({
   findings,
   loading,
   error,
-  onRetry
+  onRetry,
+  scope,
+  environmentID
 }: {
   findings: AWSSecretPermissionEquivalenceResult | null;
   loading: boolean;
   error: string;
   onRetry: () => void;
+  scope?: ProductSession | null;
+  environmentID?: string;
 }) {
   const rows = findings?.findings ?? [];
   const summaryLine = findings
@@ -17168,7 +17192,15 @@ function AWSSecretPermissionEquivalenceContent({
           rows={rows}
           getRowKey={(row) => row.finding_id}
           columns={[
-            { key: 'finding', header: 'Finding', render: (row) => <strong>{awsSecretPermissionEquivalenceLabel(row)}</strong> },
+            {
+              key: 'finding',
+              header: 'Finding',
+              render: (row) => {
+                const label = awsSecretPermissionEquivalenceLabel(row);
+                const detailLink = awsSecretPermissionEquivalenceDetailLink(scope, environmentID, row);
+                return detailLink ? <Link to={detailLink}>{label}</Link> : <strong>{label}</strong>;
+              }
+            },
             { key: 'identity', header: 'Identity', render: (row) => awsSecretPermissionEquivalenceIdentityLabel(row) },
             { key: 'secret', header: 'Secret', render: (row) => row.secret_label || row.secret_arn || row.secret_node_id },
             { key: 'permission', header: 'Equivalent permission', render: (row) => awsSecretPermissionEquivalencePermissionLabel(row) },
@@ -17941,14 +17973,66 @@ function AWSGraphEvidenceDrawer({ refs }: { refs: string[] }) {
   );
 }
 
+function awsSecretPermissionEquivalenceRiskOperationRow(
+  finding: AWSSecretPermissionEquivalenceFinding,
+  scope: ProductSession | null | undefined,
+  environmentID: string | undefined,
+  connection: AWSConnectionStatus | null
+): AWSRiskOperationTableRow {
+  const identity = awsSecretPermissionEquivalenceIdentityLabel(finding);
+  const secret = finding.secret_label || finding.secret_arn || finding.secret_node_id;
+  const evidence = awsSecretPermissionEquivalenceEvidenceLabel(finding);
+  const detailLink = awsSecretPermissionEquivalenceDetailLink(scope, environmentID, finding);
+  return {
+    id: finding.finding_id,
+    title: awsSecretPermissionEquivalenceLabel(finding),
+    category: formatTokenLabel(finding.equivalence_type),
+    evidence,
+    owner: identity || 'Unknown identity',
+    blastRadius: `${awsAccountRegionInventoryLabel(finding.account_id, finding.region)} · ${identity || 'Unknown identity'} · ${secret}`,
+    nextAction: finding.next_action,
+    status: finding.status,
+    stage: awsSecretPermissionEquivalenceStage(finding),
+    detailLink,
+    filters: {
+      severity: finding.severity || 'unknown',
+      account: connection?.account_id && connection.account_id === finding.account_id ? 'connected' : 'unknown',
+      region: connection?.region && connection.region === finding.region ? 'current' : 'unknown',
+      evidence: finding.source_signals.some((source) => source.includes('runtime')) ? 'runtime-backed' : 'inventory-backed',
+      status: 'all'
+    },
+    searchText: inventorySearchText([
+      finding.finding_id,
+      finding.equivalence_type,
+      finding.severity,
+      finding.status,
+      identity,
+      secret,
+      finding.provider,
+      finding.provider_key_reference,
+      finding.rationale,
+      finding.next_action,
+      evidence
+    ])
+  };
+}
+
 function AWSFindingsContent({
+  findings,
+  scope,
+  environmentID,
+  connection,
   filters,
   onFiltersChange
 }: {
+  findings: AWSSecretPermissionEquivalenceResult | null;
+  scope: ProductSession | null;
+  environmentID?: string;
+  connection: AWSConnectionStatus | null;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
-  const rows: AWSRiskOperationTableRow[] = [];
+  const rows = findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, scope, environmentID, connection)) ?? [];
   const displayedRows = filterAWSInventoryRows(rows, filters);
 
   return (
@@ -17960,13 +18044,17 @@ function AWSFindingsContent({
         getRowKey={(row) => row.id}
         emptyState={
           <DomainEmptyState
-            eyebrow="Empty"
-            title="No AWS findings"
-            body="No AWS finding matches this environment yet. Connect AWS or clear filters to load graph, runtime, and inventory evidence."
+            eyebrow={findings?.status === 'degraded' ? 'Evidence incomplete' : 'Empty'}
+            title={findings?.status === 'degraded' ? 'Live AWS findings are not available yet' : 'No AWS findings'}
+            body={
+              findings?.status === 'degraded'
+                ? findings.failure_reasons[0] ?? 'Live AWS inventory is unavailable, so Identrail is not presenting sample findings as customer risk.'
+                : 'No live AWS finding matches this environment yet. Run the collectors or clear filters to load evidence.'
+            }
           />
         }
         columns={[
-          { key: 'title', header: 'Finding', render: (row) => <strong>{row.title}</strong> },
+          { key: 'title', header: 'Finding', render: (row) => row.detailLink ? <Link to={row.detailLink}>{row.title}</Link> : <strong>{row.title}</strong> },
           { key: 'category', header: 'Severity', render: (row) => row.category },
           { key: 'evidence', header: 'Evidence', render: (row) => row.evidence },
           { key: 'blast', header: 'Blast radius', render: (row) => row.blastRadius },
@@ -20515,6 +20603,8 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={secretPermissionEquivalenceLoading}
             error={secretPermissionEquivalenceError}
             onRetry={loadSecretPermissionEquivalence}
+            scope={scope}
+            environmentID={selectedEnvironmentID}
           />
         ) : null}
         {routeID === 'observability' ? (
@@ -20554,6 +20644,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
         ) : null}
         {routeID === 'findings' ? (
           <AWSFindingsContent
+            findings={secretPermissionEquivalence}
+            scope={scope}
+            environmentID={selectedEnvironmentID}
+            connection={connection}
             filters={activeFilters}
             onFiltersChange={onFiltersChange}
           />

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -17080,6 +17080,52 @@ function awsSecretPermissionEquivalenceEvidenceLabel(finding: AWSSecretPermissio
   return `${formatConfidenceScore(finding.confidence)} · ${sources.join(', ') || 'No evidence refs'}`;
 }
 
+function awsSecretPermissionEquivalenceEvidenceFilterToken(finding: AWSSecretPermissionEquivalenceFinding): string {
+  if (finding.evidence.length === 0) {
+    return 'unavailable';
+  }
+  if (
+    finding.evidence.some(
+      (evidence) => evidence.source.trim().toLowerCase() === 'secrets_kms_runtime_access'
+    )
+  ) {
+    return 'runtime-backed';
+  }
+  if (finding.evidence.some((evidence) => evidence.source.trim().length > 0)) {
+    return 'inventory-backed';
+  }
+  return '';
+}
+
+function awsSecretPermissionEquivalenceSearchText(finding: AWSSecretPermissionEquivalenceFinding): string {
+  return inventorySearchText([
+    finding.account_id,
+    finding.region,
+    finding.identity_node_id,
+    finding.principal_arn,
+    finding.workload_id,
+    finding.workload_name,
+    finding.agent_id,
+    finding.agent_name,
+    finding.secret_node_id,
+    finding.secret_arn,
+    finding.secret_label,
+    finding.provider,
+    finding.provider_key_reference,
+    finding.equivalence_type,
+    finding.severity,
+    finding.status,
+    finding.rationale,
+    finding.evidence_boundary,
+    ...(finding.equivalent_permissions ?? []),
+    ...(finding.implied_actions ?? []),
+    ...(finding.source_signals ?? []),
+    ...(finding.impacted_nodes ?? []),
+    ...finding.evidence.flatMap((evidence) => [evidence.source, evidence.evidence_ref, evidence.label, evidence.relationship]),
+    ...finding.impacted_path.flatMap((step) => [step.node_id, step.node_type, step.label, step.account_id, step.region])
+  ]);
+}
+
 function awsSecretPermissionEquivalencePermissionLabel(finding: AWSSecretPermissionEquivalenceFinding): string {
   const permissions = finding.equivalent_permissions ?? [];
   if (permissions.length === 0) {
@@ -17998,22 +18044,10 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
       severity: finding.severity || 'unknown',
       account: connection?.account_id && connection.account_id === finding.account_id ? 'connected' : 'unknown',
       region: connection?.region && connection.region === finding.region ? 'current' : 'unknown',
-      evidence: finding.source_signals.some((source) => source.includes('runtime')) ? 'runtime-backed' : 'inventory-backed',
+      evidence: awsSecretPermissionEquivalenceEvidenceFilterToken(finding),
       status: awsSecretPermissionEquivalenceFindingStatusFilterToken(finding.status)
     },
-    searchText: inventorySearchText([
-      finding.finding_id,
-      finding.equivalence_type,
-      finding.severity,
-      finding.status,
-      identity,
-      secret,
-      finding.provider,
-      finding.provider_key_reference,
-      finding.rationale,
-      finding.next_action,
-      evidence
-    ])
+    searchText: awsSecretPermissionEquivalenceSearchText(finding)
   };
 }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -17605,7 +17605,7 @@ function awsSecretPermissionEquivalenceStatusFilterToken(value: string | undefin
     case 'queued':
       return 'review';
     case 'blocked':
-      return 'action_required';
+      return 'blocked';
     case 'unavailable':
       return undefined;
     default:

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -17096,7 +17096,7 @@ function awsSecretPermissionEquivalenceDetailLink(
   if (!scope || !environmentID) {
     return undefined;
   }
-  const agent = finding.agent_name || finding.agent_id;
+  const agent = finding.agent_id || finding.agent_name;
   if (agent) {
     return awsAgentIdentityDetailLink(scope, environmentID, agent, 'secrets');
   }
@@ -18053,7 +18053,8 @@ function AWSFindingsContent({
 }) {
   const rows = findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, scope, environmentID, connection)) ?? [];
   const displayedRows = filterAWSInventoryRows(rows, filters);
-  const isLoading = loading || (!findings && !error);
+  const isReadyToLoad = Boolean(scope && environmentID && connection?.connected);
+  const isLoading = loading || (isReadyToLoad && !findings && !error);
 
   return (
     <>


### PR DESCRIPTION
## Summary

- suppress deterministic AWS fixture records for live connected-account requests
- surface an explicit degraded state and coverage gap when live secret-permission inventory is unavailable
- populate the AWS findings table from secret-permission equivalence results
- link findings to the relevant machine-identity or agent detail view when an identity is available

## Root cause

The live secret-to-permission request cleared `fixture_state`, but the downstream inventory builders treated the resulting state as `success` and returned their built-in demo records. This made placeholder identities, accounts, and KMS IDs appear as customer findings. The AWS findings table was also rendered from an empty hard-coded row list, and equivalence rows had no detail links.

## Validation

- `go test ./internal/api`
- `npm test -- --run src/productShell.test.tsx` (303 tests)
- `npm run build`
- pre-push hooks passed

This change is read-only and does not grant or execute AWS remediation permissions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses deterministic AWS fixture findings in live-connected AWS environments and preserves live runtime evidence to avoid showing demo identities or KMS IDs as customer findings. Previously, clearing fixtures let built-in demo records appear; now live requests suppress fixture sources, keep runtime inputs live, return no findings until collectors run, and show a degraded state with explicit diagnostics and coverage gaps.

• Service
- For live requests, force source inventories to fixture "empty" while keeping runtime inputs live; return a blank response `FixtureState`.
- Add diagnostic `live_inventory_unavailable` and coverage gap `secret_permission_live_inventory`; dedupe failure reasons and remediation hints.
- Keep status degraded and suppress deterministic fixture findings until collectors populate live inputs.

• Web
- Populate the unified "AWS findings" table from secret‑permission equivalence and hide the per‑equivalence table; link finding titles to agent or machine identity detail views using the current scope/environment.
- Align filters and search with the API: Remediation "Blocked" sends `status: 'blocked'`; Account/Region "Unknown" omit tokens; Evidence uses `unavailable | inventory-backed | runtime-backed`; search sends `search`.
- Separate load errors from empty results; show degraded "Evidence incomplete" messaging; do not show "Loading" when the AWS connector is not ready.

<sup>Written for commit 4370ee80c3a2278d4465e12ca218931a62a6e441. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

