### PR TITLE
Allow workspace owners to access AWS findings

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -922,13 +922,20 @@ x-identrail-action-role-grants:
     - read
     - write
     - admin
+    - owner
+    - analyst
+    - viewer
   findings.triage:
     - write
     - admin
+    - owner
   graph.read:
     - read
     - write
     - admin
+    - owner
+    - analyst
+    - viewer
   me.read:
     - authenticated
     - read

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -71,8 +71,6 @@ func routePolicyKey(method string, fullPath string) string {
 }
 
 func defaultRouteActionRoleGrants() map[string][]string {
-	readRoles := []string{scopeRead, scopeWrite, scopeAdmin}
-	writeRoles := []string{scopeWrite, scopeAdmin}
 	tenancyReadRoles := []string{scopeRead, scopeWrite, scopeAdmin, "owner", "admin", "analyst", "viewer"}
 	tenancyWriteRoles := []string{scopeWrite, scopeAdmin, "owner", "admin"}
 	// tenancy.owner gates destructive workspace lifecycle actions (suspend,
@@ -88,9 +86,14 @@ func defaultRouteActionRoleGrants() map[string][]string {
 	enterpriseWriteRoles := []string{scopeWrite, scopeAdmin, "owner", "admin"}
 	authenticatedRoles := []string{"authenticated", scopeRead, scopeWrite, scopeAdmin, "owner", "admin", "analyst", "viewer"}
 	return map[string][]string{
-		policyActionFindingsRead:    readRoles,
-		policyActionFindingsTriage:  writeRoles,
-		policyActionGraphRead:       readRoles,
+		// Findings and graph data are workspace-scoped read surfaces. Browser
+		// sessions carry the active workspace membership role (for example,
+		// "owner"), while API keys carry scope roles. Both need to reach the
+		// same read-only data without requiring the primary user to create a
+		// second identity.
+		policyActionFindingsRead:    tenancyReadRoles,
+		policyActionFindingsTriage:  tenancyWriteRoles,
+		policyActionGraphRead:       tenancyReadRoles,
 		policyActionScansRead:       tenancyReadRoles,
 		policyActionScansRun:        tenancyWriteRoles,
 		policyActionScansReplay:     tenancyWriteRoles,

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -284,6 +284,13 @@ func (r *storeBackedCentralPolicyRuntimeResolver) compiledVersion(version db.Aut
 	if err != nil {
 		return compiledRouteAuthorizationPolicy{}, fmt.Errorf("compile policy version %d: %w", version.Version, err)
 	}
+	// Versions created from the former built-in defaults can remain active
+	// after an upgrade. Refresh only those exact legacy grants so the primary
+	// workspace user is not stranded behind a stale persisted policy. Custom
+	// role grants remain authoritative and are never broadened here.
+	if strings.EqualFold(strings.TrimSpace(r.policySet), defaultCentralPolicySetID) {
+		compiled = upgradeLegacyDefaultRoleGrants(compiled, r.fallback)
+	}
 	// Persisted policy bundles are immutable and may predate newly shipped
 	// routes. Overlay only the rollout compatibility entries that were added in
 	// this release, preserving every existing persisted decision while keeping
@@ -299,6 +306,39 @@ func (r *storeBackedCentralPolicyRuntimeResolver) compiledVersion(version db.Aut
 		r.cacheByKey.Store(cacheKey, compiled)
 	}
 	return compiled, nil
+}
+
+func upgradeLegacyDefaultRoleGrants(base compiledRouteAuthorizationPolicy, fallback compiledRouteAuthorizationPolicy) compiledRouteAuthorizationPolicy {
+	legacyGrants := map[string][]string{
+		policyActionFindingsRead:   {scopeRead, scopeWrite, scopeAdmin},
+		policyActionFindingsTriage: {scopeWrite, scopeAdmin},
+		policyActionGraphRead:      {scopeRead, scopeWrite, scopeAdmin},
+	}
+	for action, legacyRoles := range legacyGrants {
+		currentRoles, exists := base.RBACActionRole[action]
+		fallbackRoles, hasFallback := fallback.RBACActionRole[action]
+		if !exists || !hasFallback || !sameRoleSet(currentRoles, legacyRoles) {
+			continue
+		}
+		base.RBACActionRole[action] = append([]string(nil), fallbackRoles...)
+	}
+	return base
+}
+
+func sameRoleSet(left []string, right []string) bool {
+	leftCopy := append([]string(nil), left...)
+	rightCopy := append([]string(nil), right...)
+	sort.Strings(leftCopy)
+	sort.Strings(rightCopy)
+	if len(leftCopy) != len(rightCopy) {
+		return false
+	}
+	for i := range leftCopy {
+		if leftCopy[i] != rightCopy[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func overlayRouteAuthorizationPolicyCompatibility(base compiledRouteAuthorizationPolicy, fallback compiledRouteAuthorizationPolicy, definitions []routePolicyDefinition) compiledRouteAuthorizationPolicy {

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -59,6 +60,10 @@ type resolvedCentralPolicyRuntime struct {
 
 type centralPolicyRuntimeResolver interface {
 	Resolve(ctx context.Context) (resolvedCentralPolicyRuntime, error)
+}
+
+type centralPolicyVersionCompiler interface {
+	compiledVersion(version db.AuthzPolicyVersion) (compiledRouteAuthorizationPolicy, error)
 }
 
 type storeBackedCentralPolicyRuntimeResolver struct {
@@ -285,10 +290,10 @@ func (r *storeBackedCentralPolicyRuntimeResolver) compiledVersion(version db.Aut
 		return compiledRouteAuthorizationPolicy{}, fmt.Errorf("compile policy version %d: %w", version.Version, err)
 	}
 	// Versions created from the former built-in defaults can remain active
-	// after an upgrade. Refresh only those exact legacy grants so the primary
-	// workspace user is not stranded behind a stale persisted policy. Custom
-	// role grants remain authoritative and are never broadened here.
-	if strings.EqualFold(strings.TrimSpace(r.policySet), defaultCentralPolicySetID) {
+	// after an upgrade. Refresh only a complete, semantically exact copy of
+	// that legacy built-in bundle. A custom bundle that happens to use the old
+	// role names remains authoritative and is never broadened here.
+	if strings.EqualFold(strings.TrimSpace(r.policySet), defaultCentralPolicySetID) && isLegacyDefaultRouteAuthorizationPolicy(compiled) {
 		compiled = upgradeLegacyDefaultRoleGrants(compiled, r.fallback)
 	}
 	// Persisted policy bundles are immutable and may predate newly shipped
@@ -306,6 +311,26 @@ func (r *storeBackedCentralPolicyRuntimeResolver) compiledVersion(version db.Aut
 		r.cacheByKey.Store(cacheKey, compiled)
 	}
 	return compiled, nil
+}
+
+func isLegacyDefaultRouteAuthorizationPolicy(compiled compiledRouteAuthorizationPolicy) bool {
+	legacy, err := compileRouteAuthorizationPolicyBundle(legacyDefaultRouteAuthorizationPolicyBundle())
+	if err != nil {
+		return false
+	}
+	return reflect.DeepEqual(compiled, legacy)
+}
+
+func legacyDefaultRouteAuthorizationPolicyBundle() routeAuthorizationPolicyBundle {
+	bundle := defaultBuiltInRouteAuthorizationPolicyBundle()
+	bundle.RBACActionRole = make(map[string][]string, len(bundle.RBACActionRole))
+	for action, roles := range defaultRouteActionRoleGrants() {
+		bundle.RBACActionRole[action] = append([]string(nil), roles...)
+	}
+	bundle.RBACActionRole[policyActionFindingsRead] = []string{scopeRead, scopeWrite, scopeAdmin}
+	bundle.RBACActionRole[policyActionFindingsTriage] = []string{scopeWrite, scopeAdmin}
+	bundle.RBACActionRole[policyActionGraphRead] = []string{scopeRead, scopeWrite, scopeAdmin}
+	return bundle
 }
 
 func upgradeLegacyDefaultRoleGrants(base compiledRouteAuthorizationPolicy, fallback compiledRouteAuthorizationPolicy) compiledRouteAuthorizationPolicy {

--- a/internal/api/authz_policy_bundle_runtime_test.go
+++ b/internal/api/authz_policy_bundle_runtime_test.go
@@ -109,6 +109,25 @@ func TestDefaultRoutePolicyBundleUsesRepoScansReadForRepoFindingsTrends(t *testi
 	}
 }
 
+func TestDefaultRouteActionRoleGrantsAllowWorkspaceFindingsAccess(t *testing.T) {
+	grants := defaultRouteActionRoleGrants()
+
+	for _, test := range []struct {
+		action string
+		roles  []string
+	}{
+		{action: policyActionFindingsRead, roles: []string{"owner", "analyst", "viewer"}},
+		{action: policyActionFindingsTriage, roles: []string{"owner", "admin"}},
+		{action: policyActionGraphRead, roles: []string{"owner", "analyst", "viewer"}},
+	} {
+		for _, role := range test.roles {
+			if !containsString(grants[test.action], role) {
+				t.Fatalf("expected role %q to be granted %s, got %v", role, test.action, grants[test.action])
+			}
+		}
+	}
+}
+
 func TestDefaultRoutePolicyBundleUsesRepoScansRunForDeleteRepoFinding(t *testing.T) {
 	compiled, err := compileRouteAuthorizationPolicyBundle(defaultBuiltInRouteAuthorizationPolicyBundle())
 	if err != nil {
@@ -261,6 +280,28 @@ func TestCentralPolicyRuntimeResolverUsesPersistedActiveVersion(t *testing.T) {
 	}
 	if policy.Action != policyActionFindingsRead {
 		t.Fatalf("expected persisted action %q, got %q", policyActionFindingsRead, policy.Action)
+	}
+	for _, test := range []struct {
+		action string
+		role   string
+	}{
+		{action: policyActionFindingsRead, role: "owner"},
+		{action: policyActionFindingsRead, role: "viewer"},
+	} {
+		decision, err := runtimePolicy.Engine.Decide(ctx, PolicyInput{
+			Subject: PolicySubject{
+				TenantID:    "tenant-a",
+				WorkspaceID: "workspace-a",
+				Roles:       []string{test.role},
+			},
+			Action: test.action,
+		})
+		if err != nil {
+			t.Fatalf("decide persisted %s for role %s: %v", test.action, test.role, err)
+		}
+		if !decision.Allowed {
+			t.Fatalf("expected legacy persisted policy to allow %s for role %s, got %+v", test.action, test.role, decision)
+		}
 	}
 }
 

--- a/internal/api/authz_policy_bundle_runtime_test.go
+++ b/internal/api/authz_policy_bundle_runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -221,23 +222,7 @@ func TestCentralPolicyRuntimeResolverUsesPersistedActiveVersion(t *testing.T) {
 		t.Fatalf("upsert policy set: %v", err)
 	}
 
-	bundle := routeAuthorizationPolicyBundle{
-		SchemaVersion: routeAuthorizationPolicyBundleSchemaV1,
-		RoutePolicies: []routePolicyDefinition{{
-			Method:       "GET",
-			Path:         "/v1/findings",
-			Action:       policyActionFindingsRead,
-			ResourceType: "finding",
-		}},
-		RBACActionRole: map[string][]string{
-			policyActionFindingsRead: {scopeRead, scopeWrite, scopeAdmin},
-		},
-		ABACPolicies: map[string]abacActionPolicy{
-			policyActionFindingsRead: {
-				AnyOf: []abacClause{{}},
-			},
-		},
-	}
+	bundle := legacyDefaultRouteAuthorizationPolicyBundle()
 	bundleBytes, err := json.Marshal(bundle)
 	if err != nil {
 		t.Fatalf("marshal policy bundle: %v", err)
@@ -302,6 +287,78 @@ func TestCentralPolicyRuntimeResolverUsesPersistedActiveVersion(t *testing.T) {
 		if !decision.Allowed {
 			t.Fatalf("expected legacy persisted policy to allow %s for role %s, got %+v", test.action, test.role, decision)
 		}
+	}
+}
+
+func TestCentralPolicyRuntimeResolverDoesNotBroadenCustomLegacyRoleGrants(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := testAuthzPolicyScopeContext()
+	resolver := newCentralPolicyRuntimeResolverWithPolicySet(store, defaultCentralPolicySetID)
+
+	if err := store.UpsertAuthzPolicySet(ctx, db.AuthzPolicySet{
+		PolicySetID: defaultCentralPolicySetID,
+		DisplayName: "Central Authorization",
+		CreatedBy:   "test",
+	}); err != nil {
+		t.Fatalf("upsert policy set: %v", err)
+	}
+
+	customBundle := routeAuthorizationPolicyBundle{
+		SchemaVersion: routeAuthorizationPolicyBundleSchemaV1,
+		RoutePolicies: []routePolicyDefinition{{
+			Method:       http.MethodGet,
+			Path:         "/v1/findings",
+			Action:       policyActionFindingsRead,
+			ResourceType: "finding",
+		}},
+		RBACActionRole: map[string][]string{
+			policyActionFindingsRead: {scopeRead, scopeWrite, scopeAdmin},
+		},
+		ABACPolicies: map[string]abacActionPolicy{
+			policyActionFindingsRead: {AnyOf: []abacClause{{}}},
+		},
+	}
+	bundleBytes, err := json.Marshal(customBundle)
+	if err != nil {
+		t.Fatalf("marshal custom policy bundle: %v", err)
+	}
+	version, err := store.CreateAuthzPolicyVersion(ctx, db.AuthzPolicyVersion{
+		PolicySetID: defaultCentralPolicySetID,
+		Version:     1,
+		Bundle:      string(bundleBytes),
+		CreatedBy:   "test",
+	})
+	if err != nil {
+		t.Fatalf("create custom policy version: %v", err)
+	}
+	if err := store.UpsertAuthzPolicyRollout(ctx, db.AuthzPolicyRollout{
+		PolicySetID:       defaultCentralPolicySetID,
+		ActiveVersion:     &version.Version,
+		Mode:              db.AuthzPolicyRolloutModeEnforce,
+		ValidatedVersions: []int{version.Version},
+		CanaryPercentage:  100,
+		UpdatedBy:         "test",
+	}); err != nil {
+		t.Fatalf("upsert policy rollout: %v", err)
+	}
+
+	runtimePolicy, err := resolver.Resolve(ctx)
+	if err != nil {
+		t.Fatalf("resolve custom policy version: %v", err)
+	}
+	decision, err := runtimePolicy.Engine.Decide(ctx, PolicyInput{
+		Subject: PolicySubject{
+			TenantID:    "tenant-a",
+			WorkspaceID: "workspace-a",
+			Roles:       []string{"owner"},
+		},
+		Action: policyActionFindingsRead,
+	})
+	if err != nil {
+		t.Fatalf("decide custom policy for owner: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected custom legacy role grant to remain narrow, got %+v", decision)
 	}
 }
 

--- a/internal/api/authz_simulation.go
+++ b/internal/api/authz_simulation.go
@@ -220,7 +220,15 @@ func resolveSimulationRuntime(c *gin.Context, store db.Store, resolver centralPo
 	if err != nil {
 		return resolvedCentralPolicyRuntime{}, err
 	}
-	compiled, err := compileRouteAuthorizationPolicyBundleJSON(version.Bundle)
+	if resolver == nil {
+		resolver = newCentralPolicyRuntimeResolverWithPolicySet(store, policySetID)
+	}
+	var compiled compiledRouteAuthorizationPolicy
+	if versionCompiler, ok := resolver.(centralPolicyVersionCompiler); ok {
+		compiled, err = versionCompiler.compiledVersion(version)
+	} else {
+		compiled, err = compileRouteAuthorizationPolicyBundleJSON(version.Bundle)
+	}
 	if err != nil {
 		return resolvedCentralPolicyRuntime{}, fmt.Errorf("compile target policy version: %w", err)
 	}

--- a/internal/api/authz_simulation_test.go
+++ b/internal/api/authz_simulation_test.go
@@ -31,18 +31,7 @@ func TestRouterAuthzPolicySimulationTargetVersionReturnsDecisionAndTrace(t *test
 		t.Fatalf("upsert policy set: %v", err)
 	}
 
-	bundle := routeAuthorizationPolicyBundle{
-		SchemaVersion: routeAuthorizationPolicyBundleSchemaV1,
-		RoutePolicies: []routePolicyDefinition{
-			{Method: "GET", Path: "/v1/findings", Action: policyActionFindingsRead, ResourceType: "finding"},
-		},
-		RBACActionRole: map[string][]string{
-			policyActionFindingsRead: {scopeRead, scopeAdmin},
-		},
-		ABACPolicies: map[string]abacActionPolicy{
-			policyActionFindingsRead: {AnyOf: []abacClause{{}}},
-		},
-	}
+	bundle := legacyDefaultRouteAuthorizationPolicyBundle()
 	bundleBytes, err := json.Marshal(bundle)
 	if err != nil {
 		t.Fatalf("marshal policy bundle: %v", err)
@@ -65,7 +54,7 @@ func TestRouterAuthzPolicySimulationTargetVersionReturnsDecisionAndTrace(t *test
 	})
 
 	requestBody := `{
-		"subject":{"type":"subject","id":"user-1","tenant_id":"default","workspace_id":"default","roles":["admin"]},
+		"subject":{"type":"subject","id":"user-1","tenant_id":"default","workspace_id":"default","roles":["owner"]},
 		"action":"findings.read",
 		"resource":{"type":"finding","id":"finding-1","tenant_id":"default","workspace_id":"default"},
 		"context":{"request_path":"/v1/findings","request_method":"GET"},

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8741,7 +8741,9 @@ describe('Domain-first app routes', () => {
       ]
     });
     vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
-    vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockRejectedValue(new Error('AWS inventory request failed'));
+    vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockRejectedValue(
+      new api.ApiError('forbidden', 403, { detail: 'forbidden' })
+    );
 
     const { ProductAWSFindingsPage } = await import('./productShell');
 
@@ -8754,7 +8756,8 @@ describe('Domain-first app routes', () => {
     );
 
     expect(await screen.findByRole('alert')).toHaveTextContent("Couldn't load AWS findings");
-    expect(screen.getByText('AWS inventory request failed')).toBeInTheDocument();
+    expect(screen.getByText(/Identrail denied the findings request for this workspace/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^forbidden$/i)).not.toBeInTheDocument();
     expect(screen.queryByText('No AWS findings')).not.toBeInTheDocument();
   });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8761,6 +8761,40 @@ describe('Domain-first app routes', () => {
     expect(screen.queryByText('No AWS findings')).not.toBeInTheDocument();
   });
 
+  it('uses a live-evidence message for a 404 from the current AWS findings endpoint', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [{
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: 'production',
+        name: 'Production',
+        slug: 'production',
+        description: 'Production AWS boundary.',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z'
+      }]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockRejectedValue(
+      new api.ApiError('Request failed (404)', 404)
+    );
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Couldn't load AWS findings");
+    expect(screen.getByText(/could not load live AWS secret-to-permission evidence/i)).toBeInTheDocument();
+    expect(screen.queryByText(/This AWS scan is no longer available/i)).not.toBeInTheDocument();
+  });
+
   it('does not show findings as loading when the AWS connector is not ready', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2380,10 +2380,18 @@ function formatAPIError(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
-function formatAWSFindingsError(error: unknown, fallback: string): string {
+function formatAWSFindingsError(
+  error: unknown,
+  fallback: string,
+  source: 'live' | 'scan' = 'scan'
+): string {
   const apiLike = error instanceof Error || (typeof error === 'object' && error !== null)
     ? (error as { status?: number; detail?: string; message?: string })
     : null;
+  const detail = normalizeValue(apiLike?.detail);
+  if (detail && !['forbidden', 'unauthorized'].includes(detail.toLowerCase())) {
+    return detail;
+  }
   if (apiLike?.status === 401) {
     return 'Your Identrail session has expired. Sign in again, then retry loading AWS findings.';
   }
@@ -2391,11 +2399,13 @@ function formatAWSFindingsError(error: unknown, fallback: string): string {
     return 'Identrail denied the findings request for this workspace. Your AWS connection is separate from this access check. Refresh and retry; if it continues, verify the selected workspace or contact your Identrail administrator.';
   }
   if (apiLike?.status === 404) {
-    return 'This AWS scan is no longer available. Run AWS discovery again to create a fresh findings result.';
+    return source === 'live'
+      ? 'Identrail could not load live AWS secret-to-permission evidence. Verify the AWS connection and retry.'
+      : 'This AWS scan is no longer available. Run AWS discovery again to create a fresh findings result.';
   }
-  const detail = normalizeValue(formatAPIError(error, ''));
-  if (detail && !['forbidden', 'unauthorized'].includes(detail.toLowerCase())) {
-    return detail;
+  const message = normalizeValue(formatAPIError(error, ''));
+  if (message) {
+    return message;
   }
   return fallback;
 }
@@ -20613,7 +20623,11 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       if (requestID !== secretPermissionEquivalenceRequestRef.current) {
         return;
       }
-      setSecretPermissionEquivalenceError(formatAWSFindingsError(error, 'Unable to load AWS secret-to-permission equivalence.'));
+      setSecretPermissionEquivalenceError(formatAWSFindingsError(
+        error,
+        'Unable to load AWS secret-to-permission equivalence.',
+        'live'
+      ));
     } finally {
       if (requestID === secretPermissionEquivalenceRequestRef.current) {
         setSecretPermissionEquivalenceLoading(false);

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2380,6 +2380,26 @@ function formatAPIError(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
+function formatAWSFindingsError(error: unknown, fallback: string): string {
+  const apiLike = error instanceof Error || (typeof error === 'object' && error !== null)
+    ? (error as { status?: number; detail?: string; message?: string })
+    : null;
+  if (apiLike?.status === 401) {
+    return 'Your Identrail session has expired. Sign in again, then retry loading AWS findings.';
+  }
+  if (apiLike?.status === 403) {
+    return 'Identrail denied the findings request for this workspace. Your AWS connection is separate from this access check. Refresh and retry; if it continues, verify the selected workspace or contact your Identrail administrator.';
+  }
+  if (apiLike?.status === 404) {
+    return 'This AWS scan is no longer available. Run AWS discovery again to create a fresh findings result.';
+  }
+  const detail = normalizeValue(formatAPIError(error, ''));
+  if (detail && !['forbidden', 'unauthorized'].includes(detail.toLowerCase())) {
+    return detail;
+  }
+  return fallback;
+}
+
 function formatAWSConnectorSetupError(error: unknown): string {
   const apiLike = error instanceof Error || (typeof error === 'object' && error !== null)
     ? (error as { status?: number; detail?: string; message?: string })
@@ -20593,7 +20613,7 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       if (requestID !== secretPermissionEquivalenceRequestRef.current) {
         return;
       }
-      setSecretPermissionEquivalenceError(formatAPIError(error, 'Unable to load AWS secret-to-permission equivalence.'));
+      setSecretPermissionEquivalenceError(formatAWSFindingsError(error, 'Unable to load AWS secret-to-permission equivalence.'));
     } finally {
       if (requestID === secretPermissionEquivalenceRequestRef.current) {
         setSecretPermissionEquivalenceLoading(false);
@@ -20674,7 +20694,7 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       if (requestID !== persistedFindingsRequestRef.current) {
         return;
       }
-      setPersistedFindingsError(formatAPIError(requestError, 'Unable to load findings from this AWS scan.'));
+      setPersistedFindingsError(formatAWSFindingsError(requestError, 'Unable to load findings from this AWS scan.'));
     } finally {
       if (requestID === persistedFindingsRequestRef.current) {
         setPersistedFindingsLoading(false);


### PR DESCRIPTION
## Summary

- Allow workspace membership roles to use the workspace-scoped AWS findings and graph read surfaces.
- Allow workspace owners and admins to triage findings while keeping the connector read-only.
- Upgrade only exact legacy built-in policy grants so existing default policy versions do not keep rejecting the primary workspace user; custom policy grants remain unchanged.
- Replace bare `forbidden` findings errors with actionable session, workspace-access, stale-scan, and retry guidance.

## Root cause

The AWS connector and `IdentrailReadOnly` role can be healthy while the findings request is rejected by Identrail authorization. Browser sessions carry workspace membership roles such as `owner`, but the former findings and graph grants accepted only API scope roles (`read`, `write`, and `admin`). The main workspace user therefore received a 403 before AWS findings were loaded.

## Validation

- `go test ./internal/api`
- `npm test -- --run src/productShell.test.tsx` (317 tests)
- `npm run build` (40 routes prerendered)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow workspace members to read AWS findings and graph data, and allow owners/admins to triage, removing 403s for primary browser users. Previously only API scopes (`read`, `write`, `admin`) could access; now `owner`, `analyst`, and `viewer` can read and `owner`/`admin` can triage, with legacy default policies auto-upgraded at runtime and custom policies preserved.

- Backend authorization: expand default role grants for `findings.read`, `findings.triage`, and `graph.read` to include workspace roles; update OpenAPI `x-identrail-action-role-grants`. Upgrade only exact legacy default policy bundles at runtime to the new grants; never broaden custom bundles.
- Authorization simulation: compile target versions through the central resolver so simulation decisions and traces reflect the upgraded grants.
- Web UX: add an AWS findings error formatter that hides bare “forbidden” and provides guidance for 401 (session expired), 403 (workspace access denied, separate from AWS connector), and 404, which now differentiates live evidence errors from stale scan results.

<sup>Written for commit c2fbbcebd60807118a10a8a6b2904bae6d295774. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

