### PR TITLE
Fix AWS discovery findings handoff

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -10682,6 +10682,7 @@ export const apiClient = {
   listFindings(
     filters: {
       limit?: number;
+      cursor?: string;
       scan_id?: string;
       severity?: string;
       type?: string;
@@ -10692,7 +10693,7 @@ export const apiClient = {
     } = {},
     auth?: RequestAuthContext
   ) {
-    return request<{ items: Finding[] }>(`/v1/findings${buildQuery(filters)}`, auth);
+    return request<{ items: Finding[]; next_cursor?: string }>(`/v1/findings${buildQuery(filters)}`, auth);
   },
   listRepoFindings(
     filters: {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8485,6 +8485,7 @@ describe('Domain-first app routes', () => {
           title: 'Historical IAM finding',
           human_summary: 'A persisted finding from the completed scan.',
           remediation: 'Review the role policy.',
+          evidence: { account_id: '999999999999', region: 'us-west-2' },
           created_at: '2026-08-20T20:03:00Z'
         }
       ]
@@ -8503,6 +8504,11 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByText('Showing findings from this AWS scan')).toBeInTheDocument();
     expect(await screen.findByText('Historical IAM finding')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Account' }), { target: { value: 'unknown' } });
+    expect(await screen.findByText('Historical IAM finding')).toBeInTheDocument();
+    fireEvent.change(screen.getByRole('combobox', { name: 'Account' }), { target: { value: 'connected' } });
+    expect(await screen.findByText('No findings match these filters')).toBeInTheDocument();
   });
 
   it('rejects persisted AWS findings until the scan reaches a terminal result', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8333,26 +8333,50 @@ describe('Domain-first app routes', () => {
         started_at: '2026-08-20T20:00:00Z',
         finished_at: '2026-08-20T20:03:00Z',
         asset_count: 12,
-        finding_count: 1
+        finding_count: 2
       }
     });
-    const listFindings = vi.spyOn(api.apiClient, 'listFindings').mockResolvedValue({
-      items: [
-        {
-          id: 'finding-aws-1',
-          scan_id: 'scan-aws-complete',
-          type: 'aws_iam_overprivileged_role',
-          severity: 'high',
-          title: 'Overprivileged IAM role',
-          human_summary: 'The role grants more permissions than this workload requires.',
-          path: ['production-role', 'AdministratorAccess'],
-          owner: 'AWS scanner',
-          evidence: { source: 'iam-policy' },
-          remediation: 'Reduce the role policy to the required actions.',
-          created_at: '2026-08-20T20:03:00Z'
-        }
-      ]
-    });
+    const listFindings = vi.spyOn(api.apiClient, 'listFindings').mockImplementation(async (filters = {}) =>
+      filters.cursor
+        ? {
+            items: [
+              {
+                id: 'finding-aws-2',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_s3_public_bucket',
+                severity: 'medium',
+                title: 'Public S3 bucket',
+                human_summary: 'The bucket is reachable through a public policy.',
+                path: ['production-assets'],
+                owner: 'AWS scanner',
+                evidence: { source: 's3-policy' },
+                remediation: 'Restrict the bucket policy to approved principals.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'fixed'
+              }
+            ]
+          }
+        : {
+            items: [
+              {
+                id: 'finding-aws-1',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_overprivileged_role',
+                severity: 'high',
+                title: 'Overprivileged IAM role',
+                human_summary: 'The role grants more permissions than this workload requires.',
+                path: ['production-role', 'AdministratorAccess'],
+                owner: 'AWS scanner',
+                evidence: { source: 'iam-policy' },
+                remediation: 'Reduce the role policy to the required actions.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open',
+                triage: { status: 'suppressed' }
+              }
+            ],
+            next_cursor: 'aws-findings-page-2'
+          }
+    );
     vi.spyOn(api.apiClient, 'listScanEvents').mockRejectedValue(new Error('scan events unavailable'));
     const getSecretPermissionEquivalence = vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence');
 
@@ -8370,14 +8394,218 @@ describe('Domain-first app routes', () => {
     expect(screen.getByText(/could not verify source completeness/i)).toBeInTheDocument();
     const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
     expect(within(findingsTable).getByText('Overprivileged IAM role')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Public S3 bucket')).toBeInTheDocument();
     expect(within(findingsTable).getByText('High')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('Open')).toBeInTheDocument();
+    expect(within(findingsTable).getAllByText('Blocked')).toHaveLength(2);
     expect(getScan).toHaveBeenCalledWith('scan-aws-complete', expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' }));
     expect(listFindings).toHaveBeenCalledWith(
       { scan_id: 'scan-aws-complete', limit: 500 },
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
+    expect(listFindings).toHaveBeenCalledWith(
+      { scan_id: 'scan-aws-complete', limit: 500, cursor: 'aws-findings-page-2' },
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
     expect(getSecretPermissionEquivalence).not.toHaveBeenCalled();
+  });
+
+  it('loads historical AWS findings without a live connector', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
+      scan: {
+        id: 'scan-aws-history',
+        project_id: 'production',
+        connector_id: 'aws-connector-1',
+        provider: 'aws',
+        status: 'succeeded',
+        started_at: '2026-08-20T20:00:00Z',
+        finished_at: '2026-08-20T20:03:00Z',
+        asset_count: 1,
+        finding_count: 1
+      }
+    });
+    vi.spyOn(api.apiClient, 'listFindings').mockResolvedValue({
+      items: [
+        {
+          id: 'finding-aws-history',
+          scan_id: 'scan-aws-history',
+          type: 'aws_iam_overprivileged_role',
+          severity: 'high',
+          title: 'Historical IAM finding',
+          human_summary: 'A persisted finding from the completed scan.',
+          remediation: 'Review the role policy.',
+          created_at: '2026-08-20T20:03:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({ items: [] });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production&scan_id=scan-aws-history']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Showing findings from this AWS scan')).toBeInTheDocument();
+    expect(await screen.findByText('Historical IAM finding')).toBeInTheDocument();
+  });
+
+  it('rejects persisted AWS findings until the scan reaches a terminal result', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
+      scan: {
+        id: 'scan-aws-running',
+        project_id: 'production',
+        connector_id: 'aws-connector-1',
+        provider: 'aws',
+        status: 'running',
+        started_at: '2026-08-20T20:00:00Z',
+        asset_count: 0,
+        finding_count: 0
+      }
+    });
+    vi.spyOn(api.apiClient, 'listFindings').mockResolvedValue({ items: [] });
+    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({ items: [] });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production&scan_id=scan-aws-running']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('The requested AWS scan has not completed yet.');
+  });
+
+  it('rejects persisted AWS findings from another project or connector', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
+      scan: {
+        id: 'scan-aws-other-scope',
+        project_id: 'staging',
+        connector_id: 'aws-connector-2',
+        provider: 'aws',
+        status: 'succeeded',
+        started_at: '2026-08-20T20:00:00Z',
+        finished_at: '2026-08-20T20:03:00Z',
+        asset_count: 0,
+        finding_count: 0
+      }
+    });
+    vi.spyOn(api.apiClient, 'listFindings').mockResolvedValue({ items: [] });
+    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({ items: [] });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production&scan_id=scan-aws-other-scope']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('The requested AWS scan does not belong to this environment.');
+  });
+
+  it('marks an empty partial AWS scan as incomplete evidence', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
+      scan: {
+        id: 'scan-aws-partial',
+        project_id: 'production',
+        connector_id: 'aws-connector-1',
+        provider: 'aws',
+        status: 'partial',
+        started_at: '2026-08-20T20:00:00Z',
+        finished_at: '2026-08-20T20:03:00Z',
+        asset_count: 1,
+        finding_count: 0
+      }
+    });
+    vi.spyOn(api.apiClient, 'listFindings').mockResolvedValue({ items: [] });
+    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({ items: [] });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production&scan_id=scan-aws-partial']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('No findings in this AWS scan')).toBeInTheDocument();
+    expect(screen.getByText('Evidence incomplete')).toBeInTheDocument();
+    expect(screen.getByText(/sources that were available/i)).toBeInTheDocument();
   });
 
   it('clears a completed scan context when switching AWS findings environments', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8333,7 +8333,7 @@ describe('Domain-first app routes', () => {
         started_at: '2026-08-20T20:00:00Z',
         finished_at: '2026-08-20T20:03:00Z',
         asset_count: 12,
-        finding_count: 2
+        finding_count: 4
       }
     });
     const listFindings = vi.spyOn(api.apiClient, 'listFindings').mockImplementation(async (filters = {}) =>
@@ -8353,6 +8353,34 @@ describe('Domain-first app routes', () => {
                 remediation: 'Restrict the bucket policy to approved principals.',
                 created_at: '2026-08-20T20:03:00Z',
                 lifecycle_status: 'fixed'
+              },
+              {
+                id: 'finding-aws-3',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_acknowledged_role',
+                severity: 'low',
+                title: 'Acknowledged IAM role',
+                human_summary: 'The finding has been acknowledged for review.',
+                path: ['review-role'],
+                owner: 'AWS scanner',
+                evidence: { source: 'iam-policy' },
+                remediation: 'Review the acknowledged finding.',
+                created_at: '2026-08-20T20:03:00Z',
+                triage: { status: 'ack' }
+              },
+              {
+                id: 'finding-aws-4',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_resolved_role',
+                severity: 'low',
+                title: 'Resolved IAM role',
+                human_summary: 'The finding has been resolved.',
+                path: ['resolved-role'],
+                owner: 'AWS scanner',
+                evidence: { source: 'iam-policy' },
+                remediation: 'No remediation is pending.',
+                created_at: '2026-08-20T20:03:00Z',
+                triage: { status: 'resolved' }
               }
             ]
           }
@@ -8396,7 +8424,15 @@ describe('Domain-first app routes', () => {
     expect(within(findingsTable).getByText('Overprivileged IAM role')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Public S3 bucket')).toBeInTheDocument();
     expect(within(findingsTable).getByText('High')).toBeInTheDocument();
-    expect(within(findingsTable).getAllByText('Blocked')).toHaveLength(2);
+    expect(within(findingsTable).getByText('Suppressed')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Acknowledged')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Resolved')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Blocked')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Remediation'), { target: { value: 'suppressed' } });
+    await waitFor(() => {
+      expect(within(findingsTable).getByText('Overprivileged IAM role')).toBeInTheDocument();
+      expect(within(findingsTable).queryByText('Public S3 bucket')).not.toBeInTheDocument();
+    });
     expect(getScan).toHaveBeenCalledWith('scan-aws-complete', expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' }));
     expect(listFindings).toHaveBeenCalledWith(
       { scan_id: 'scan-aws-complete', limit: 500 },
@@ -8409,7 +8445,7 @@ describe('Domain-first app routes', () => {
     expect(getSecretPermissionEquivalence).not.toHaveBeenCalled();
   });
 
-  it('loads historical AWS findings without a live connector', async () => {
+  it('loads historical AWS findings without requiring the current connector', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
       items: [
@@ -8425,7 +8461,7 @@ describe('Domain-first app routes', () => {
         }
       ]
     });
-    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: { ...disconnectedAWS, connector_id: 'aws-connector-new' } });
     vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
       scan: {
         id: 'scan-aws-history',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8306,6 +8306,154 @@ describe('Domain-first app routes', () => {
     expect(screen.queryByText('No AWS findings')).not.toBeInTheDocument();
   });
 
+  it('shows findings persisted by the completed AWS discovery scan', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const getScan = vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
+      scan: {
+        id: 'scan-aws-complete',
+        project_id: 'production',
+        connector_id: 'aws-connector-1',
+        provider: 'AWS',
+        status: 'succeeded',
+        started_at: '2026-08-20T20:00:00Z',
+        finished_at: '2026-08-20T20:03:00Z',
+        asset_count: 12,
+        finding_count: 1
+      }
+    });
+    const listFindings = vi.spyOn(api.apiClient, 'listFindings').mockResolvedValue({
+      items: [
+        {
+          id: 'finding-aws-1',
+          scan_id: 'scan-aws-complete',
+          type: 'aws_iam_overprivileged_role',
+          severity: 'high',
+          title: 'Overprivileged IAM role',
+          human_summary: 'The role grants more permissions than this workload requires.',
+          path: ['production-role', 'AdministratorAccess'],
+          owner: 'AWS scanner',
+          evidence: { source: 'iam-policy' },
+          remediation: 'Reduce the role policy to the required actions.',
+          created_at: '2026-08-20T20:03:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'listScanEvents').mockRejectedValue(new Error('scan events unavailable'));
+    const getSecretPermissionEquivalence = vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence');
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production&scan_id=scan-aws-complete']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Showing findings from this AWS scan')).toBeInTheDocument();
+    expect(screen.getByText(/could not verify source completeness/i)).toBeInTheDocument();
+    const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
+    expect(within(findingsTable).getByText('Overprivileged IAM role')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('High')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Open')).toBeInTheDocument();
+    expect(getScan).toHaveBeenCalledWith('scan-aws-complete', expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' }));
+    expect(listFindings).toHaveBeenCalledWith(
+      { scan_id: 'scan-aws-complete', limit: 500 },
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getSecretPermissionEquivalence).not.toHaveBeenCalled();
+  });
+
+  it('clears a completed scan context when switching AWS findings environments', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging',
+          name: 'Staging',
+          slug: 'staging',
+          description: 'Staging AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
+      scan: {
+        id: 'scan-aws-complete',
+        project_id: 'production',
+        connector_id: 'aws-connector-1',
+        provider: 'aws',
+        status: 'succeeded',
+        started_at: '2026-08-20T20:00:00Z',
+        finished_at: '2026-08-20T20:03:00Z',
+        asset_count: 12,
+        finding_count: 0
+      }
+    });
+    vi.spyOn(api.apiClient, 'listFindings').mockResolvedValue({ items: [] });
+    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({ items: [] });
+    vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockResolvedValue({
+      findings: {
+        status: 'ready',
+        findings: [],
+        summary: {},
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+    function LocationProbe() {
+      const currentLocation = useLocation();
+      return <output data-testid="aws-findings-location">{currentLocation.search}</output>;
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production&scan_id=scan-aws-complete&severity=high']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<><ProductAWSFindingsPage /><LocationProbe /></>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
+    await waitFor(() => expect(screen.getByTestId('aws-findings-location')).toHaveTextContent('environment=staging&severity=high'));
+    expect(screen.getByTestId('aws-findings-location')).not.toHaveTextContent('scan_id=');
+  });
+
   it('shows AWS findings load errors separately from an empty result', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18103,14 +18103,50 @@ function awsPersistedFindingStage(finding: ApiFinding): AWSCapabilityStage {
 }
 
 function awsPersistedFindingStatus(finding: ApiFinding): string {
+  const triageStatus = normalizeValue(finding.triage?.status).toLowerCase();
+  if (triageStatus === 'ack' || triageStatus === 'suppressed' || triageStatus === 'resolved') {
+    return triageStatus === 'ack' ? 'queued' : 'blocked';
+  }
   switch (normalizeValue(finding.lifecycle_status).toLowerCase()) {
-    case 'ack':
-      return 'queued';
+    case 'fixed':
+    case 'risk_accepted':
+    case 'false_positive':
     case 'suppressed':
     case 'resolved':
       return 'blocked';
+    case 'reopened':
     default:
       return 'open';
+  }
+}
+
+const AWS_PERSISTED_FINDINGS_PAGE_LIMIT = 500;
+
+async function listAllAWSScanFindings(scanID: string, auth: RequestAuthContext): Promise<ApiFinding[]> {
+  const findings: ApiFinding[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  while (true) {
+    const response = await apiClient.listFindings(
+      {
+        scan_id: scanID,
+        limit: AWS_PERSISTED_FINDINGS_PAGE_LIMIT,
+        ...(cursor ? { cursor } : {})
+      },
+      auth
+    );
+    findings.push(...response.items);
+
+    const nextCursor = normalizeValue(response.next_cursor);
+    if (!nextCursor) {
+      return findings;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error('AWS findings pagination returned a repeated cursor.');
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
   }
 }
 
@@ -18207,8 +18243,9 @@ function AWSFindingsContent({
     ? persistedFindings?.map((finding) => awsPersistedFindingRiskOperationRow(finding, connection)) ?? []
     : findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, scope, environmentID, connection)) ?? [];
   const displayedRows = filterAWSInventoryRows(rows, filters);
-  const isReadyToLoad = Boolean(scope && environmentID && connection?.connected);
-  const isLoading = loading || (showingPersistedScan && isReadyToLoad && !persistedFindings && !error) || (!showingPersistedScan && isReadyToLoad && !findings && !error);
+  const persistedScanReadyToLoad = Boolean(scope && environmentID);
+  const liveFindingsReadyToLoad = Boolean(scope && environmentID && connection?.connected);
+  const isLoading = loading || (showingPersistedScan && persistedScanReadyToLoad && !persistedFindings && !error) || (!showingPersistedScan && liveFindingsReadyToLoad && !findings && !error);
 
   return (
     <>
@@ -20499,16 +20536,17 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     setPersistedScanPartial(false);
     setPersistedScanCoverageUnknown(false);
     setPersistedFindingsError('');
-    if (routeID !== 'findings' || !persistedScanID || !scope || !selectedEnvironmentID || !connection?.connected) {
+    if (routeID !== 'findings' || !persistedScanID || !scope || !selectedEnvironmentID) {
       setPersistedFindingsLoading(false);
       return;
     }
     setPersistedFindingsLoading(true);
+    const auth = buildProductAuthContext(scope);
     try {
       const [scanResponse, findingsResponse, eventsResponse] = await Promise.all([
-        apiClient.getScan(persistedScanID, buildProductAuthContext(scope)),
-        apiClient.listFindings({ scan_id: persistedScanID, limit: 500 }, buildProductAuthContext(scope)),
-        apiClient.listScanEvents(persistedScanID, undefined, 100, buildProductAuthContext(scope))
+        apiClient.getScan(persistedScanID, auth),
+        listAllAWSScanFindings(persistedScanID, auth),
+        apiClient.listScanEvents(persistedScanID, undefined, 100, auth)
           .then((response) => ({ items: response.items, available: true }))
           .catch(() => ({ items: [], available: false }))
       ]);
@@ -20516,12 +20554,26 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
         return;
       }
       const scan = scanResponse.scan;
-      if (normalizeValue(scan.provider).toLowerCase() !== 'aws' || (scan.project_id && scan.project_id !== selectedEnvironmentID) || (connection.connector_id && scan.connector_id && scan.connector_id !== connection.connector_id)) {
+      const scanStatus = normalizeValue(scan.status).toLowerCase();
+      const scanProjectID = normalizeValue(scan.project_id);
+      const scanConnectorID = normalizeValue(scan.connector_id);
+      const currentConnectorID = normalizeValue(connection?.connector_id);
+      const isSupportedResult = scanStatus === 'succeeded' || scanStatus === 'completed' || scanStatus === 'partial';
+      if (!isSupportedResult) {
+        throw new Error('The requested AWS scan has not completed yet.');
+      }
+      if (
+        normalizeValue(scan.provider).toLowerCase() !== 'aws' ||
+        !scanProjectID ||
+        scanProjectID !== selectedEnvironmentID ||
+        !scanConnectorID ||
+        (currentConnectorID && scanConnectorID !== currentConnectorID)
+      ) {
         throw new Error('The requested AWS scan does not belong to this environment.');
       }
       setPersistedScan(scan);
-      setPersistedFindings(findingsResponse.items);
-      setPersistedScanPartial(awsDiscoveryHasPartialResults(eventsResponse.items));
+      setPersistedFindings(findingsResponse);
+      setPersistedScanPartial(scanStatus === 'partial' || awsDiscoveryHasPartialResults(eventsResponse.items));
       setPersistedScanCoverageUnknown(!eventsResponse.available);
     } catch (requestError) {
       if (requestID !== persistedFindingsRequestRef.current) {
@@ -20533,7 +20585,7 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
         setPersistedFindingsLoading(false);
       }
     }
-  }, [connection?.connected, connection?.connector_id, persistedScanID, routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+  }, [connection?.connector_id, persistedScanID, routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
 
   useEffect(() => {
     void loadPersistedAWSFindings();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1760,13 +1760,16 @@ function environmentIDFromSearch(search: string): string {
   return normalizeValue(new URLSearchParams(search).get(ENVIRONMENT_QUERY_PARAM));
 }
 
-function environmentSearch(search: string, environmentID: string): string {
+function environmentSearch(search: string, environmentID: string, options: { omit?: string[] } = {}): string {
   const params = new URLSearchParams(search);
   const normalized = normalizeValue(environmentID);
   if (normalized) {
     params.set(ENVIRONMENT_QUERY_PARAM, normalized);
   } else {
     params.delete(ENVIRONMENT_QUERY_PARAM);
+  }
+  for (const key of options.omit ?? []) {
+    params.delete(key);
   }
   const next = params.toString();
   return next ? `?${next}` : '';
@@ -3845,8 +3848,18 @@ function awsConnectedTradeoffs(connection: AWSConnectionStatus): string[] {
   }
 }
 
-function awsRouteLink(scope: ProductSession, routeID: ProductDomainRouteID, environmentID: string): string {
-  return appendEnvironmentQuery(domainRoutePath(scope, 'aws', findDomainRoute('aws', routeID)), environmentID);
+function awsRouteLink(
+  scope: ProductSession,
+  routeID: ProductDomainRouteID,
+  environmentID: string,
+  options: { scanID?: string } = {}
+): string {
+  const path = appendEnvironmentQuery(domainRoutePath(scope, 'aws', findDomainRoute('aws', routeID)), environmentID);
+  if (!options.scanID) {
+    return path;
+  }
+  const separator = path.includes('?') ? '&' : '?';
+  return `${path}${separator}scan_id=${encodeURIComponent(options.scanID)}`;
 }
 
 function awsDiscoveryPath(
@@ -5496,7 +5509,11 @@ function useAWSInventoryData(): AWSInventoryDataState {
       navigate(
         {
           pathname: location.pathname,
-          search: environmentSearch(location.search, environmentID)
+          search: environmentSearch(
+            location.search,
+            environmentID,
+            location.pathname.endsWith('/aws/findings') ? { omit: ['scan_id'] } : undefined
+          )
         },
         { replace: false }
       );
@@ -18074,6 +18091,73 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
   };
 }
 
+function awsPersistedFindingStage(finding: ApiFinding): AWSCapabilityStage {
+  const severity = normalizeValue(finding.severity).toLowerCase();
+  if (severity === 'critical') {
+    return 'not-available';
+  }
+  if (severity === 'high') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsPersistedFindingStatus(finding: ApiFinding): string {
+  switch (normalizeValue(finding.lifecycle_status).toLowerCase()) {
+    case 'ack':
+      return 'queued';
+    case 'suppressed':
+    case 'resolved':
+      return 'blocked';
+    default:
+      return 'open';
+  }
+}
+
+function awsPersistedFindingEvidence(finding: ApiFinding): string {
+  const summary = normalizeValue(finding.human_summary);
+  if (summary) {
+    return summary;
+  }
+  return Object.keys(finding.evidence ?? {}).length > 0 ? 'Inventory-backed AWS evidence' : 'Evidence unavailable';
+}
+
+function awsPersistedFindingRiskOperationRow(
+  finding: ApiFinding,
+  connection: AWSConnectionStatus | null
+): AWSRiskOperationTableRow {
+  const status = awsPersistedFindingStatus(finding);
+  const path = finding.path?.filter(Boolean).join(' → ');
+  const account = connection?.account_id ?? 'Connected AWS account';
+  const region = connection?.region ?? 'Connected region';
+  const evidence = awsPersistedFindingEvidence(finding);
+  return {
+    id: finding.id,
+    title: finding.title || formatTokenLabel(finding.type),
+    category: formatTokenLabel(finding.severity),
+    evidence,
+    owner: finding.owner || finding.adapter_source || 'AWS scanner',
+    blastRadius: path || `${account} · ${region}`,
+    nextAction: finding.remediation || 'Review the finding evidence and remediate the affected AWS resource.',
+    status,
+    stage: awsPersistedFindingStage(finding),
+    filters: {
+      severity: normalizeValue(finding.severity).toLowerCase() || 'unknown',
+      account: 'connected',
+      region: 'current',
+      evidence: Object.keys(finding.evidence ?? {}).length > 0 ? 'inventory-backed' : 'unavailable',
+      status
+    },
+    searchText: inventorySearchText([
+      finding.title,
+      finding.type,
+      finding.human_summary,
+      finding.remediation,
+      ...(finding.path ?? [])
+    ])
+  };
+}
+
 function awsSecretPermissionEquivalenceFindingStatusFilterToken(value: string | undefined): string {
   switch (normalizeFilterValue(value ?? '')) {
     case 'action_required':
@@ -18089,6 +18173,11 @@ function awsSecretPermissionEquivalenceFindingStatusFilterToken(value: string | 
 
 function AWSFindingsContent({
   findings,
+  persistedFindings,
+  persistedScan,
+  persistedScanPartial,
+  persistedScanCoverageUnknown,
+  persistedScanID,
   scope,
   environmentID,
   connection,
@@ -18099,6 +18188,11 @@ function AWSFindingsContent({
   onFiltersChange
 }: {
   findings: AWSSecretPermissionEquivalenceResult | null;
+  persistedFindings: ApiFinding[] | null;
+  persistedScan: ScanRecord | null;
+  persistedScanPartial: boolean;
+  persistedScanCoverageUnknown: boolean;
+  persistedScanID?: string;
   scope: ProductSession | null;
   environmentID?: string;
   connection: AWSConnectionStatus | null;
@@ -18108,13 +18202,32 @@ function AWSFindingsContent({
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
-  const rows = findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, scope, environmentID, connection)) ?? [];
+  const showingPersistedScan = Boolean(persistedScanID);
+  const rows = showingPersistedScan
+    ? persistedFindings?.map((finding) => awsPersistedFindingRiskOperationRow(finding, connection)) ?? []
+    : findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, scope, environmentID, connection)) ?? [];
   const displayedRows = filterAWSInventoryRows(rows, filters);
   const isReadyToLoad = Boolean(scope && environmentID && connection?.connected);
-  const isLoading = loading || (isReadyToLoad && !findings && !error);
+  const isLoading = loading || (showingPersistedScan && isReadyToLoad && !persistedFindings && !error) || (!showingPersistedScan && isReadyToLoad && !findings && !error);
 
   return (
     <>
+      {showingPersistedScan && persistedScan ? (
+        <DomainStatusPanel
+          eyebrow="Discovery result"
+          title="Showing findings from this AWS scan"
+          status={`${persistedScan.finding_count} finding${persistedScan.finding_count === 1 ? '' : 's'}`}
+          tone={persistedScanPartial || persistedScanCoverageUnknown ? 'warning' : 'success'}
+        >
+          <p>
+            {persistedScanPartial
+              ? 'The scan completed with some unavailable sources. These findings are valid for the evidence Identrail collected; review coverage gaps before treating the result as complete.'
+              : persistedScanCoverageUnknown
+                ? 'These findings come directly from the completed AWS discovery run, but Identrail could not verify source completeness. Run discovery again if you need a fresh coverage check.'
+                : 'These findings come directly from the completed AWS discovery run.'}
+          </p>
+        </DomainStatusPanel>
+      ) : null}
       <AWSRiskOperationFilterSet routeID="findings" filters={filters} onChange={onFiltersChange} />
       {error ? (
         <DomainErrorState
@@ -18135,10 +18248,16 @@ function AWSFindingsContent({
           getRowKey={(row) => row.id}
           emptyState={
             <DomainEmptyState
-              eyebrow={findings?.status === 'degraded' ? 'Evidence incomplete' : 'Empty'}
-              title={findings?.status === 'degraded' ? 'Live AWS findings are not available yet' : 'No AWS findings'}
+              eyebrow={showingPersistedScan && (persistedScanPartial || persistedScanCoverageUnknown) ? 'Evidence incomplete' : 'Empty'}
+              title={showingPersistedScan ? 'No findings in this AWS scan' : findings?.status === 'degraded' ? 'Live AWS findings are not available yet' : 'No AWS findings'}
               body={
-                findings?.status === 'degraded'
+                showingPersistedScan
+                  ? persistedScanPartial
+                    ? 'The scan returned no findings from the sources that were available. Resolve the coverage gaps and run discovery again for a complete result.'
+                    : persistedScanCoverageUnknown
+                      ? 'This completed AWS scan did not produce any findings, but source completeness could not be verified. Run discovery again before treating the empty result as complete.'
+                      : 'This completed AWS scan did not produce any findings.'
+                  : findings?.status === 'degraded'
                   ? findings.failure_reasons[0] ?? 'Live AWS inventory is unavailable, so Identrail is not presenting sample findings as customer risk.'
                   : 'No live AWS finding matches this environment yet. Run the collectors or clear filters to load evidence.'
               }
@@ -18348,8 +18467,10 @@ function AWSGovernanceContent({
 
 function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRouteID }) {
   const data = useAWSInventoryData();
+  const location = useLocation();
   const { scope, environmentScope, selectedEnvironmentID, connection, connectionLoading, connectionError } = data;
   const copy = AWS_RISK_OPERATION_PAGE_COPY[routeID];
+  const persistedScanID = useMemo(() => normalizeValue(new URLSearchParams(location.search).get('scan_id')), [location.search]);
   const [activeFilters, setActiveFilters] = useState<AWSInventoryFilterState>(() => ({
     ...AWS_RISK_OPERATION_FILTER_DEFAULTS[routeID]
   }));
@@ -18502,6 +18623,13 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [secretPermissionEquivalenceLoading, setSecretPermissionEquivalenceLoading] = useState(false);
   const [secretPermissionEquivalenceError, setSecretPermissionEquivalenceError] = useState('');
   const secretPermissionEquivalenceRequestRef = useRef(0);
+  const [persistedFindings, setPersistedFindings] = useState<ApiFinding[] | null>(null);
+  const [persistedScan, setPersistedScan] = useState<ScanRecord | null>(null);
+  const [persistedScanPartial, setPersistedScanPartial] = useState(false);
+  const [persistedScanCoverageUnknown, setPersistedScanCoverageUnknown] = useState(false);
+  const [persistedFindingsLoading, setPersistedFindingsLoading] = useState(false);
+  const [persistedFindingsError, setPersistedFindingsError] = useState('');
+  const persistedFindingsRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -18512,7 +18640,7 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   }, [routeID]);
 
   const showSecretPermissionEquivalence = routeID === 'runtime';
-  const shouldLoadSecretPermissionEquivalence = routeID === 'runtime' || routeID === 'findings';
+  const shouldLoadSecretPermissionEquivalence = routeID === 'runtime' || (routeID === 'findings' && !persistedScanID);
 
   const loadGraphExplorer = useCallback(async ({ append = false }: { append?: boolean } = {}) => {
     const requestID = ++graphExplorerRequestRef.current;
@@ -20364,6 +20492,56 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadSecretPermissionEquivalence]);
 
+  const loadPersistedAWSFindings = useCallback(async () => {
+    const requestID = ++persistedFindingsRequestRef.current;
+    setPersistedFindings(null);
+    setPersistedScan(null);
+    setPersistedScanPartial(false);
+    setPersistedScanCoverageUnknown(false);
+    setPersistedFindingsError('');
+    if (routeID !== 'findings' || !persistedScanID || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setPersistedFindingsLoading(false);
+      return;
+    }
+    setPersistedFindingsLoading(true);
+    try {
+      const [scanResponse, findingsResponse, eventsResponse] = await Promise.all([
+        apiClient.getScan(persistedScanID, buildProductAuthContext(scope)),
+        apiClient.listFindings({ scan_id: persistedScanID, limit: 500 }, buildProductAuthContext(scope)),
+        apiClient.listScanEvents(persistedScanID, undefined, 100, buildProductAuthContext(scope))
+          .then((response) => ({ items: response.items, available: true }))
+          .catch(() => ({ items: [], available: false }))
+      ]);
+      if (requestID !== persistedFindingsRequestRef.current) {
+        return;
+      }
+      const scan = scanResponse.scan;
+      if (normalizeValue(scan.provider).toLowerCase() !== 'aws' || (scan.project_id && scan.project_id !== selectedEnvironmentID) || (connection.connector_id && scan.connector_id && scan.connector_id !== connection.connector_id)) {
+        throw new Error('The requested AWS scan does not belong to this environment.');
+      }
+      setPersistedScan(scan);
+      setPersistedFindings(findingsResponse.items);
+      setPersistedScanPartial(awsDiscoveryHasPartialResults(eventsResponse.items));
+      setPersistedScanCoverageUnknown(!eventsResponse.available);
+    } catch (requestError) {
+      if (requestID !== persistedFindingsRequestRef.current) {
+        return;
+      }
+      setPersistedFindingsError(formatAPIError(requestError, 'Unable to load findings from this AWS scan.'));
+    } finally {
+      if (requestID === persistedFindingsRequestRef.current) {
+        setPersistedFindingsLoading(false);
+      }
+    }
+  }, [connection?.connected, connection?.connector_id, persistedScanID, routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+
+  useEffect(() => {
+    void loadPersistedAWSFindings();
+    return () => {
+      persistedFindingsRequestRef.current += 1;
+    };
+  }, [loadPersistedAWSFindings]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -20738,12 +20916,17 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
         {routeID === 'findings' ? (
           <AWSFindingsContent
             findings={secretPermissionEquivalence}
+            persistedFindings={persistedFindings}
+            persistedScan={persistedScan}
+            persistedScanPartial={persistedScanPartial}
+            persistedScanCoverageUnknown={persistedScanCoverageUnknown}
+            persistedScanID={persistedScanID}
             scope={scope}
             environmentID={selectedEnvironmentID}
             connection={connection}
-            loading={secretPermissionEquivalenceLoading}
-            error={secretPermissionEquivalenceError}
-            onRetry={loadSecretPermissionEquivalence}
+            loading={persistedScanID ? persistedFindingsLoading : secretPermissionEquivalenceLoading}
+            error={persistedScanID ? persistedFindingsError : secretPermissionEquivalenceError}
+            onRetry={persistedScanID ? loadPersistedAWSFindings : loadSecretPermissionEquivalence}
             filters={activeFilters}
             onFiltersChange={onFiltersChange}
           />
@@ -21057,7 +21240,9 @@ export function ProductAWSDiscoveryPage() {
 
   const phase = awsDiscoveryPhase(scan, events);
   const partial = awsDiscoveryHasPartialResults(events);
-  const findingsPath = scope && selectedEnvironmentID ? awsRouteLink(scope, 'findings', selectedEnvironmentID) : '#';
+  const findingsPath = scope && selectedEnvironmentID
+    ? awsRouteLink(scope, 'findings', selectedEnvironmentID, { scanID: scanID || undefined })
+    : '#';
   const connectPath = scope && selectedEnvironmentID ? awsRouteLink(scope, 'connect', selectedEnvironmentID) : '#';
   const hasTerminalResults = phase === 'results' && Boolean(scanID) && Boolean(scan);
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -12957,6 +12957,9 @@ const AWS_RISK_OPERATION_FILTERS: AWSRiskOperationFilterConfigMap = {
       options: [
         { label: 'All statuses', value: 'all' },
         { label: 'Open', value: 'open' },
+        { label: 'Acknowledged', value: 'ack' },
+        { label: 'Suppressed', value: 'suppressed' },
+        { label: 'Resolved', value: 'resolved' },
         { label: 'Queued', value: 'queued' },
         { label: 'Blocked', value: 'blocked' },
         { label: 'Unavailable', value: 'unavailable' }
@@ -18104,8 +18107,8 @@ function awsPersistedFindingStage(finding: ApiFinding): AWSCapabilityStage {
 
 function awsPersistedFindingStatus(finding: ApiFinding): string {
   const triageStatus = normalizeValue(finding.triage?.status).toLowerCase();
-  if (triageStatus === 'ack' || triageStatus === 'suppressed' || triageStatus === 'resolved') {
-    return triageStatus === 'ack' ? 'queued' : 'blocked';
+  if (triageStatus === 'open' || triageStatus === 'ack' || triageStatus === 'suppressed' || triageStatus === 'resolved') {
+    return triageStatus;
   }
   switch (normalizeValue(finding.lifecycle_status).toLowerCase()) {
     case 'fixed':
@@ -18117,6 +18120,19 @@ function awsPersistedFindingStatus(finding: ApiFinding): string {
     case 'reopened':
     default:
       return 'open';
+  }
+}
+
+function awsPersistedFindingStatusLabel(status: string): string {
+  switch (status) {
+    case 'ack':
+      return 'Acknowledged';
+    case 'risk_accepted':
+      return 'Risk accepted';
+    case 'false_positive':
+      return 'False positive';
+    default:
+      return formatTokenLabel(status);
   }
 }
 
@@ -18305,7 +18321,7 @@ function AWSFindingsContent({
             { key: 'category', header: 'Severity', render: (row) => row.category },
             { key: 'evidence', header: 'Evidence', render: (row) => row.evidence },
             { key: 'blast', header: 'Blast radius', render: (row) => row.blastRadius },
-            { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={formatTokenLabel(row.status)} /> }
+            { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={showingPersistedScan ? awsPersistedFindingStatusLabel(row.status) : formatTokenLabel(row.status)} /> }
           ]}
         />
       )}
@@ -20557,17 +20573,17 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       const scanStatus = normalizeValue(scan.status).toLowerCase();
       const scanProjectID = normalizeValue(scan.project_id);
       const scanConnectorID = normalizeValue(scan.connector_id);
-      const currentConnectorID = normalizeValue(connection?.connector_id);
       const isSupportedResult = scanStatus === 'succeeded' || scanStatus === 'completed' || scanStatus === 'partial';
       if (!isSupportedResult) {
         throw new Error('The requested AWS scan has not completed yet.');
       }
+      // A scan can outlive the connector that created it. Project-scoped, authenticated
+      // scan metadata is the ownership boundary; connector IDs are historical metadata.
       if (
         normalizeValue(scan.provider).toLowerCase() !== 'aws' ||
         !scanProjectID ||
         scanProjectID !== selectedEnvironmentID ||
-        !scanConnectorID ||
-        (currentConnectorID && scanConnectorID !== currentConnectorID)
+        !scanConnectorID
       ) {
         throw new Error('The requested AWS scan does not belong to this environment.');
       }
@@ -20585,7 +20601,7 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
         setPersistedFindingsLoading(false);
       }
     }
-  }, [connection?.connector_id, persistedScanID, routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+  }, [persistedScanID, routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
 
   useEffect(() => {
     void loadPersistedAWSFindings();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18174,14 +18174,81 @@ function awsPersistedFindingEvidence(finding: ApiFinding): string {
   return Object.keys(finding.evidence ?? {}).length > 0 ? 'Inventory-backed AWS evidence' : 'Evidence unavailable';
 }
 
+type AWSPersistedFindingScope = {
+  accountID?: string;
+  region?: string;
+};
+
+const AWS_FINDING_ACCOUNT_ID_PATTERN = /^\d{12}$/;
+const AWS_FINDING_REGION_PATTERN = /^(?:af|ap|ca|cn|eu|il|me|sa|us|mx|us-gov|us-iso|us-isob|eu-isoe)-[a-z0-9-]+-\d+$/;
+
+function awsPersistedFindingScope(finding: ApiFinding): AWSPersistedFindingScope {
+  const scope: AWSPersistedFindingScope = {};
+  const visited = new Set<object>();
+
+  const inspect = (value: unknown, key?: string): void => {
+    if (scope.accountID && scope.region) {
+      return;
+    }
+
+    const normalizedKey = key?.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+    const normalizedValue = normalizeValue(value);
+    if (normalizedValue) {
+      if (
+        normalizedKey &&
+        ['account', 'accountid', 'awsaccountid'].includes(normalizedKey) &&
+        AWS_FINDING_ACCOUNT_ID_PATTERN.test(normalizedValue)
+      ) {
+        scope.accountID ??= normalizedValue;
+      }
+      if (
+        normalizedKey &&
+        ['region', 'awsregion'].includes(normalizedKey) &&
+        AWS_FINDING_REGION_PATTERN.test(normalizedValue)
+      ) {
+        scope.region ??= normalizedValue;
+      }
+      if (normalizedValue.startsWith('arn:')) {
+        const arnParts = normalizedValue.split(':');
+        if (arnParts.length >= 6) {
+          const accountID = arnParts[4];
+          const region = arnParts[3];
+          if (AWS_FINDING_ACCOUNT_ID_PATTERN.test(accountID)) {
+            scope.accountID ??= accountID;
+          }
+          if (AWS_FINDING_REGION_PATTERN.test(region)) {
+            scope.region ??= region;
+          }
+        }
+      }
+      return;
+    }
+
+    if (!value || typeof value !== 'object' || visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+    for (const [childKey, childValue] of Object.entries(value)) {
+      inspect(childValue, childKey);
+    }
+  };
+
+  inspect(finding.evidence);
+  for (const pathPart of finding.path ?? []) {
+    inspect(pathPart);
+  }
+  return scope;
+}
+
 function awsPersistedFindingRiskOperationRow(
   finding: ApiFinding,
   connection: AWSConnectionStatus | null
 ): AWSRiskOperationTableRow {
   const status = awsPersistedFindingStatus(finding);
   const path = finding.path?.filter(Boolean).join(' → ');
-  const account = connection?.account_id ?? 'Connected AWS account';
-  const region = connection?.region ?? 'Connected region';
+  const findingScope = awsPersistedFindingScope(finding);
+  const account = findingScope.accountID ? `Account ${findingScope.accountID}` : 'Account unknown';
+  const region = findingScope.region ? `Region ${findingScope.region}` : 'Region unknown';
   const evidence = awsPersistedFindingEvidence(finding);
   return {
     id: finding.id,
@@ -18195,8 +18262,8 @@ function awsPersistedFindingRiskOperationRow(
     stage: awsPersistedFindingStage(finding),
     filters: {
       severity: normalizeValue(finding.severity).toLowerCase() || 'unknown',
-      account: 'connected',
-      region: 'current',
+      account: findingScope.accountID && findingScope.accountID === connection?.account_id ? 'connected' : 'unknown',
+      region: findingScope.region && findingScope.region === connection?.region ? 'current' : 'unknown',
       evidence: Object.keys(finding.evidence ?? {}).length > 0 ? 'inventory-backed' : 'unavailable',
       status
     },
@@ -18205,6 +18272,8 @@ function awsPersistedFindingRiskOperationRow(
       finding.type,
       finding.human_summary,
       finding.remediation,
+      findingScope.accountID,
+      findingScope.region,
       ...(finding.path ?? [])
     ])
   };
@@ -18301,10 +18370,20 @@ function AWSFindingsContent({
           getRowKey={(row) => row.id}
           emptyState={
             <DomainEmptyState
-              eyebrow={showingPersistedScan && (persistedScanPartial || persistedScanCoverageUnknown) ? 'Evidence incomplete' : 'Empty'}
-              title={showingPersistedScan ? 'No findings in this AWS scan' : findings?.status === 'degraded' ? 'Live AWS findings are not available yet' : 'No AWS findings'}
+              eyebrow={showingPersistedScan && rows.length > 0 && displayedRows.length === 0 ? 'Filtered' : showingPersistedScan && (persistedScanPartial || persistedScanCoverageUnknown) ? 'Evidence incomplete' : 'Empty'}
+              title={
+                showingPersistedScan && rows.length > 0 && displayedRows.length === 0
+                  ? 'No findings match these filters'
+                  : showingPersistedScan
+                    ? 'No findings in this AWS scan'
+                    : findings?.status === 'degraded'
+                      ? 'Live AWS findings are not available yet'
+                      : 'No AWS findings'
+              }
               body={
-                showingPersistedScan
+                showingPersistedScan && rows.length > 0 && displayedRows.length === 0
+                  ? 'This scan contains findings, but none match the selected filters. Clear or adjust the filters to see them.'
+                  : showingPersistedScan
                   ? persistedScanPartial
                     ? 'The scan returned no findings from the sources that were available. Resolve the coverage gaps and run discovery again for a complete result.'
                     : persistedScanCoverageUnknown


### PR DESCRIPTION
## Summary
- carry the completed AWS scan ID through the discovery-to-Findings redirect
- render persisted findings from that scan instead of switching to the separate live secret-permission endpoint
- preserve partial-result and unknown-source-completeness states without hiding valid findings
- clear stale scan context when switching AWS Findings environments

## Validation
- `npm test -- --run` (611 tests)
- `npm run build`

## Browser audit
The authenticated DuckDuckGo browser extension was unavailable in this session, so the live logged-in app could not be clicked through safely. The repository audit and UI regression coverage cover the reported AWS flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the AWS discovery-to-Findings handoff so Findings shows persisted results from the completed scan instead of the live secret-permission endpoint when a `scan_id` is present. This makes historical results and triage states visible even if the connector changed.

- Discovery links to Findings with a `scan_id`; Findings honors it, shows a status panel with count, and warns on partial results or unknown coverage.
- With `scan_id`, Findings skips `getAWSProjectSecretPermissionEquivalence` and uses `getScan`, `listFindings` (paginates via `next_cursor`), and `listScanEvents`. It validates provider and project, and defers until the scan reaches a terminal state.
- Historical AWS findings load without a live or matching connector; triage states (ack, suppressed, resolved) are preserved, shown in the status pill, and filterable. Closed lifecycle states map to Blocked.
- Changing the Environment removes `scan_id` from the query while preserving other filters; Discovery links append `scan_id` to the Findings URL.
- API: `apiClient.listFindings` accepts `cursor` and returns `next_cursor` to support pagination.
- Tests cover pagination, status/triage rendering and filtering (including Blocked), historical-without-connector, pre‑terminal scans, wrong scope, and clearing `scan_id` on environment change.

<sup>Written for commit 223ed3a83b62321f231dda3e030667d9a5648b08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

