### PR TITLE
[AWS Findings] Normalize evidence, provenance, and finding scope

### DIFF
--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8393,9 +8393,12 @@ describe('Domain-first app routes', () => {
                 severity: 'high',
                 title: 'Overprivileged IAM role',
                 human_summary: 'The role grants more permissions than this workload requires.',
-                path: ['production-role', 'AdministratorAccess'],
+                path: ['production-role', 'aws%3Aaccess%3Aiam%3AGetRole%20-%3E%20aws%3Aaccess%3Aiam%3AListRoles'],
                 owner: 'AWS scanner',
-                evidence: { source: 'iam-policy' },
+                adapter_source: 'iam-policy collector',
+                confidence_score: 0.88,
+                first_seen_at: '2026-08-20T20:01:00Z',
+                evidence: { source: 'iam-policy', account_id: '123456789012', region: 'us-east-1' },
                 remediation: 'Reduce the role policy to the required actions.',
                 created_at: '2026-08-20T20:03:00Z',
                 lifecycle_status: 'open',
@@ -8422,6 +8425,12 @@ describe('Domain-first app routes', () => {
     expect(screen.getByText(/could not verify source completeness/i)).toBeInTheDocument();
     const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
     expect(within(findingsTable).getByText('Overprivileged IAM role')).toBeInTheDocument();
+    const overprivilegedRow = within(findingsTable).getByText('Overprivileged IAM role').closest('tr');
+    expect(overprivilegedRow).not.toBeNull();
+    expect(within(overprivilegedRow as HTMLElement).getByText('Account 123456789012 · Region us-east-1 · IAM permission path · 2 evidence nodes')).toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).getByText('Source: iam-policy collector · Confidence: 88% · Completeness: Unknown')).toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).getByText('Technical evidence (2 refs)')).toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).getByText('scan-aws-complete')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Public S3 bucket')).toBeInTheDocument();
     expect(within(findingsTable).getByText('High')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Suppressed')).toBeInTheDocument();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8107,6 +8107,59 @@ describe('Domain-first app routes', () => {
     } as any;
     const getSecretPermissionEquivalence = vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockResolvedValue({
       findings: {
+        status: 'ready',
+        findings: [equivalenceFinding],
+        summary: {
+          external_provider_key_count: 0,
+          aws_managed_secret_count: 0,
+          runtime_observed_count: 0,
+          kms_backed_count: 0
+        },
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        coverage_gaps: [
+          {
+            capability: 'secret_value_collection',
+            status: 'unsupported',
+            reason: 'Secret values are intentionally excluded.'
+          }
+        ],
+        diagnostics: []
+      } as any
+    });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Findings' })).toBeInTheDocument();
+    const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
+    expect(within(findingsTable).getByText(/Completeness: Complete/i)).toBeInTheDocument();
+    expect(within(findingsTable).getByRole('link', { name: /Agent provider key equivalence/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=case-triage-id&tab=secrets'
+    );
+    expect(within(findingsTable).getByText('High')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Review')).toBeInTheDocument();
+    expect(screen.queryByRole('table', { name: 'AWS secret-to-permission equivalence findings' })).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+
+    getSecretPermissionEquivalence.mockResolvedValue({
+      findings: {
         status: 'degraded',
         findings: [equivalenceFinding],
         summary: {
@@ -8129,31 +8182,25 @@ describe('Domain-first app routes', () => {
       } as any
     });
 
-    const { ProductAWSFindingsPage } = await import('./productShell');
-
-    render(
-      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production']}>
-        <Routes>
-          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
-        </Routes>
-      </MemoryRouter>
-    );
-
-    expect(await screen.findByRole('heading', { level: 2, name: 'Findings' })).toBeInTheDocument();
-    const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
-    expect(within(findingsTable).getByText(/Completeness: Partial/i)).toBeInTheDocument();
-    expect(within(findingsTable).getByRole('link', { name: /Agent provider key equivalence/i })).toHaveAttribute(
-      'href',
-      '/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=case-triage-id&tab=secrets'
-    );
-    expect(within(findingsTable).getByText('High')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('Review')).toBeInTheDocument();
-    expect(screen.queryByRole('table', { name: 'AWS secret-to-permission equivalence findings' })).not.toBeInTheDocument();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Findings search' }), { target: { value: 'openai' } });
     await waitFor(() =>
       expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
         'workspace-a',
         'production',
-        expect.objectContaining({ connectorID: 'aws-connector-1' }),
+        expect.objectContaining({ connectorID: 'aws-connector-1', search: 'openai' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    await waitFor(() =>
+      expect(within(screen.getByRole('table', { name: 'AWS findings' })).getByText(/Completeness: Partial/i)).toBeInTheDocument()
+    );
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Findings search' }), { target: { value: '' } });
+    await waitFor(() =>
+      expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1', search: undefined }),
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8107,7 +8107,7 @@ describe('Domain-first app routes', () => {
     } as any;
     const getSecretPermissionEquivalence = vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockResolvedValue({
       findings: {
-        status: 'ready',
+        status: 'degraded',
         findings: [equivalenceFinding],
         summary: {
           external_provider_key_count: 0,
@@ -8118,7 +8118,13 @@ describe('Domain-first app routes', () => {
         caveats: [],
         failure_reasons: [],
         remediation_hints: [],
-        coverage_gaps: [],
+        coverage_gaps: [
+          {
+            capability: 'secrets_manager_runtime',
+            status: 'partial',
+            reason: 'Runtime delivery evidence is unavailable.'
+          }
+        ],
         diagnostics: []
       } as any
     });
@@ -8135,6 +8141,7 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByRole('heading', { level: 2, name: 'Findings' })).toBeInTheDocument();
     const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
+    expect(within(findingsTable).getByText(/Completeness: Partial/i)).toBeInTheDocument();
     expect(within(findingsTable).getByRole('link', { name: /Agent provider key equivalence/i })).toHaveAttribute(
       'href',
       '/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=case-triage-id&tab=secrets'

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -13124,6 +13124,17 @@ type AWSRiskOperationTableRow = AWSInventoryFilterable & {
   status: string;
   stage: AWSCapabilityStage;
   detailLink?: string;
+  findingID?: string;
+  scanID?: string;
+  accountID?: string;
+  region?: string;
+  source?: string;
+  observedAt?: string;
+  confidence?: number;
+  provenance?: string;
+  completeness?: string;
+  evidenceBoundary?: string;
+  technicalEvidence?: string[];
 };
 
 function AWSRiskOperationFilterSet({
@@ -18092,6 +18103,81 @@ function AWSGraphEvidenceDrawer({ refs }: { refs: string[] }) {
   );
 }
 
+function AWSFindingTechnicalEvidenceDrawer({ row }: { row: AWSRiskOperationTableRow }) {
+  const refs = row.technicalEvidence?.filter(Boolean) ?? [];
+  return (
+    <details className="idt-aws-finding-technical-evidence">
+      <summary>Technical evidence{refs.length > 0 ? ` (${refs.length} refs)` : ''}</summary>
+      <dl>
+        <div>
+          <dt>Finding ID</dt>
+          <dd><code>{row.findingID || row.id}</code></dd>
+        </div>
+        <div>
+          <dt>Scan ID</dt>
+          <dd><code>{row.scanID || 'Unavailable'}</code></dd>
+        </div>
+        <div>
+          <dt>Scope</dt>
+          <dd>{row.accountID || 'Account unknown'} · {row.region || 'Region unknown'}</dd>
+        </div>
+        <div>
+          <dt>Observed</dt>
+          <dd>{row.observedAt || 'Unavailable'}</dd>
+        </div>
+        <div>
+          <dt>Provenance</dt>
+          <dd>{row.provenance || 'Unknown'}</dd>
+        </div>
+        <div>
+          <dt>Completeness</dt>
+          <dd>{awsPersistedFindingCompletenessLabel(row.completeness || 'unknown')}</dd>
+        </div>
+        {row.source ? (
+          <div>
+            <dt>Source</dt>
+            <dd>{row.source}</dd>
+          </div>
+        ) : null}
+        {row.evidenceBoundary ? (
+          <div>
+            <dt>Evidence boundary</dt>
+            <dd>{row.evidenceBoundary}</dd>
+          </div>
+        ) : null}
+        {row.confidence !== undefined ? (
+          <div>
+            <dt>Confidence</dt>
+            <dd>{formatConfidenceScore(row.confidence)}</dd>
+          </div>
+        ) : null}
+      </dl>
+      {refs.length > 0 ? (
+        <ul>
+          {refs.map((ref, index) => (
+            <li key={`${ref}-${index}`}><code>{ref}</code></li>
+          ))}
+        </ul>
+      ) : <p>No raw path or evidence references were returned.</p>}
+    </details>
+  );
+}
+
+function AWSFindingEvidenceCell({ row }: { row: AWSRiskOperationTableRow }) {
+  const metadata = [
+    row.source ? `Source: ${row.source}` : undefined,
+    row.confidence !== undefined ? `Confidence: ${formatConfidenceScore(row.confidence)}` : undefined,
+    row.completeness ? `Completeness: ${awsPersistedFindingCompletenessLabel(row.completeness)}` : undefined
+  ].filter(Boolean);
+  return (
+    <div className="idt-aws-finding-evidence-cell">
+      <span>{row.evidence}</span>
+      {metadata.length > 0 ? <small>{metadata.join(' · ')}</small> : null}
+      <AWSFindingTechnicalEvidenceDrawer row={row} />
+    </div>
+  );
+}
+
 function awsSecretPermissionEquivalenceRiskOperationRow(
   finding: AWSSecretPermissionEquivalenceFinding,
   scope: ProductSession | null | undefined,
@@ -18113,6 +18199,19 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
     status: finding.status,
     stage: awsSecretPermissionEquivalenceStage(finding),
     detailLink,
+    findingID: finding.finding_id,
+    accountID: finding.account_id,
+    region: finding.region,
+    source: finding.source_signals.join(', ') || 'AWS live analysis',
+    observedAt: finding.updated_at || finding.created_at,
+    confidence: finding.confidence,
+    provenance: 'Live AWS analysis',
+    completeness: finding.evidence.length > 0 ? 'complete' : 'unknown',
+    evidenceBoundary: finding.evidence_boundary,
+    technicalEvidence: [
+      ...finding.evidence.map((evidence) => evidence.evidence_ref),
+      ...finding.impacted_path.map((step) => step.node_id)
+    ].filter(Boolean),
     filters: {
       severity: finding.severity || 'unknown',
       account: connection?.account_id && connection.account_id === finding.account_id ? 'connected' : 'unknown',
@@ -18199,9 +18298,78 @@ async function listAllAWSScanFindings(scanID: string, auth: RequestAuthContext):
 function awsPersistedFindingEvidence(finding: ApiFinding): string {
   const summary = normalizeValue(finding.human_summary);
   if (summary) {
-    return summary;
+    return summary.length > 220 ? `${summary.slice(0, 217)}...` : summary;
   }
   return Object.keys(finding.evidence ?? {}).length > 0 ? 'Inventory-backed AWS evidence' : 'Evidence unavailable';
+}
+
+function awsPersistedFindingMetadataValue(finding: ApiFinding, keys: string[]): string | undefined {
+  const wantedKeys = new Set(keys.map((key) => key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()));
+  const visited = new Set<object>();
+  let result: string | undefined;
+
+  const inspect = (value: unknown, key?: string): void => {
+    if (result) {
+      return;
+    }
+    const normalizedKey = key?.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+    const normalizedValue = normalizeValue(value);
+    if (normalizedKey && wantedKeys.has(normalizedKey) && normalizedValue) {
+      result = normalizedValue;
+      return;
+    }
+    if (!value || typeof value !== 'object' || visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+    for (const [childKey, childValue] of Object.entries(value)) {
+      inspect(childValue, childKey);
+    }
+  };
+
+  inspect(finding.evidence);
+  return result;
+}
+
+function awsPersistedFindingSource(finding: ApiFinding): string {
+  return (
+    normalizeValue(finding.adapter_source) ||
+    awsPersistedFindingMetadataValue(finding, ['source', 'collector', 'source_type', 'collector_type']) ||
+    'AWS scanner'
+  );
+}
+
+function awsPersistedFindingPathIsSerialized(value: string): boolean {
+  let decoded = value;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    // Keep the original value hidden if it is malformed encoded data.
+  }
+  return decoded.length > 120 || decoded.includes('aws:access:') || decoded.includes(' -> ') || value.includes('%');
+}
+
+function awsPersistedFindingAffectedResource(finding: ApiFinding): string {
+  const path = finding.path?.map((value) => normalizeValue(value)).filter(Boolean) ?? [];
+  if (path.length === 0) {
+    return 'Resource unavailable';
+  }
+  if (path.some(awsPersistedFindingPathIsSerialized)) {
+    return 'IAM permission path';
+  }
+  const firstPathNode = path[0];
+  return firstPathNode.length > 96 ? `${firstPathNode.slice(0, 93)}...` : firstPathNode;
+}
+
+function awsPersistedFindingCompletenessLabel(value: string): string {
+  switch (value) {
+    case 'partial':
+      return 'Partial';
+    case 'unknown':
+      return 'Unknown';
+    default:
+      return 'Complete';
+  }
 }
 
 type AWSPersistedFindingScope = {
@@ -18272,24 +18440,46 @@ function awsPersistedFindingScope(finding: ApiFinding): AWSPersistedFindingScope
 
 function awsPersistedFindingRiskOperationRow(
   finding: ApiFinding,
-  connection: AWSConnectionStatus | null
+  connection: AWSConnectionStatus | null,
+  persistedScan: ScanRecord | null,
+  completeness: string
 ): AWSRiskOperationTableRow {
   const status = awsPersistedFindingStatus(finding);
-  const path = finding.path?.filter(Boolean).join(' → ');
   const findingScope = awsPersistedFindingScope(finding);
   const account = findingScope.accountID ? `Account ${findingScope.accountID}` : 'Account unknown';
   const region = findingScope.region ? `Region ${findingScope.region}` : 'Region unknown';
   const evidence = awsPersistedFindingEvidence(finding);
+  const source = awsPersistedFindingSource(finding);
+  const scanID = normalizeValue(finding.scan_id) || normalizeValue(persistedScan?.id);
+  const observedAt =
+    normalizeValue(finding.last_seen_at) ||
+    normalizeValue(finding.first_seen_at) ||
+    normalizeValue(finding.created_at) ||
+    normalizeValue(persistedScan?.finished_at) ||
+    normalizeValue(persistedScan?.started_at);
+  const evidenceBoundary = awsPersistedFindingMetadataValue(finding, ['evidence_boundary', 'coverage', 'coverage_state']);
+  const technicalEvidence = finding.path?.map((value) => normalizeValue(value)).filter(Boolean) ?? [];
   return {
     id: finding.id,
     title: finding.title || formatTokenLabel(finding.type),
     category: formatTokenLabel(finding.severity),
     evidence,
-    owner: finding.owner || finding.adapter_source || 'AWS scanner',
-    blastRadius: path || `${account} · ${region}`,
+    owner: finding.owner || source,
+    blastRadius: `${account} · ${region} · ${awsPersistedFindingAffectedResource(finding)}${technicalEvidence.length > 0 ? ` · ${technicalEvidence.length} evidence node${technicalEvidence.length === 1 ? '' : 's'}` : ''}`,
     nextAction: finding.remediation || 'Review the finding evidence and remediate the affected AWS resource.',
     status,
     stage: awsPersistedFindingStage(finding),
+    findingID: finding.id,
+    scanID,
+    accountID: findingScope.accountID,
+    region: findingScope.region,
+    source,
+    observedAt,
+    confidence: finding.confidence_score,
+    provenance: 'AWS discovery scan',
+    completeness,
+    evidenceBoundary,
+    technicalEvidence,
     filters: {
       severity: normalizeValue(finding.severity).toLowerCase() || 'unknown',
       account: findingScope.accountID && findingScope.accountID === connection?.account_id ? 'connected' : 'unknown',
@@ -18354,8 +18544,9 @@ function AWSFindingsContent({
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
   const showingPersistedScan = Boolean(persistedScanID);
+  const persistedCompleteness = persistedScanPartial ? 'partial' : persistedScanCoverageUnknown ? 'unknown' : 'complete';
   const rows = showingPersistedScan
-    ? persistedFindings?.map((finding) => awsPersistedFindingRiskOperationRow(finding, connection)) ?? []
+    ? persistedFindings?.map((finding) => awsPersistedFindingRiskOperationRow(finding, connection, persistedScan, persistedCompleteness)) ?? []
     : findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, scope, environmentID, connection)) ?? [];
   const displayedRows = filterAWSInventoryRows(rows, filters);
   const persistedScanReadyToLoad = Boolean(scope && environmentID);
@@ -18428,7 +18619,7 @@ function AWSFindingsContent({
           columns={[
             { key: 'title', header: 'Finding', render: (row) => row.detailLink ? <Link to={row.detailLink}>{row.title}</Link> : <strong>{row.title}</strong> },
             { key: 'category', header: 'Severity', render: (row) => row.category },
-            { key: 'evidence', header: 'Evidence', render: (row) => row.evidence },
+            { key: 'evidence', header: 'Evidence', render: (row) => <AWSFindingEvidenceCell row={row} /> },
             { key: 'blast', header: 'Blast radius', render: (row) => row.blastRadius },
             { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={showingPersistedScan ? awsPersistedFindingStatusLabel(row.status) : formatTokenLabel(row.status)} /> }
           ]}

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18180,6 +18180,7 @@ function AWSFindingEvidenceCell({ row }: { row: AWSRiskOperationTableRow }) {
 
 function awsSecretPermissionEquivalenceRiskOperationRow(
   finding: AWSSecretPermissionEquivalenceFinding,
+  result: AWSSecretPermissionEquivalenceResult,
   scope: ProductSession | null | undefined,
   environmentID: string | undefined,
   connection: AWSConnectionStatus | null
@@ -18206,7 +18207,7 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
     observedAt: finding.updated_at || finding.created_at,
     confidence: finding.confidence,
     provenance: 'Live AWS analysis',
-    completeness: finding.evidence.length > 0 ? 'complete' : 'unknown',
+    completeness: awsSecretPermissionEquivalenceCompleteness(result),
     evidenceBoundary: finding.evidence_boundary,
     technicalEvidence: [
       ...finding.evidence.map((evidence) => evidence.evidence_ref),
@@ -18221,6 +18222,16 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
     },
     searchText: awsSecretPermissionEquivalenceSearchText(finding)
   };
+}
+
+function awsSecretPermissionEquivalenceCompleteness(result: AWSSecretPermissionEquivalenceResult): string {
+  if (result.status === 'blocked') {
+    return 'unknown';
+  }
+  if (result.status === 'degraded' || result.coverage_gaps.length > 0) {
+    return 'partial';
+  }
+  return 'complete';
 }
 
 function awsPersistedFindingStage(finding: ApiFinding): AWSCapabilityStage {
@@ -18547,7 +18558,7 @@ function AWSFindingsContent({
   const persistedCompleteness = persistedScanPartial ? 'partial' : persistedScanCoverageUnknown ? 'unknown' : 'complete';
   const rows = showingPersistedScan
     ? persistedFindings?.map((finding) => awsPersistedFindingRiskOperationRow(finding, connection, persistedScan, persistedCompleteness)) ?? []
-    : findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, scope, environmentID, connection)) ?? [];
+    : findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, findings, scope, environmentID, connection)) ?? [];
   const displayedRows = filterAWSInventoryRows(rows, filters);
   const persistedScanReadyToLoad = Boolean(scope && environmentID);
   const liveFindingsReadyToLoad = Boolean(scope && environmentID && connection?.connected);

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18228,7 +18228,7 @@ function awsSecretPermissionEquivalenceCompleteness(result: AWSSecretPermissionE
   if (result.status === 'blocked') {
     return 'unknown';
   }
-  if (result.status === 'degraded' || result.coverage_gaps.length > 0) {
+  if (result.status === 'degraded') {
     return 'partial';
   }
   return 'complete';

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -33347,3 +33347,68 @@ html[data-theme='light'] .idt-danger-modal-typed input {
   background: #030304;
   color: #ffffff;
 }
+
+.idt-aws-finding-evidence-cell {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 15rem;
+}
+
+.idt-aws-finding-evidence-cell > small {
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.idt-aws-finding-technical-evidence {
+  border: 1px solid rgba(154, 164, 190, 0.28);
+  border-radius: 0.35rem;
+  padding: 0.35rem 0.5rem;
+  background: rgba(4, 8, 18, 0.28);
+  font-size: 0.72rem;
+}
+
+.idt-aws-finding-technical-evidence summary {
+  cursor: pointer;
+  color: var(--idt-text-muted, #aeb8c9);
+  font-weight: 600;
+}
+
+.idt-aws-finding-technical-evidence dl {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0.55rem 0 0;
+}
+
+.idt-aws-finding-technical-evidence dl div {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.idt-aws-finding-technical-evidence dt {
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.idt-aws-finding-technical-evidence dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-finding-technical-evidence ul {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0.55rem 0 0;
+  padding-left: 1rem;
+}
+
+.idt-aws-finding-technical-evidence code {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+html[data-theme='light'] .idt-aws-finding-technical-evidence {
+  background: rgba(242, 244, 249, 0.86);
+}


### PR DESCRIPTION
Closes #1824

## Summary

- normalize AWS finding and scan metadata through the findings adapter
- preserve account, region, source, observation time, confidence, provenance, completeness, and evidence boundaries
- replace URL-encoded IAM permission chains in the primary table with concise evidence summaries
- keep raw IAM paths and evidence references available under expandable technical evidence
- add regression coverage for historical-scan scope and the normalized display contract

## Validation

- `npm test -- --run src/productShell.test.tsx` — 318 tests passed
- `npm run build` — passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes AWS finding evidence, provenance, and scope so live analysis and persisted scans render consistently. Previously the table showed URL-encoded IAM permission chains; now it shows a concise resource summary with technical evidence behind a toggle, and completeness and status reflect AWS result status and scan coverage.

- Evidence column: shows the human summary plus “Source · Confidence · Completeness,” and an expandable “Technical evidence (N refs)” with Finding ID, Scan ID, Scope, Observed, Provenance, Completeness, Source, Evidence boundary, Confidence, and raw refs.
- Completeness and status: live findings use AWS result.status (degraded → Partial, blocked → Unknown), and the status pill reflects the AWS result; persisted scans label Complete/Partial/Unknown from scan coverage.
- Blast radius: shows “Account · Region · affected resource summary · N evidence nodes”; long or URL-encoded paths are labeled “IAM permission path.” Persisted and live rows derive Source, Scan ID, Observed time, Confidence, Provenance, Evidence boundary, and normalize scope; long summaries are truncated; styles and tests updated.

<sup>Written for commit 0d9aad9e8cbceecb6c433c87018353cf99d5ca0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

