### PR TITLE
Add asynchronous AWS discovery flow

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -84,6 +84,11 @@ x-identrail-route-authorizations:
     action: scans.read
     resource_type: scan
   - method: GET
+    path: /v1/scans/{scan_id}
+    action: scans.read
+    resource_type: scan
+    resource_id_param: scan_id
+  - method: GET
     path: /v1/scans/{scan_id}/diff
     action: scans.read
     resource_type: scan_diff
@@ -10038,6 +10043,39 @@ paths:
                 $ref: "#/components/schemas/AWSPlatformBaselineNotReadyResponse"
         "429":
           $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/scans/{scan_id}:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [Scans]
+      summary: Get scan status
+      operationId: getScan
+      parameters:
+        - in: path
+          name: scan_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Scan status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  scan:
+                    $ref: "#/components/schemas/ScanRecord"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
   /v1/scans/{scan_id}/diff:

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -291,6 +291,7 @@ func (r *storeBackedCentralPolicyRuntimeResolver) compiledVersion(version db.Aut
 	// omission. A future route addition must be added to this explicit list and
 	// covered by the compatibility test below.
 	compiled = overlayRouteAuthorizationPolicyCompatibility(compiled, r.fallback, []routePolicyDefinition{
+		{Method: http.MethodGet, Path: "/v1/scans/:scan_id", Action: policyActionScansRead, ResourceType: "scan", ResourceIDParam: "scan_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/rollouts/:rollout_id/reconcile", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/rollouts/:rollout_id/retry", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},
 	})

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -705,6 +705,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/relationships", Action: policyActionGraphRead, ResourceType: "relationship"},
 		{Method: http.MethodGet, Path: "/v1/ownership/signals", Action: policyActionGraphRead, ResourceType: "ownership_signal"},
 		{Method: http.MethodGet, Path: "/v1/scans", Action: policyActionScansRead, ResourceType: "scan"},
+		{Method: http.MethodGet, Path: "/v1/scans/:scan_id", Action: policyActionScansRead, ResourceType: "scan", ResourceIDParam: "scan_id"},
 		{Method: http.MethodGet, Path: "/v1/scans/:scan_id/diff", Action: policyActionScansRead, ResourceType: "scan_diff", ResourceIDParam: "scan_id"},
 		{Method: http.MethodGet, Path: "/v1/scans/:scan_id/events", Action: policyActionScansRead, ResourceType: "scan_event", ResourceIDParam: "scan_id"},
 		{Method: http.MethodPost, Path: "/v1/scans", Action: policyActionScansRun, ResourceType: "scan"},

--- a/internal/api/authz_policy_bundle_runtime_test.go
+++ b/internal/api/authz_policy_bundle_runtime_test.go
@@ -697,16 +697,21 @@ func TestCentralPolicyRuntimeResolverOverlaysNewRolloutRoutesOnPersistedVersion(
 	if err != nil {
 		t.Fatalf("resolve persisted policy version: %v", err)
 	}
-	for _, path := range []string{
-		"/v1/workspaces/:workspace_id/projects/:project_id/aws/rollouts/:rollout_id/reconcile",
-		"/v1/workspaces/:workspace_id/projects/:project_id/aws/rollouts/:rollout_id/retry",
+	for _, test := range []struct {
+		method string
+		path   string
+		action string
+	}{
+		{method: "GET", path: "/v1/scans/:scan_id", action: policyActionScansRead},
+		{method: "POST", path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/rollouts/:rollout_id/reconcile", action: policyActionTenancyWrite},
+		{method: "POST", path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/rollouts/:rollout_id/retry", action: policyActionTenancyWrite},
 	} {
-		policy, exists := resolved.Registry.lookup("POST", path)
+		policy, exists := resolved.Registry.lookup(test.method, test.path)
 		if !exists {
-			t.Fatalf("expected compatibility overlay for POST %s", path)
+			t.Fatalf("expected compatibility overlay for %s %s", test.method, test.path)
 		}
-		if policy.Action != policyActionTenancyWrite {
-			t.Fatalf("expected tenancy.write for POST %s, got %q", path, policy.Action)
+		if policy.Action != test.action {
+			t.Fatalf("expected %s for %s %s, got %q", test.action, test.method, test.path, policy.Action)
 		}
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -861,6 +861,24 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
+	v1.GET("/scans/:scan_id", func(c *gin.Context) {
+		scanID, ok := requiredUUIDParam(c, c.Param("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
+		item, err := svc.GetScan(c.Request.Context(), scanID)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "scan not found"})
+				return
+			}
+			logger.Error("get scan", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get scan"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"scan": item})
+	})
+
 	v1.GET("/scans/:scan_id/diff", func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		scanID, ok := requiredUUIDParam(c, c.Param("scan_id"), "scan_id")

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -489,6 +489,20 @@ func TestRouterRunsScanAndListsData(t *testing.T) {
 		t.Fatalf("expected completed scan detail, got %+v", detailBody.Scan)
 	}
 
+	invalidDetailReq := httptest.NewRequest(http.MethodGet, "/v1/scans/not-a-uuid", nil)
+	invalidDetailW := httptest.NewRecorder()
+	r.ServeHTTP(invalidDetailW, invalidDetailReq)
+	if invalidDetailW.Code != http.StatusBadRequest {
+		t.Fatalf("expected malformed scan detail 400, got %d", invalidDetailW.Code)
+	}
+
+	missingDetailReq := httptest.NewRequest(http.MethodGet, "/v1/scans/00000000-0000-0000-0000-000000000000", nil)
+	missingDetailW := httptest.NewRecorder()
+	r.ServeHTTP(missingDetailW, missingDetailReq)
+	if missingDetailW.Code != http.StatusNotFound {
+		t.Fatalf("expected missing scan detail 404, got %d", missingDetailW.Code)
+	}
+
 	phaseEventsReq := httptest.NewRequest(http.MethodGet, "/v1/scans/"+firstScanID+"/events", nil)
 	phaseEventsW := httptest.NewRecorder()
 	r.ServeHTTP(phaseEventsW, phaseEventsReq)

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -473,6 +473,44 @@ func TestRouterRunsScanAndListsData(t *testing.T) {
 		t.Fatal("expected first queued scan to be processed")
 	}
 
+	detailReq := httptest.NewRequest(http.MethodGet, "/v1/scans/"+firstScanID, nil)
+	detailW := httptest.NewRecorder()
+	r.ServeHTTP(detailW, detailReq)
+	if detailW.Code != http.StatusOK {
+		t.Fatalf("expected scan detail 200, got %d", detailW.Code)
+	}
+	var detailBody struct {
+		Scan db.ScanRecord `json:"scan"`
+	}
+	if err := json.Unmarshal(detailW.Body.Bytes(), &detailBody); err != nil {
+		t.Fatalf("decode scan detail body: %v", err)
+	}
+	if detailBody.Scan.ID != firstScanID || detailBody.Scan.Status != "succeeded" {
+		t.Fatalf("expected completed scan detail, got %+v", detailBody.Scan)
+	}
+
+	phaseEventsReq := httptest.NewRequest(http.MethodGet, "/v1/scans/"+firstScanID+"/events", nil)
+	phaseEventsW := httptest.NewRecorder()
+	r.ServeHTTP(phaseEventsW, phaseEventsReq)
+	if phaseEventsW.Code != http.StatusOK {
+		t.Fatalf("expected scan events 200, got %d", phaseEventsW.Code)
+	}
+	var eventsBody struct {
+		Items []db.ScanEvent `json:"items"`
+	}
+	if err := json.Unmarshal(phaseEventsW.Body.Bytes(), &eventsBody); err != nil {
+		t.Fatalf("decode scan events body: %v", err)
+	}
+	seenPhases := map[string]bool{}
+	for _, event := range eventsBody.Items {
+		if phase, ok := event.Metadata["phase"].(string); ok {
+			seenPhases[phase] = true
+		}
+	}
+	if !seenPhases["collecting"] || !seenPhases["analyzing"] {
+		t.Fatalf("expected collecting and analyzing scan phases, got %v", seenPhases)
+	}
+
 	postReq2 := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
 	postW2 := httptest.NewRecorder()
 	r.ServeHTTP(postW2, postReq2)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -952,7 +952,24 @@ func (s *Service) runScanWithRecord(ctx context.Context, record db.ScanRecord, a
 		"phase":    "collecting",
 		"provider": record.Provider,
 	})
-	result, err := scanner.Run(ctx)
+	var (
+		result               app.ScanResult
+		analysisPhaseEmitted bool
+	)
+	if phaseScanner, ok := scanner.(app.PhaseAwareScanner); ok {
+		result, err = phaseScanner.RunWithPhase(ctx, func(phase string) {
+			if phase != "analyzing" {
+				return
+			}
+			analysisPhaseEmitted = true
+			s.appendScanEvent(ctx, record.ID, db.ScanEventLevelInfo, "analyzing collected evidence", map[string]any{
+				"phase":    "analyzing",
+				"provider": record.Provider,
+			})
+		})
+	} else {
+		result, err = scanner.Run(ctx)
+	}
 	if err != nil {
 		if handleErr := s.handleScanFailure(ctx, record, allowRetry, scanFailureStageExecution, 0, 0, err, "scan failed during collection/analysis"); handleErr != nil {
 			return RunScanResult{}, handleErr
@@ -962,10 +979,12 @@ func (s *Service) runScanWithRecord(ctx context.Context, record db.ScanRecord, a
 		}
 		return RunScanResult{}, err
 	}
-	s.appendScanEvent(ctx, record.ID, db.ScanEventLevelInfo, "analyzing collected evidence", map[string]any{
-		"phase":    "analyzing",
-		"provider": record.Provider,
-	})
+	if !analysisPhaseEmitted {
+		s.appendScanEvent(ctx, record.ID, db.ScanEventLevelInfo, "analyzing collected evidence", map[string]any{
+			"phase":    "analyzing",
+			"provider": record.Provider,
+		})
+	}
 	result.Findings = enrichFindings(result.Findings)
 	if len(result.SourceErrors) > 0 {
 		if s.Metrics != nil {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -948,6 +948,10 @@ func (s *Service) runScanWithRecord(ctx context.Context, record db.ScanRecord, a
 		}
 		return RunScanResult{}, err
 	}
+	s.appendScanEvent(ctx, record.ID, db.ScanEventLevelInfo, "collecting provider evidence", map[string]any{
+		"phase":    "collecting",
+		"provider": record.Provider,
+	})
 	result, err := scanner.Run(ctx)
 	if err != nil {
 		if handleErr := s.handleScanFailure(ctx, record, allowRetry, scanFailureStageExecution, 0, 0, err, "scan failed during collection/analysis"); handleErr != nil {
@@ -958,6 +962,10 @@ func (s *Service) runScanWithRecord(ctx context.Context, record db.ScanRecord, a
 		}
 		return RunScanResult{}, err
 	}
+	s.appendScanEvent(ctx, record.ID, db.ScanEventLevelInfo, "analyzing collected evidence", map[string]any{
+		"phase":    "analyzing",
+		"provider": record.Provider,
+	})
 	result.Findings = enrichFindings(result.Findings)
 	if len(result.SourceErrors) > 0 {
 		if s.Metrics != nil {
@@ -3989,6 +3997,12 @@ func (s *Service) GetFindingExports(ctx context.Context, findingID string, scanI
 func (s *Service) ListScans(ctx context.Context, limit int) ([]db.ScanRecord, error) {
 	ctx = s.scopeContext(ctx)
 	return s.Store.ListScans(ctx, limit)
+}
+
+// GetScan returns one persisted scan.
+func (s *Service) GetScan(ctx context.Context, scanID string) (db.ScanRecord, error) {
+	ctx = s.scopeContext(ctx)
+	return s.Store.GetScan(ctx, scanID)
 }
 
 // GetFindingsSummary returns grouped counts by severity and type.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,6 +23,16 @@ type ScanResult struct {
 	Completed     time.Time
 }
 
+// PhaseCallback receives scanner lifecycle transitions at the point where
+// the corresponding pipeline stage begins.
+type PhaseCallback func(phase string)
+
+// PhaseAwareScanner exposes the scanner pipeline to callers that need
+// progress updates without changing the compatibility Run contract.
+type PhaseAwareScanner interface {
+	RunWithPhase(ctx context.Context, onPhase PhaseCallback) (ScanResult, error)
+}
+
 // Scanner orchestrates end-to-end scan stages with explicit dependencies.
 type Scanner struct {
 	Collector            providers.Collector
@@ -35,6 +45,13 @@ type Scanner struct {
 // Run executes a deterministic scan pipeline. Each dependency is injected so
 // provider modules can evolve independently while keeping orchestration stable.
 func (s Scanner) Run(ctx context.Context) (ScanResult, error) {
+	return s.RunWithPhase(ctx, nil)
+}
+
+// RunWithPhase executes the scan pipeline and reports transitions before each
+// stage starts. In particular, analyzing is emitted after collection succeeds
+// and immediately before normalization begins.
+func (s Scanner) RunWithPhase(ctx context.Context, onPhase PhaseCallback) (ScanResult, error) {
 	tracer := otel.Tracer("identrail/scanner")
 	ctx, span := tracer.Start(ctx, "scanner.run")
 	defer span.End()
@@ -63,6 +80,9 @@ func (s Scanner) Run(ctx context.Context) (ScanResult, error) {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "collector failed")
 		return ScanResult{}, err
+	}
+	if onPhase != nil {
+		onPhase("analyzing")
 	}
 
 	normalizeCtx, normalizeSpan := tracer.Start(ctx, "scanner.normalize")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -17,6 +18,9 @@ type stubDiagnosticCollector struct {
 	err    error
 }
 type stubNormalizer struct{ err error }
+type phaseRecordingNormalizer struct {
+	phases *[]string
+}
 type stubPermResolver struct{ err error }
 type stubRelResolver struct{ err error }
 type stubRules struct{ err error }
@@ -62,6 +66,11 @@ func (s stubNormalizer) Normalize(context.Context, []providers.RawAsset) (provid
 			Name:     "role-a",
 		}},
 	}, nil
+}
+
+func (s phaseRecordingNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset) (providers.NormalizedBundle, error) {
+	*s.phases = append(*s.phases, "normalize")
+	return stubNormalizer{}.Normalize(ctx, raw)
 }
 
 func (s fixedNormalizer) Normalize(context.Context, []providers.RawAsset) (providers.NormalizedBundle, error) {
@@ -123,6 +132,27 @@ func TestScannerRunSuccess(t *testing.T) {
 	}
 	if len(result.Findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(result.Findings))
+	}
+}
+
+func TestScannerRunWithPhaseReportsAnalysisBeforeNormalization(t *testing.T) {
+	phases := []string{}
+	scanner := Scanner{
+		Collector:            stubCollector{},
+		Normalizer:           phaseRecordingNormalizer{phases: &phases},
+		PermissionResolver:   stubPermResolver{},
+		RelationshipResolver: stubRelResolver{},
+		RiskRuleSet:          stubRules{},
+	}
+
+	_, err := scanner.RunWithPhase(context.Background(), func(phase string) {
+		phases = append(phases, phase)
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got, want := phases, []string{"analyzing", "normalize"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected phase callback before normalization, got %v", got)
 	}
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,6 +34,7 @@ import {
   ProductAWSCoveragePage,
   ProductAWSAgentsPage,
   ProductAWSControlCenterPage,
+  ProductAWSDiscoveryPage,
   ProductAWSFindingsPage,
   ProductAWSGovernancePage,
   ProductAWSGADemoPage,
@@ -4829,6 +4830,7 @@ export function RoutedSite() {
             <Route path="findings" element={<LegacyScopedAppRedirect target="github/findings" />} />
             <Route path="ai-risks" element={<LegacyScopedAppRedirect target="github/agentic-risk" />} />
             <Route path="aws" element={<ProductAWSControlCenterPage />} />
+            <Route path="aws/discovery" element={<ProductAWSDiscoveryPage />} />
             <Route path="aws/connect" element={<ProductAWSConnectPage />} />
             <Route path="aws/accounts" element={<ProductAWSAccountsPage />} />
             <Route path="aws/coverage" element={<ProductAWSCoveragePage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -335,6 +335,8 @@ export type ScanRecord = {
   asset_count: number;
   finding_count: number;
   error_message?: string;
+  failure_category?: string;
+  dead_lettered?: boolean;
 };
 
 export type ScanRequest = {
@@ -10612,6 +10614,9 @@ export const apiClient = {
   },
   listScans(auth?: RequestAuthContext) {
     return request<{ items: ScanRecord[] }>('/v1/scans?sort_by=started_at&sort_order=desc', auth);
+  },
+  getScan(scanID: string, auth?: RequestAuthContext) {
+    return request<{ scan: ScanRecord }>(`/v1/scans/${encodeURIComponent(scanID)}`, auth);
   },
   startScan(payloadOrAuth?: ScanRequest | RequestAuthContext, maybeAuth?: RequestAuthContext) {
     // A second argument means the first is unambiguously the scan payload. With a single

--- a/web/src/productDomainRoutes.ts
+++ b/web/src/productDomainRoutes.ts
@@ -1,6 +1,7 @@
 export const DOMAIN_APP_ROUTE_MANIFEST = [
   '/app/:tenantID/:workspaceID',
   '/app/:tenantID/:workspaceID/aws',
+  '/app/:tenantID/:workspaceID/aws/discovery',
   '/app/:tenantID/:workspaceID/aws/connect',
   '/app/:tenantID/:workspaceID/aws/accounts',
   '/app/:tenantID/:workspaceID/aws/coverage',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3363,6 +3363,7 @@ describe('Domain-first app routes', () => {
     expect(DOMAIN_APP_ROUTE_MANIFEST).toEqual([
       '/app/:tenantID/:workspaceID',
       '/app/:tenantID/:workspaceID/aws',
+      '/app/:tenantID/:workspaceID/aws/discovery',
       '/app/:tenantID/:workspaceID/aws/connect',
       '/app/:tenantID/:workspaceID/aws/accounts',
       '/app/:tenantID/:workspaceID/aws/coverage',
@@ -12304,6 +12305,107 @@ describe('Domain-first app routes', () => {
       { project_id: 'staging', connector_id: 'staging-connector' },
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     ));
+  });
+
+  it('ignores a late AWS discovery start response from the previous environment', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    const startProduction = deferred<{ scan: { id: string; project_id: string; connector_id: string; provider: string; status: string; started_at: string; asset_count: number; finding_count: number } }>();
+    const startStaging = deferred<{ scan: { id: string; project_id: string; connector_id: string; provider: string; status: string; started_at: string; asset_count: number; finding_count: number } }>();
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging',
+          name: 'Staging',
+          slug: 'staging',
+          description: 'Staging AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockImplementation((_workspaceID, projectID) => Promise.resolve({
+      connection: projectID === 'staging' ? { ...connectedAWS, connector_id: 'staging-connector' } : connectedAWS
+    }));
+    const startScan = vi.spyOn(api.apiClient, 'startScan')
+      .mockImplementationOnce(() => startProduction.promise)
+      .mockImplementationOnce(() => startStaging.promise);
+    vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
+      scan: {
+        id: 'scan-staging',
+        project_id: 'staging',
+        connector_id: 'staging-connector',
+        provider: 'aws',
+        status: 'running',
+        started_at: '2026-08-20T20:00:00Z',
+        asset_count: 0,
+        finding_count: 0
+      }
+    });
+    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({ items: [] });
+
+    const { ProductAWSDiscoveryPage } = await import('./productShell');
+    function LocationProbe() {
+      const currentLocation = useLocation();
+      return <output data-testid="aws-discovery-location">{currentLocation.search}</output>;
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/discovery?environment=production&start=1']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/discovery" element={<><ProductAWSDiscoveryPage /><LocationProbe /></>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(startScan).toHaveBeenCalledTimes(1));
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
+    await waitFor(() => expect(startScan).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      startProduction.resolve({
+        scan: {
+          id: 'scan-production',
+          project_id: 'production',
+          connector_id: 'aws-connector-1',
+          provider: 'aws',
+          status: 'queued',
+          started_at: '2026-08-20T20:00:00Z',
+          asset_count: 0,
+          finding_count: 0
+        }
+      });
+    });
+    expect(screen.getByTestId('aws-discovery-location')).toHaveTextContent('environment=staging&start=1');
+
+    await act(async () => {
+      startStaging.resolve({
+        scan: {
+          id: 'scan-staging',
+          project_id: 'staging',
+          connector_id: 'staging-connector',
+          provider: 'aws',
+          status: 'queued',
+          started_at: '2026-08-20T20:00:00Z',
+          asset_count: 0,
+          finding_count: 0
+        }
+      });
+    });
+    await waitFor(() => expect(screen.getByTestId('aws-discovery-location')).toHaveTextContent('environment=staging&scan_id=scan-staging'));
   });
 
   it('keeps edited AWS role drafts when polling status returns older connection data', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -12127,6 +12127,185 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('region', { name: 'AWS account setup' })).toBeInTheDocument();
   });
 
+  it('retries an AWS discovery enqueue after a transient start failure', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    const scan = {
+      id: 'scan-retry',
+      project_id: 'production',
+      connector_id: 'aws-connector-1',
+      provider: 'aws',
+      status: 'queued',
+      started_at: '2026-08-20T20:00:00Z',
+      asset_count: 0,
+      finding_count: 0
+    };
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [{
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: 'production',
+        name: 'Production',
+        slug: 'production',
+        description: 'Production AWS boundary.',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z'
+      }]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const startScan = vi.spyOn(api.apiClient, 'startScan')
+      .mockRejectedValueOnce(new Error('temporary start failure'))
+      .mockResolvedValue({ scan });
+    vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({ scan: { ...scan, status: 'running' } });
+    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({ items: [] });
+
+    const { ProductAWSDiscoveryPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/discovery?environment=production&start=1']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/discovery" element={<ProductAWSDiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 3, name: /Couldn't start AWS discovery/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Try again/i }));
+
+    await waitFor(() => expect(startScan).toHaveBeenCalledTimes(2));
+  });
+
+  it('allows a failed AWS discovery to start a replacement scan', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    const failedScan = {
+      id: 'scan-failed',
+      project_id: 'production',
+      connector_id: 'aws-connector-1',
+      provider: 'aws',
+      status: 'failed',
+      started_at: '2026-08-20T20:00:00Z',
+      asset_count: 0,
+      finding_count: 0,
+      error_message: 'AWS worker failed.'
+    };
+    const replacementScan = { ...failedScan, id: 'scan-replacement', status: 'queued', error_message: undefined };
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [{
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: 'production',
+        name: 'Production',
+        slug: 'production',
+        description: 'Production AWS boundary.',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z'
+      }]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const startScan = vi.spyOn(api.apiClient, 'startScan').mockResolvedValue({ scan: replacementScan });
+    vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({ scan: failedScan });
+    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({ items: [] });
+
+    const { ProductAWSDiscoveryPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/discovery?environment=production&scan_id=scan-failed']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/discovery" element={<ProductAWSDiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 3, name: /Discovery failed/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('link', { name: /Start a new discovery/i }));
+
+    await waitFor(() => expect(startScan).toHaveBeenCalledWith(
+      { project_id: 'production', connector_id: 'aws-connector-1' },
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    ));
+  });
+
+  it('does not start AWS discovery with the previous environment connector', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    const stagingConnection = deferred<{ connection: AWSConnectionStatus }>();
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging',
+          name: 'Staging',
+          slug: 'staging',
+          description: 'Staging AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockImplementation((_workspaceID, projectID) =>
+      projectID === 'staging' ? stagingConnection.promise : Promise.resolve({ connection: connectedAWS })
+    );
+    const startScan = vi.spyOn(api.apiClient, 'startScan').mockResolvedValue({
+      scan: {
+        id: 'scan-staging',
+        project_id: 'staging',
+        connector_id: 'staging-connector',
+        provider: 'aws',
+        status: 'queued',
+        started_at: '2026-08-20T20:00:00Z',
+        asset_count: 0,
+        finding_count: 0
+      }
+    });
+
+    const { ProductAWSDiscoveryPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/discovery?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/discovery" element={<ProductAWSDiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const environmentSelector = await screen.findByRole('combobox', { name: 'Environment' });
+    await waitFor(() => expect(api.apiClient.getAWSProjectConnection).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    ));
+    fireEvent.change(environmentSelector, { target: { value: 'staging' } });
+    await waitFor(() => expect(api.apiClient.getAWSProjectConnection).toHaveBeenCalledWith(
+      'workspace-a',
+      'staging',
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    ));
+    expect(startScan).not.toHaveBeenCalled();
+
+    await act(async () => {
+      stagingConnection.resolve({ connection: { ...connectedAWS, connector_id: 'staging-connector' } });
+    });
+    await waitFor(() => expect(startScan).toHaveBeenCalledWith(
+      { project_id: 'staging', connector_id: 'staging-connector' },
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    ));
+  });
+
   it('keeps edited AWS role drafts when polling status returns older connection data', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -12114,7 +12114,7 @@ describe('Domain-first app routes', () => {
     expect(within(summary).getByText('1 region')).toBeInTheDocument();
     expect(within(summary).getByRole('link', { name: /Start AWS intelligence/i })).toHaveAttribute(
       'href',
-      '/app/tenant-a/workspace-a/aws?environment=production'
+      '/app/tenant-a/workspace-a/aws/discovery?environment=production&start=1'
     );
     expect(within(summary).getByRole('link', { name: /Review machine identities/i })).toHaveAttribute(
       'href',

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20877,6 +20877,7 @@ export function ProductAWSDiscoveryPage() {
   const startRequested = query.get('start') === '1';
   const scanID = normalizeValue(query.get('scan_id'));
   const [connection, setConnection] = useState<AWSConnectionStatus | null>(null);
+  const [connectionEnvironmentID, setConnectionEnvironmentID] = useState('');
   const [connectionLoading, setConnectionLoading] = useState(false);
   const [connectionError, setConnectionError] = useState('');
   const [scan, setScan] = useState<ScanRecord | null>(null);
@@ -20884,6 +20885,7 @@ export function ProductAWSDiscoveryPage() {
   const [loading, setLoading] = useState(Boolean(scanID));
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState('');
+  const [retryNonce, setRetryNonce] = useState(0);
   const startRef = useRef('');
   const requestRef = useRef(0);
   const redirectRef = useRef('');
@@ -20897,9 +20899,12 @@ export function ProductAWSDiscoveryPage() {
     const requestEnvironmentID = selectedEnvironmentID;
     if (!scope || !requestEnvironmentID) {
       setConnection(null);
+      setConnectionEnvironmentID('');
       setConnectionLoading(false);
       return;
     }
+    setConnection(null);
+    setConnectionEnvironmentID('');
     setConnectionLoading(true);
     setConnectionError('');
     void apiClient.getAWSProjectConnection(
@@ -20909,10 +20914,12 @@ export function ProductAWSDiscoveryPage() {
     ).then((response) => {
       if (requestID === requestRef.current && requestEnvironmentID === selectedEnvironmentID) {
         setConnection(response.connection);
+        setConnectionEnvironmentID(requestEnvironmentID);
       }
     }).catch((requestError) => {
       if (requestID === requestRef.current && requestEnvironmentID === selectedEnvironmentID) {
         setConnection(null);
+        setConnectionEnvironmentID('');
         setConnectionError(formatAPIError(requestError, 'Unable to load AWS connection status.'));
       }
     }).finally(() => {
@@ -20925,9 +20932,26 @@ export function ProductAWSDiscoveryPage() {
     };
   }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
 
+  const retryDiscovery = useCallback(() => {
+    startRef.current = '';
+    setError('');
+    setLoading(Boolean(scanID));
+    setRetryNonce((value) => value + 1);
+  }, [scanID]);
+
+  const prepareNewDiscovery = useCallback(() => {
+    startRef.current = '';
+    redirectRef.current = '';
+    setScan(null);
+    setEvents([]);
+    setError('');
+    setLoading(false);
+    setRetryNonce((value) => value + 1);
+  }, []);
+
   useEffect(() => {
     const requestEnvironmentID = selectedEnvironmentID;
-    if (!startRequested || scanID || !scope || !requestEnvironmentID || environmentScope.loading || connectionLoading) {
+    if (!startRequested || scanID || !scope || !requestEnvironmentID || environmentScope.loading || connectionLoading || connectionEnvironmentID !== requestEnvironmentID) {
       return;
     }
     if (!connection) {
@@ -20968,11 +20992,10 @@ export function ProductAWSDiscoveryPage() {
     }).finally(() => {
       setStarting(false);
     });
-  }, [connection, connectionLoading, environmentScope.loading, scanID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, startRequested, navigate]);
+  }, [connection, connectionEnvironmentID, connectionLoading, environmentScope.loading, retryNonce, scanID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, startRequested, navigate]);
 
   useEffect(() => {
     if (!scanID || !scope || !selectedEnvironmentID) {
-      startRef.current = '';
       setScan(null);
       setEvents([]);
       setLoading(false);
@@ -21009,7 +21032,7 @@ export function ProductAWSDiscoveryPage() {
     return () => {
       active = false;
     };
-  }, [scanID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+  }, [retryNonce, scanID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
 
   const phase = awsDiscoveryPhase(scan, events);
   const partial = awsDiscoveryHasPartialResults(events);
@@ -21053,7 +21076,7 @@ export function ProductAWSDiscoveryPage() {
           <DomainErrorState
             title={phase === 'error' ? 'AWS discovery failed' : 'Couldn\'t start AWS discovery'}
             body={error}
-            retryAction={{ label: 'Try again', to: awsDiscoveryPath(scope, selectedEnvironmentID, { start: true }) }}
+            retryAction={{ label: 'Try again', onClick: retryDiscovery }}
           >
             <Link className="idt-btn idt-btn-ghost" to={connectPath}>Back to AWS connection</Link>
           </DomainErrorState>
@@ -21106,7 +21129,7 @@ export function ProductAWSDiscoveryPage() {
             ) : null}
             {phase === 'error' ? (
               <div className="idt-aws-discovery-actions">
-                <Link className="idt-btn idt-btn-primary" to={awsDiscoveryPath(scope, selectedEnvironmentID, { start: true })}>Start a new discovery</Link>
+                <Link className="idt-btn idt-btn-primary" to={awsDiscoveryPath(scope, selectedEnvironmentID, { start: true })} onClick={prepareNewDiscovery}>Start a new discovery</Link>
                 <Link className="idt-btn idt-btn-ghost" to={connectPath}>Review AWS connection</Link>
               </div>
             ) : null}

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -213,6 +213,8 @@ import {
   type RepoRiskGraphNodeKind,
   type RepoScanRequest,
   type RepoScanRecord,
+  type ScanEvent,
+  type ScanRecord,
   type TrendPoint,
   type RequestAuthContext,
   type ScanPolicyRecord,
@@ -3847,6 +3849,25 @@ function awsRouteLink(scope: ProductSession, routeID: ProductDomainRouteID, envi
   return appendEnvironmentQuery(domainRoutePath(scope, 'aws', findDomainRoute('aws', routeID)), environmentID);
 }
 
+function awsDiscoveryPath(
+  scope: ProductSession,
+  environmentID: string,
+  options: { start?: boolean; scanID?: string } = {}
+): string {
+  const params = new URLSearchParams();
+  if (normalizeValue(environmentID)) {
+    params.set(ENVIRONMENT_QUERY_PARAM, normalizeValue(environmentID));
+  }
+  if (options.start) {
+    params.set('start', '1');
+  }
+  if (options.scanID) {
+    params.set('scan_id', options.scanID);
+  }
+  const query = params.toString();
+  return `${buildScopedPath(scope, 'aws/discovery')}${query ? `?${query}` : ''}`;
+}
+
 function awsRemediationCenterPath(scope: ProductSession, environmentID: string): string {
   return appendEnvironmentQuery(buildScopedPath(scope, 'aws/remediation/center'), environmentID);
 }
@@ -4275,7 +4296,7 @@ function AWSConnectedSuccessPanel({
   onDisable: () => void;
   lifecycleBusy: boolean;
 }) {
-  const overviewPath = awsRouteLink(scope, 'overview', environmentID);
+  const discoveryPath = awsDiscoveryPath(scope, environmentID, { start: true });
   const identitiesPath = awsRouteLink(scope, 'identities', environmentID);
   const coveragePath = awsRouteLink(scope, 'coverage', environmentID);
   const findingsPath = awsRouteLink(scope, 'findings', environmentID);
@@ -4345,7 +4366,7 @@ function AWSConnectedSuccessPanel({
       <div className="idt-aws-connected-actions">
         {connectorConnected ? (
           <>
-            <Link className="idt-btn idt-btn-primary" to={overviewPath}>
+            <Link className="idt-btn idt-btn-primary" to={discoveryPath}>
               Start AWS intelligence
             </Link>
             <Link className="idt-btn idt-btn-dark" to={identitiesPath}>
@@ -20787,6 +20808,322 @@ export function ProductAWSGADemoPage() {
 
 export function ProductAWSGraphPage() {
   return <ProductAWSRiskOperationsPage routeID="graph" />;
+}
+
+type AWSDiscoveryPhase = 'connecting' | 'collecting' | 'analyzing' | 'results' | 'error';
+
+const AWS_DISCOVERY_STEPS: Array<{ id: Exclude<AWSDiscoveryPhase, 'error' | 'results'>; label: string; description: string }> = [
+  { id: 'connecting', label: 'Connecting', description: 'Confirming the AWS connector and starting the discovery run.' },
+  { id: 'collecting', label: 'Collecting', description: 'Reading the approved AWS identity and workload evidence.' },
+  { id: 'analyzing', label: 'Analyzing', description: 'Building relationships and evaluating the collected evidence.' }
+];
+
+function awsDiscoveryEventPhase(events: ScanEvent[]): AWSDiscoveryPhase | null {
+  const orderedEvents = [...events].sort((left, right) => {
+    return new Date(right.created_at).getTime() - new Date(left.created_at).getTime();
+  });
+  for (const event of orderedEvents) {
+    const phase = normalizeValue(event.metadata?.phase).toLowerCase();
+    if (phase === 'collecting' || phase === 'analyzing') {
+      return phase;
+    }
+    const message = normalizeValue(event.message).toLowerCase();
+    if (message.includes('analyzing') || message.includes('artifacts persisted') || message.includes('findings persisted')) {
+      return 'analyzing';
+    }
+    if (message.includes('collecting')) {
+      return 'collecting';
+    }
+  }
+  return null;
+}
+
+function awsDiscoveryHasPartialResults(events: ScanEvent[]): boolean {
+  return events.some((event) => {
+    const message = normalizeValue(event.message).toLowerCase();
+    return message.includes('partial source') || normalizeValue(event.metadata?.state).toLowerCase() === 'partial';
+  });
+}
+
+function awsDiscoveryPhase(scan: ScanRecord | null, events: ScanEvent[]): AWSDiscoveryPhase {
+  if (!scan) {
+    return 'connecting';
+  }
+  const status = normalizeValue(scan.status).toLowerCase();
+  if (status === 'failed' || status === 'canceled' || scan.dead_lettered) {
+    return 'error';
+  }
+  if (status === 'succeeded' || status === 'completed' || status === 'partial') {
+    return 'results';
+  }
+  return awsDiscoveryEventPhase(events) ?? (status === 'queued' ? 'connecting' : 'collecting');
+}
+
+function awsDiscoveryStatusLabel(phase: AWSDiscoveryPhase, partial: boolean): string {
+  if (phase === 'error') return 'Discovery failed';
+  if (phase === 'results') return partial ? 'Partial results ready' : 'Results ready';
+  return AWS_DISCOVERY_STEPS.find((step) => step.id === phase)?.label ?? 'Starting discovery';
+}
+
+export function ProductAWSDiscoveryPage() {
+  const params = useParams<ScopeRouteParams>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const scope = resolveScopeFromParams(params);
+  const requestedEnvironmentID = useMemo(() => environmentIDFromSearch(location.search), [location.search]);
+  const environmentScope = useEnvironmentScope(scope, requestedEnvironmentID);
+  const selectedEnvironmentID = environmentScope.selectedID;
+  const query = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const startRequested = query.get('start') === '1';
+  const scanID = normalizeValue(query.get('scan_id'));
+  const [connection, setConnection] = useState<AWSConnectionStatus | null>(null);
+  const [connectionLoading, setConnectionLoading] = useState(false);
+  const [connectionError, setConnectionError] = useState('');
+  const [scan, setScan] = useState<ScanRecord | null>(null);
+  const [events, setEvents] = useState<ScanEvent[]>([]);
+  const [loading, setLoading] = useState(Boolean(scanID));
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState('');
+  const startRef = useRef('');
+  const requestRef = useRef(0);
+  const redirectRef = useRef('');
+
+  const onChangeEnvironment = useCallback((environmentID: string) => {
+    navigate(awsDiscoveryPath(scope!, environmentID, { start: true }), { replace: true });
+  }, [navigate, scope]);
+
+  useEffect(() => {
+    const requestID = ++requestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    if (!scope || !requestEnvironmentID) {
+      setConnection(null);
+      setConnectionLoading(false);
+      return;
+    }
+    setConnectionLoading(true);
+    setConnectionError('');
+    void apiClient.getAWSProjectConnection(
+      scope.workspaceID,
+      requestEnvironmentID,
+      buildProductAuthContext(scope)
+    ).then((response) => {
+      if (requestID === requestRef.current && requestEnvironmentID === selectedEnvironmentID) {
+        setConnection(response.connection);
+      }
+    }).catch((requestError) => {
+      if (requestID === requestRef.current && requestEnvironmentID === selectedEnvironmentID) {
+        setConnection(null);
+        setConnectionError(formatAPIError(requestError, 'Unable to load AWS connection status.'));
+      }
+    }).finally(() => {
+      if (requestID === requestRef.current && requestEnvironmentID === selectedEnvironmentID) {
+        setConnectionLoading(false);
+      }
+    });
+    return () => {
+      requestRef.current += 1;
+    };
+  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+
+  useEffect(() => {
+    const requestEnvironmentID = selectedEnvironmentID;
+    if (!startRequested || scanID || !scope || !requestEnvironmentID || environmentScope.loading || connectionLoading) {
+      return;
+    }
+    if (!connection) {
+      return;
+    }
+    const startKey = `${scope.tenantID}:${scope.workspaceID}:${requestEnvironmentID}:${connection.connector_id ?? ''}`;
+    if (startRef.current === startKey) {
+      return;
+    }
+    startRef.current = startKey;
+    setStarting(true);
+    setError('');
+    void apiClient.startScan(
+      { project_id: requestEnvironmentID, connector_id: connection.connector_id },
+      buildProductAuthContext(scope)
+    ).then((response) => {
+      navigate(awsDiscoveryPath(scope, requestEnvironmentID, { scanID: response.scan.id }), { replace: true });
+    }).catch(async (requestError) => {
+      if (requestError instanceof ApiError && requestError.status === 409) {
+        try {
+          const scans = await apiClient.listScans(buildProductAuthContext(scope));
+          const existing = scans.items.find((item) => (
+            item.provider === 'aws' &&
+            item.project_id === requestEnvironmentID &&
+            (!connection.connector_id || item.connector_id === connection.connector_id) &&
+            isActiveScanStatus(item.status)
+          ));
+          if (existing) {
+            navigate(awsDiscoveryPath(scope, requestEnvironmentID, { scanID: existing.id }), { replace: true });
+            return;
+          }
+        } catch {
+          // Preserve the original conflict message when the recovery lookup fails.
+        }
+      }
+      setError(formatAPIError(requestError, 'Unable to start AWS discovery.'));
+      startRef.current = '';
+    }).finally(() => {
+      setStarting(false);
+    });
+  }, [connection, connectionLoading, environmentScope.loading, scanID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, startRequested, navigate]);
+
+  useEffect(() => {
+    if (!scanID || !scope || !selectedEnvironmentID) {
+      startRef.current = '';
+      setScan(null);
+      setEvents([]);
+      setLoading(false);
+      return;
+    }
+    let active = true;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const load = async () => {
+      try {
+        const [scanResponse, eventResponse] = await Promise.all([
+          apiClient.getScan(scanID, buildProductAuthContext(scope)),
+          apiClient.listScanEvents(scanID, undefined, 100, buildProductAuthContext(scope))
+        ]);
+        if (!active || requestEnvironmentID !== selectedEnvironmentID) {
+          return;
+        }
+        setScan(scanResponse.scan);
+        setEvents(eventResponse.items);
+        setError('');
+        setLoading(false);
+        if (isActiveScanStatus(scanResponse.scan.status)) {
+          window.setTimeout(load, 1500);
+        }
+      } catch (requestError) {
+        if (!active || requestEnvironmentID !== selectedEnvironmentID) {
+          return;
+        }
+        setLoading(false);
+        setError(formatAPIError(requestError, 'Unable to load AWS discovery status.'));
+      }
+    };
+    setLoading(true);
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [scanID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+
+  const phase = awsDiscoveryPhase(scan, events);
+  const partial = awsDiscoveryHasPartialResults(events);
+  const findingsPath = scope && selectedEnvironmentID ? awsRouteLink(scope, 'findings', selectedEnvironmentID) : '#';
+  const connectPath = scope && selectedEnvironmentID ? awsRouteLink(scope, 'connect', selectedEnvironmentID) : '#';
+  const hasTerminalResults = phase === 'results' && Boolean(scanID) && Boolean(scan);
+
+  useEffect(() => {
+    if (!hasTerminalResults || !scanID || !scope || !selectedEnvironmentID || redirectRef.current === scanID) {
+      return;
+    }
+    redirectRef.current = scanID;
+    const timeoutID = window.setTimeout(() => {
+      navigate(findingsPath, { replace: true });
+    }, 1200);
+    return () => window.clearTimeout(timeoutID);
+  }, [findingsPath, hasTerminalResults, navigate, scanID, scope, selectedEnvironmentID]);
+
+  const statusTone = phase === 'error' ? 'danger' : phase === 'results' ? (partial ? 'warning' : 'success') : 'info';
+  const scopeSelector = scope ? <ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} /> : null;
+
+  if (!scope) {
+    return <DomainErrorState title="Workspace route context is missing" body="Choose a tenant and workspace before starting AWS discovery." />;
+  }
+
+  return (
+    <DomainPageShell
+      domain="aws"
+      eyebrow={null}
+      hideLogo
+      title="AWS discovery"
+      description="Identrail is collecting and analyzing the approved AWS scope before opening Findings."
+      scope={scopeSelector}
+      statusTone={statusTone}
+      status={<DomainStatusBadge variant={phase === 'error' ? 'needs-attention' : phase === 'results' ? (partial ? 'degraded' : 'connected') : 'running-scan'} detail={awsDiscoveryStatusLabel(phase, partial)} />}
+    >
+      <div className="idt-aws-discovery-shell">
+        {environmentScope.error ? <DomainErrorState title="Unable to load the AWS environment" body={environmentScope.error} /> : null}
+        {connectionError ? <DomainErrorState title="Unable to verify the AWS connector" body={connectionError} /> : null}
+        {error ? (
+          <DomainErrorState
+            title={phase === 'error' ? 'AWS discovery failed' : 'Couldn\'t start AWS discovery'}
+            body={error}
+            retryAction={{ label: 'Try again', to: awsDiscoveryPath(scope, selectedEnvironmentID, { start: true }) }}
+          >
+            <Link className="idt-btn idt-btn-ghost" to={connectPath}>Back to AWS connection</Link>
+          </DomainErrorState>
+        ) : null}
+
+        {loading || starting || connectionLoading || environmentScope.loading ? <DomainLoadingState label={starting ? 'Starting AWS discovery' : 'Loading discovery status'} /> : null}
+
+        {!loading && !starting && !error && scan ? (
+          <section className="idt-aws-discovery-progress" aria-label="AWS discovery progress" aria-live="polite">
+            <header>
+              <div>
+                <p className="idt-app-kicker">Live run status</p>
+                <h3>{awsDiscoveryStatusLabel(phase, partial)}</h3>
+                <p>
+                  {phase === 'error'
+                    ? scan.error_message || 'The AWS worker could not complete this discovery run.'
+                    : phase === 'results'
+                      ? partial
+                        ? 'Some sources were unavailable. The available results are ready to review.'
+                        : scan.finding_count === 0
+                          ? 'The collected scope completed successfully and produced no findings.'
+                          : `${scan.finding_count} finding${scan.finding_count === 1 ? '' : 's'} are ready to review.`
+                      : 'You can leave this page open while the run continues in the background.'}
+                </p>
+              </div>
+              {phase === 'results' ? <span className="idt-aws-discovery-result-count">{scan.finding_count} findings</span> : null}
+            </header>
+            <ol className="idt-aws-discovery-steps">
+              {AWS_DISCOVERY_STEPS.map((step, index) => {
+                const stepIndex = AWS_DISCOVERY_STEPS.findIndex((item) => item.id === phase);
+                const complete = phase === 'results' || (phase === 'error' ? index < Math.max(stepIndex, 0) : index < stepIndex);
+                const current = phase === step.id || (phase === 'error' && index === Math.max(stepIndex, 0));
+                return (
+                  <li key={step.id} className={`idt-aws-discovery-step ${complete ? 'is-complete' : ''} ${current ? 'is-current' : ''} ${phase === 'error' && current ? 'is-error' : ''}`}>
+                    <span className="idt-aws-discovery-step-marker" aria-hidden="true">{complete ? '✓' : index + 1}</span>
+                    <div><strong>{step.label}</strong><p>{step.description}</p></div>
+                  </li>
+                );
+              })}
+              <li className={`idt-aws-discovery-step ${phase === 'results' ? 'is-current is-complete' : ''} ${phase === 'error' ? 'is-error' : ''}`}>
+                <span className="idt-aws-discovery-step-marker" aria-hidden="true">{phase === 'results' ? '✓' : '4'}</span>
+                <div><strong>{phase === 'error' ? 'Needs attention' : 'Results ready'}</strong><p>{phase === 'results' ? 'Opening AWS Findings next.' : 'Findings will open when the run completes.'}</p></div>
+              </li>
+            </ol>
+            {phase === 'results' ? (
+              <div className="idt-aws-discovery-actions">
+                <Link className="idt-btn idt-btn-primary" to={findingsPath}>Open Findings now</Link>
+                <span>Redirecting automatically…</span>
+              </div>
+            ) : null}
+            {phase === 'error' ? (
+              <div className="idt-aws-discovery-actions">
+                <Link className="idt-btn idt-btn-primary" to={awsDiscoveryPath(scope, selectedEnvironmentID, { start: true })}>Start a new discovery</Link>
+                <Link className="idt-btn idt-btn-ghost" to={connectPath}>Review AWS connection</Link>
+              </div>
+            ) : null}
+          </section>
+        ) : null}
+
+        {!loading && !starting && !error && !scan ? (
+          <DomainEmptyState
+            eyebrow="AWS discovery"
+            title="Ready to collect AWS evidence"
+            body="Start a read-only discovery run. Identrail will show each stage and open Findings when the results are ready."
+            nextAction={{ label: 'Start discovery', to: awsDiscoveryPath(scope, selectedEnvironmentID, { start: true }) }}
+          />
+        ) : null}
+      </div>
+    </DomainPageShell>
+  );
 }
 
 export function ProductAWSFindingsPage() {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20887,6 +20887,7 @@ export function ProductAWSDiscoveryPage() {
   const [error, setError] = useState('');
   const [retryNonce, setRetryNonce] = useState(0);
   const startRef = useRef('');
+  const startRequestRef = useRef(0);
   const requestRef = useRef(0);
   const redirectRef = useRef('');
 
@@ -20933,6 +20934,7 @@ export function ProductAWSDiscoveryPage() {
   }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
 
   const retryDiscovery = useCallback(() => {
+    startRequestRef.current += 1;
     startRef.current = '';
     setError('');
     setLoading(Boolean(scanID));
@@ -20940,6 +20942,7 @@ export function ProductAWSDiscoveryPage() {
   }, [scanID]);
 
   const prepareNewDiscovery = useCallback(() => {
+    startRequestRef.current += 1;
     startRef.current = '';
     redirectRef.current = '';
     setScan(null);
@@ -20948,6 +20951,11 @@ export function ProductAWSDiscoveryPage() {
     setLoading(false);
     setRetryNonce((value) => value + 1);
   }, []);
+
+  useEffect(() => {
+    startRequestRef.current += 1;
+    setStarting(false);
+  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
 
   useEffect(() => {
     const requestEnvironmentID = selectedEnvironmentID;
@@ -20961,6 +20969,8 @@ export function ProductAWSDiscoveryPage() {
     if (startRef.current === startKey) {
       return;
     }
+    const requestID = startRequestRef.current + 1;
+    startRequestRef.current = requestID;
     startRef.current = startKey;
     setStarting(true);
     setError('');
@@ -20968,11 +20978,20 @@ export function ProductAWSDiscoveryPage() {
       { project_id: requestEnvironmentID, connector_id: connection.connector_id },
       buildProductAuthContext(scope)
     ).then((response) => {
+      if (requestID !== startRequestRef.current || requestEnvironmentID !== selectedEnvironmentID) {
+        return;
+      }
       navigate(awsDiscoveryPath(scope, requestEnvironmentID, { scanID: response.scan.id }), { replace: true });
     }).catch(async (requestError) => {
+      if (requestID !== startRequestRef.current || requestEnvironmentID !== selectedEnvironmentID) {
+        return;
+      }
       if (requestError instanceof ApiError && requestError.status === 409) {
         try {
           const scans = await apiClient.listScans(buildProductAuthContext(scope));
+          if (requestID !== startRequestRef.current || requestEnvironmentID !== selectedEnvironmentID) {
+            return;
+          }
           const existing = scans.items.find((item) => (
             item.provider === 'aws' &&
             item.project_id === requestEnvironmentID &&
@@ -20990,7 +21009,9 @@ export function ProductAWSDiscoveryPage() {
       setError(formatAPIError(requestError, 'Unable to start AWS discovery.'));
       startRef.current = '';
     }).finally(() => {
-      setStarting(false);
+      if (requestID === startRequestRef.current && requestEnvironmentID === selectedEnvironmentID) {
+        setStarting(false);
+      }
     });
   }, [connection, connectionEnvironmentID, connectionLoading, environmentScope.loading, retryNonce, scanID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, startRequested, navigate]);
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -24456,6 +24456,119 @@ html[data-theme='light'] .idt-app-shell-screen select {
   line-height: 1.45;
 }
 
+.idt-aws-discovery-shell {
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-aws-discovery-progress {
+  display: grid;
+  gap: 1.25rem;
+  border: 1px solid rgba(126, 105, 255, 0.38);
+  border-radius: 12px;
+  padding: 1.3rem;
+  background: linear-gradient(135deg, rgba(20, 17, 45, 0.96), #050505 72%);
+}
+
+.idt-aws-discovery-progress > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-aws-discovery-progress h3 {
+  margin: 0;
+  color: #ffffff;
+}
+
+.idt-aws-discovery-progress header p:not(.idt-app-kicker) {
+  max-width: 58rem;
+  margin: 0.35rem 0 0;
+  color: var(--app-muted);
+  line-height: 1.5;
+}
+
+.idt-aws-discovery-result-count {
+  flex: 0 0 auto;
+  border: 1px solid rgba(88, 214, 141, 0.4);
+  border-radius: 999px;
+  padding: 0.35rem 0.62rem;
+  color: #b8f3cf;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.idt-aws-discovery-steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.7rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-aws-discovery-step {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr);
+  gap: 0.65rem;
+  min-width: 0;
+  border-top: 2px solid var(--app-border-soft);
+  padding-top: 0.7rem;
+  color: var(--app-muted);
+}
+
+.idt-aws-discovery-step.is-current {
+  border-color: #7e69ff;
+  color: #ffffff;
+}
+
+.idt-aws-discovery-step.is-complete {
+  border-color: #58d68d;
+  color: #b8f3cf;
+}
+
+.idt-aws-discovery-step.is-error {
+  border-color: #e26b6b;
+  color: #ffc1c1;
+}
+
+.idt-aws-discovery-step-marker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.idt-aws-discovery-step strong {
+  display: block;
+  color: inherit;
+}
+
+.idt-aws-discovery-step p {
+  margin: 0.22rem 0 0;
+  color: var(--app-muted);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.idt-aws-discovery-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.idt-aws-discovery-actions > span {
+  color: var(--app-muted);
+  font-size: 0.84rem;
+}
+
 .idt-app-console-layout .idt-aws-connect-summary .idt-source-meta {
   grid-template-columns: 1fr;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -25433,6 +25433,10 @@ html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge
 }
 
 @media (max-width: 720px) {
+  .idt-aws-discovery-steps {
+    grid-template-columns: 1fr;
+  }
+
   .idt-domain-header-main,
   .idt-domain-status-panel header,
   .idt-domain-filter-bar {


### PR DESCRIPTION
## Summary

- start a persisted asynchronous AWS discovery job from Start AWS intelligence
- show connecting, collecting, analyzing, and results-ready progress
- handle partial results, failures, retries, and zero findings
- automatically hand off to the existing Findings view when complete
- add scan detail and phase-event APIs with authorization and regression coverage

## Validation

- Go API and database tests passed
- all frontend tests passed (605 tests)
- production build passed
- pre-commit and push-time checks passed

No deployment is included in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an asynchronous AWS discovery flow with a progress page that starts and tracks a persisted scan, then redirects to AWS Findings when results are ready. Replaces the old “Start AWS intelligence” jump with a start-and-track experience, adds a scan detail API, and guarantees standardized phase events for reliable progress polling.

- Backend and API
  - Adds GET /v1/scans/{scan_id} with route policy authorization by scan_id; documents it in OpenAPI and covers it in router/authz tests.
  - Introduces phase-aware scanning and emits phase events with metadata.phase set to collecting and analyzing; always emits analyzing even if the scanner is not phase-aware.
  - Adds Service.GetScan; extends ScanRecord with failure_category and dead_lettered.

- Frontend and UX
  - Adds aws/discovery route and progress UI; “Start AWS intelligence” now links to it with ?start=1.
  - Starts a new scan (reuses an active one on 409), polls getScan and listScanEvents, shows Connecting → Collecting → Analyzing → Results, and auto-opens Findings when complete.
  - Defers starting until the selected environment’s connection is loaded and uses its connector; ignores late responses from previous environments; retries transient start failures; provides “Start a new discovery” from a failed run; handles partial results and zero findings.

<sup>Written for commit a19d7f2e9f5aef1d5e6d859e6d8ddf035a6d82d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

