### PR TITLE
Improve AWS findings triage experience

### DIFF
--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8151,6 +8151,14 @@ describe('Domain-first app routes', () => {
       'href',
       '/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=case-triage-id&tab=secrets'
     );
+    const liveFindingRow = within(findingsTable).getByRole('link', { name: /openai\/api-key/i }).closest('tr');
+    expect(liveFindingRow).not.toBeNull();
+    expect(within(liveFindingRow as HTMLElement).getByText(/Case Triage · openai\/api-key · Secret · Account 123456789012 · Region us-east-1/)).toBeInTheDocument();
+    fireEvent.click(within(liveFindingRow as HTMLElement).getByRole('button', { name: 'View details' }));
+    const liveFindingDrawer = await screen.findByRole('dialog', { name: 'Finding details' });
+    expect(within(liveFindingDrawer).getByText('Case Triage', { exact: true })).toBeInTheDocument();
+    fireEvent.click(within(liveFindingDrawer).getByRole('button', { name: 'Close detail drawer' }));
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Finding details' })).not.toBeInTheDocument());
     expect(within(findingsTable).getByText('High')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Open')).toBeInTheDocument();
     expect(screen.queryByRole('table', { name: 'AWS secret-to-permission equivalence findings' })).not.toBeInTheDocument();
@@ -8656,13 +8664,13 @@ describe('Domain-first app routes', () => {
     expect(overprivilegedRow).not.toBeNull();
     expect(within(overprivilegedRow as HTMLElement).getByText('production-role · IAM role · Account 123456789012 · Global')).toBeInTheDocument();
     expect(within(overprivilegedRow as HTMLElement).getByText('2 related risks detected for this identity.')).toBeInTheDocument();
-    expect(within(overprivilegedRow as HTMLElement).getByText('Source: iam-policy collector · Confidence: 88% · Completeness: Unknown')).toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).getByText('Source: iam-policy collector · Confidence: 82% · Completeness: Unknown')).toBeInTheDocument();
     expect(within(overprivilegedRow as HTMLElement).queryByText('Technical evidence (2 refs)')).not.toBeInTheDocument();
     expect(within(overprivilegedRow as HTMLElement).queryByText('scan-aws-complete')).not.toBeInTheDocument();
     fireEvent.click(within(overprivilegedRow as HTMLElement).getByRole('button', { name: 'View details' }));
     const findingDrawer = await screen.findByRole('dialog', { name: 'Finding details' });
     expect(within(findingDrawer).getByText('Related risks (2)')).toBeInTheDocument();
-    expect(within(findingDrawer).getByText('Technical evidence (2 refs)')).toBeInTheDocument();
+    expect(within(findingDrawer).getByText('Technical evidence (1 refs)')).toBeInTheDocument();
     expect(within(findingDrawer).getByText('scan-aws-complete')).toBeInTheDocument();
     expect(within(findingDrawer).getByRole('link', { name: 'Open in AWS Console' })).toHaveAttribute(
       'href',
@@ -8675,11 +8683,14 @@ describe('Domain-first app routes', () => {
       expect(within(findingDrawer).getByText('Technical evidence (1 refs)')).toBeInTheDocument();
     });
     fireEvent.click(within(findingDrawer).getByRole('button', { name: 'View details for Overprivileged IAM role' }));
-    await waitFor(() => expect(within(findingDrawer).getByText('Reduce the role policy to the required actions.')).toBeInTheDocument());
+    await waitFor(() => {
+      expect(within(findingDrawer).getByText('Reduce the role policy to the required actions.')).toBeInTheDocument();
+      expect(within(findingDrawer).getByText('Technical evidence (2 refs)')).toBeInTheDocument();
+    });
     fireEvent.click(within(findingDrawer).getByRole('button', { name: 'Close detail drawer' }));
     await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Finding details' })).not.toBeInTheDocument());
     expect(within(findingsTable).getByText('Public S3 bucket')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('High')).toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).getByText('Medium')).toBeInTheDocument();
     expect(within(overprivilegedRow as HTMLElement).getByText('Open')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Acknowledged')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Resolved')).toBeInTheDocument();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8425,6 +8425,34 @@ describe('Domain-first app routes', () => {
                 lifecycle_status: 'fixed'
               },
               {
+                id: 'finding-aws-lambda-colon-resource',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_lambda_function',
+                severity: 'low',
+                title: 'Lambda resource label',
+                human_summary: 'A Lambda finding with a colon-form ARN resource.',
+                path: ['arn:aws:lambda:us-east-1:123456789012:function:shared-function-colon'],
+                owner: 'AWS scanner',
+                evidence: { source: 'lambda-policy' },
+                remediation: 'Review the function policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
+                id: 'finding-aws-secret-colon-resource',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_secretsmanager_secret',
+                severity: 'low',
+                title: 'Secret resource label',
+                human_summary: 'A Secrets Manager finding with a colon-form ARN resource.',
+                path: ['arn:aws:secretsmanager:us-east-1:123456789012:secret:database-password-abc123'],
+                owner: 'AWS scanner',
+                evidence: { source: 'secret-policy' },
+                remediation: 'Review the secret policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
                 id: 'finding-aws-gov',
                 scan_id: 'scan-aws-complete',
                 type: 'aws_iam_partition_role',
@@ -8658,8 +8686,10 @@ describe('Domain-first app routes', () => {
     expect(within(findingsTable).getByText('Blocked')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Suppressed')).toBeInTheDocument();
     expect(within(findingsTable).queryByText(/Region unknown/i)).not.toBeInTheDocument();
-    expect(within(findingsTable).getByText(/shared-function.*Region us-east-1/)).toBeInTheDocument();
-    expect(within(findingsTable).getByText(/shared-function.*Region eu-west-1/)).toBeInTheDocument();
+    expect(within(findingsTable).getByText('shared-function · Lambda function · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('shared-function · Lambda function · Account 123456789012 · Region eu-west-1 · 1 evidence node')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('shared-function-colon · Lambda function · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('database-password-abc123 · Secrets Manager secret · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
 
     for (const [title, href] of [
       ['Gov IAM role', 'https://console.amazonaws-us-gov.com/iam/home#/roles/gov-role'],

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8105,10 +8105,15 @@ describe('Domain-first app routes', () => {
       evidence: [],
       next_action: 'Review the provider credential scope.'
     } as any;
+    const actionableEquivalenceFinding = {
+      ...equivalenceFinding,
+      finding_id: 'aws-secret-permission-equivalence:findings-route-actionable',
+      status: 'action_required'
+    };
     const getSecretPermissionEquivalence = vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockResolvedValue({
       findings: {
         status: 'ready',
-        findings: [equivalenceFinding],
+        findings: [equivalenceFinding, actionableEquivalenceFinding],
         summary: {
           external_provider_key_count: 0,
           aws_managed_secret_count: 0,
@@ -8142,12 +8147,12 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('heading', { level: 2, name: 'Findings' })).toBeInTheDocument();
     const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
     expect(within(findingsTable).getByText(/Completeness: Complete/i)).toBeInTheDocument();
-    expect(within(findingsTable).getByRole('link', { name: /Agent provider key equivalence/i })).toHaveAttribute(
+    expect(within(findingsTable).getByRole('link', { name: /openai\/api-key/i })).toHaveAttribute(
       'href',
       '/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=case-triage-id&tab=secrets'
     );
     expect(within(findingsTable).getByText('High')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('Review')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Open')).toBeInTheDocument();
     expect(screen.queryByRole('table', { name: 'AWS secret-to-permission equivalence findings' })).not.toBeInTheDocument();
     await waitFor(() =>
       expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
@@ -8217,6 +8222,17 @@ describe('Domain-first app routes', () => {
     expect(getSecretPermissionEquivalence.mock.lastCall?.[2]?.accountID).toBeUndefined();
 
     fireEvent.change(screen.getByRole('combobox', { name: 'Region' }), { target: { value: 'unknown' } });
+    await waitFor(() =>
+      expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(getSecretPermissionEquivalence.mock.lastCall?.[2]?.region).toBeUndefined();
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Region' }), { target: { value: 'other' } });
     await waitFor(() =>
       expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
         'workspace-a',
@@ -8409,6 +8425,118 @@ describe('Domain-first app routes', () => {
                 lifecycle_status: 'fixed'
               },
               {
+                id: 'finding-aws-gov',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_partition_role',
+                severity: 'low',
+                title: 'Gov IAM role',
+                human_summary: 'A role in the AWS GovCloud partition.',
+                path: ['arn:aws-us-gov:iam::123456789012:role/gov-role'],
+                owner: 'AWS scanner',
+                evidence: { source: 'iam-policy' },
+                remediation: 'Review the role policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
+                id: 'finding-aws-cn',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_partition_role',
+                severity: 'low',
+                title: 'China IAM role',
+                human_summary: 'A role in the AWS China partition.',
+                path: ['arn:aws-cn:iam::123456789012:role/cn-role'],
+                owner: 'AWS scanner',
+                evidence: { source: 'iam-policy' },
+                remediation: 'Review the role policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
+                id: 'finding-aws-iso',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_partition_role',
+                severity: 'low',
+                title: 'ISO IAM role',
+                human_summary: 'A role in the AWS ISO partition.',
+                path: ['arn:aws-iso:iam::123456789012:role/iso-role'],
+                owner: 'AWS scanner',
+                evidence: { source: 'iam-policy' },
+                remediation: 'Review the role policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
+                id: 'finding-aws-iso-b',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_partition_role',
+                severity: 'low',
+                title: 'ISO-B IAM role',
+                human_summary: 'A role in the AWS ISO-B partition.',
+                path: ['arn:aws-iso-b:iam::123456789012:role/iso-b-role'],
+                owner: 'AWS scanner',
+                evidence: { source: 'iam-policy' },
+                remediation: 'Review the role policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
+                id: 'finding-aws-lifecycle-suppressed',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_lifecycle_role',
+                severity: 'medium',
+                title: 'Suppressed lifecycle role',
+                human_summary: 'The role has a suppressed finding.',
+                path: ['arn:aws:iam::123456789012:role/lifecycle-role'],
+                owner: 'AWS scanner',
+                evidence: { source: 'iam-policy' },
+                remediation: 'Review the suppression decision.',
+                created_at: '2026-08-20T20:03:00Z',
+                triage: { status: 'suppressed' }
+              },
+              {
+                id: 'finding-aws-lifecycle-resolved',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_lifecycle_role',
+                severity: 'low',
+                title: 'Resolved lifecycle role',
+                human_summary: 'The role has a resolved finding.',
+                path: ['arn:aws:iam::123456789012:role/lifecycle-role'],
+                owner: 'AWS scanner',
+                evidence: { source: 'iam-policy' },
+                remediation: 'No remediation is pending.',
+                created_at: '2026-08-20T20:03:00Z',
+                triage: { status: 'resolved' }
+              },
+              {
+                id: 'finding-aws-east-function',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_lambda_function',
+                severity: 'low',
+                title: 'East Lambda function',
+                human_summary: 'A regional Lambda finding.',
+                path: ['arn:aws:lambda:us-east-1:123456789012:function/shared-function'],
+                owner: 'AWS scanner',
+                evidence: { source: 'lambda-policy' },
+                remediation: 'Review the function policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
+                id: 'finding-aws-west-function',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_lambda_function',
+                severity: 'low',
+                title: 'West Lambda function',
+                human_summary: 'A regional Lambda finding.',
+                path: ['arn:aws:lambda:eu-west-1:123456789012:function/shared-function'],
+                owner: 'AWS scanner',
+                evidence: { source: 'lambda-policy' },
+                remediation: 'Review the function policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
                 id: 'finding-aws-3',
                 scan_id: 'scan-aws-complete',
                 type: 'aws_iam_acknowledged_role',
@@ -8512,14 +8640,41 @@ describe('Domain-first app routes', () => {
       'href',
       'https://console.aws.amazon.com/iam/home#/roles/production-role'
     );
+    fireEvent.click(within(findingDrawer).getByRole('button', { name: 'View details for Ownerless IAM role' }));
+    await waitFor(() => {
+      expect(within(findingDrawer).getByText('Assign an accountable owner to the role.')).toBeInTheDocument();
+      expect(within(findingDrawer).getByText('Unassigned')).toBeInTheDocument();
+      expect(within(findingDrawer).getByText('Technical evidence (1 refs)')).toBeInTheDocument();
+    });
+    fireEvent.click(within(findingDrawer).getByRole('button', { name: 'View details for Overprivileged IAM role' }));
+    await waitFor(() => expect(within(findingDrawer).getByText('Reduce the role policy to the required actions.')).toBeInTheDocument());
     fireEvent.click(within(findingDrawer).getByRole('button', { name: 'Close detail drawer' }));
     await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Finding details' })).not.toBeInTheDocument());
     expect(within(findingsTable).getByText('Public S3 bucket')).toBeInTheDocument();
     expect(within(findingsTable).getByText('High')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('Open')).toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).getByText('Open')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Acknowledged')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Resolved')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Blocked')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Suppressed')).toBeInTheDocument();
+    expect(within(findingsTable).queryByText(/Region unknown/i)).not.toBeInTheDocument();
+    expect(within(findingsTable).getByText(/shared-function.*Region us-east-1/)).toBeInTheDocument();
+    expect(within(findingsTable).getByText(/shared-function.*Region eu-west-1/)).toBeInTheDocument();
+
+    for (const [title, href] of [
+      ['Gov IAM role', 'https://console.amazonaws-us-gov.com/iam/home#/roles/gov-role'],
+      ['China IAM role', 'https://console.amazonaws.cn/iam/home#/roles/cn-role'],
+      ['ISO IAM role', 'https://console.c2s.ic.gov/iam/home#/roles/iso-role'],
+      ['ISO-B IAM role', 'https://console.sc2s.sgov.gov/iam/home#/roles/iso-b-role']
+    ] as const) {
+      const row = within(findingsTable).getByText(title, { exact: true }).closest('tr');
+      expect(row).not.toBeNull();
+      fireEvent.click(within(row as HTMLElement).getByRole('button', { name: 'View details' }));
+      const partitionDrawer = await screen.findByRole('dialog', { name: 'Finding details' });
+      expect(within(partitionDrawer).getByRole('link', { name: 'Open in AWS Console' })).toHaveAttribute('href', href);
+      fireEvent.click(within(partitionDrawer).getByRole('button', { name: 'Close detail drawer' }));
+      await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Finding details' })).not.toBeInTheDocument());
+    }
     fireEvent.change(screen.getByLabelText('Remediation'), { target: { value: 'suppressed' } });
     await waitFor(() => {
       expect(within(findingsTable).getByText('Overprivileged IAM role')).toBeInTheDocument();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8485,6 +8485,34 @@ describe('Domain-first app routes', () => {
                 lifecycle_status: 'open'
               },
               {
+                id: 'finding-aws-secret-prod-path',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_secretsmanager_secret',
+                severity: 'low',
+                title: 'Production database secret',
+                human_summary: 'A path-qualified production secret.',
+                path: ['arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/db'],
+                owner: 'AWS scanner',
+                evidence: { source: 'secret-policy' },
+                remediation: 'Review the production secret policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
+                id: 'finding-aws-secret-staging-path',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_secretsmanager_secret',
+                severity: 'low',
+                title: 'Staging database secret',
+                human_summary: 'A path-qualified staging secret.',
+                path: ['arn:aws:secretsmanager:us-east-1:123456789012:secret:staging/db'],
+                owner: 'AWS scanner',
+                evidence: { source: 'secret-policy' },
+                remediation: 'Review the staging secret policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
                 id: 'finding-aws-iam-path-role',
                 scan_id: 'scan-aws-complete',
                 type: 'aws_iam_partition_role',
@@ -8740,6 +8768,8 @@ describe('Domain-first app routes', () => {
     expect(within(findingsTable).getByText('shared-function-colon · Lambda function · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
     expect(within(findingsTable).getByText('payments · Lambda function · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
     expect(within(findingsTable).getByText('database-password-abc123 · Secrets Manager secret · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Production database secret', { exact: true })).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Staging database secret', { exact: true })).toBeInTheDocument();
 
     for (const [title, href] of [
       ['Gov IAM role', 'https://console.amazonaws-us-gov.com/iam/home#/roles/gov-role'],

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8387,7 +8387,7 @@ describe('Domain-first app routes', () => {
         started_at: '2026-08-20T20:00:00Z',
         finished_at: '2026-08-20T20:03:00Z',
         asset_count: 12,
-        finding_count: 4
+        finding_count: 5
       }
     });
     const listFindings = vi.spyOn(api.apiClient, 'listFindings').mockImplementation(async (filters = {}) =>
@@ -8447,7 +8447,7 @@ describe('Domain-first app routes', () => {
                 severity: 'high',
                 title: 'Overprivileged IAM role',
                 human_summary: 'The role grants more permissions than this workload requires.',
-                path: ['production-role', 'aws%3Aaccess%3Aiam%3AGetRole%20-%3E%20aws%3Aaccess%3Aiam%3AListRoles'],
+                path: ['arn:aws:iam::123456789012:role/production-role', 'aws%3Aaccess%3Aiam%3AGetRole%20-%3E%20aws%3Aaccess%3Aiam%3AListRoles'],
                 owner: 'AWS scanner',
                 adapter_source: 'iam-policy collector',
                 confidence_score: 0.88,
@@ -8457,11 +8457,28 @@ describe('Domain-first app routes', () => {
                 created_at: '2026-08-20T20:03:00Z',
                 lifecycle_status: 'open',
                 triage: { status: 'suppressed' }
+              },
+              {
+                id: 'finding-aws-5',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_ownerless_role',
+                severity: 'medium',
+                title: 'Ownerless IAM role',
+                human_summary: 'No accountable owner was detected for the role.',
+                path: ['production-role'],
+                adapter_source: 'iam-policy collector',
+                confidence_score: 0.82,
+                first_seen_at: '2026-08-20T20:01:00Z',
+                evidence: { source: 'iam-policy', account_id: '123456789012', region: 'us-east-1' },
+                remediation: 'Assign an accountable owner to the role.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
               }
             ],
             next_cursor: 'aws-findings-page-2'
           }
     );
+    vi.spyOn(api.apiClient, 'listFindingHistory').mockResolvedValue({ items: [] });
     vi.spyOn(api.apiClient, 'listScanEvents').mockRejectedValue(new Error('scan events unavailable'));
     const getSecretPermissionEquivalence = vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence');
 
@@ -8478,16 +8495,28 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByText('Showing findings from this AWS scan')).toBeInTheDocument();
     expect(screen.getByText(/could not verify source completeness/i)).toBeInTheDocument();
     const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
-    expect(within(findingsTable).getByText('Overprivileged IAM role')).toBeInTheDocument();
-    const overprivilegedRow = within(findingsTable).getByText('Overprivileged IAM role').closest('tr');
+    expect(within(findingsTable).getByText('production-role', { exact: true })).toBeInTheDocument();
+    const overprivilegedRow = within(findingsTable).getByText('production-role', { exact: true }).closest('tr');
     expect(overprivilegedRow).not.toBeNull();
-    expect(within(overprivilegedRow as HTMLElement).getByText('Account 123456789012 · Region us-east-1 · IAM permission path · 2 evidence nodes')).toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).getByText('production-role · IAM role · Account 123456789012 · Global')).toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).getByText('2 related risks detected for this identity.')).toBeInTheDocument();
     expect(within(overprivilegedRow as HTMLElement).getByText('Source: iam-policy collector · Confidence: 88% · Completeness: Unknown')).toBeInTheDocument();
-    expect(within(overprivilegedRow as HTMLElement).getByText('Technical evidence (2 refs)')).toBeInTheDocument();
-    expect(within(overprivilegedRow as HTMLElement).getByText('scan-aws-complete')).toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).queryByText('Technical evidence (2 refs)')).not.toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).queryByText('scan-aws-complete')).not.toBeInTheDocument();
+    fireEvent.click(within(overprivilegedRow as HTMLElement).getByRole('button', { name: 'View details' }));
+    const findingDrawer = await screen.findByRole('dialog', { name: 'Finding details' });
+    expect(within(findingDrawer).getByText('Related risks (2)')).toBeInTheDocument();
+    expect(within(findingDrawer).getByText('Technical evidence (2 refs)')).toBeInTheDocument();
+    expect(within(findingDrawer).getByText('scan-aws-complete')).toBeInTheDocument();
+    expect(within(findingDrawer).getByRole('link', { name: 'Open in AWS Console' })).toHaveAttribute(
+      'href',
+      'https://console.aws.amazon.com/iam/home#/roles/production-role'
+    );
+    fireEvent.click(within(findingDrawer).getByRole('button', { name: 'Close detail drawer' }));
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Finding details' })).not.toBeInTheDocument());
     expect(within(findingsTable).getByText('Public S3 bucket')).toBeInTheDocument();
     expect(within(findingsTable).getByText('High')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('Suppressed')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('Open')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Acknowledged')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Resolved')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Blocked')).toBeInTheDocument();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8110,10 +8110,19 @@ describe('Domain-first app routes', () => {
       finding_id: 'aws-secret-permission-equivalence:findings-route-actionable',
       status: 'action_required'
     };
+    const sameNameDifferentIdentityFinding = {
+      ...equivalenceFinding,
+      finding_id: 'aws-secret-permission-equivalence:findings-route-different-identity',
+      region: 'eu-west-1',
+      identity_node_id: 'aws:identity:case-triage-eu',
+      agent_id: 'case-triage-id-eu',
+      secret_node_id: 'aws:resource:secret:anthropic-api-key',
+      secret_label: 'anthropic/api-key'
+    };
     const getSecretPermissionEquivalence = vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockResolvedValue({
       findings: {
         status: 'ready',
-        findings: [equivalenceFinding, actionableEquivalenceFinding],
+        findings: [equivalenceFinding, actionableEquivalenceFinding, sameNameDifferentIdentityFinding],
         summary: {
           external_provider_key_count: 0,
           aws_managed_secret_count: 0,
@@ -8146,7 +8155,7 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByRole('heading', { level: 2, name: 'Findings' })).toBeInTheDocument();
     const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
-    expect(within(findingsTable).getByText(/Completeness: Complete/i)).toBeInTheDocument();
+    expect(within(findingsTable).getAllByText(/Completeness: Complete/i)).toHaveLength(2);
     expect(within(findingsTable).getByRole('link', { name: /openai\/api-key/i })).toHaveAttribute(
       'href',
       '/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=case-triage-id&tab=secrets'
@@ -8154,12 +8163,13 @@ describe('Domain-first app routes', () => {
     const liveFindingRow = within(findingsTable).getByRole('link', { name: /openai\/api-key/i }).closest('tr');
     expect(liveFindingRow).not.toBeNull();
     expect(within(liveFindingRow as HTMLElement).getByText(/Case Triage · openai\/api-key · Secret · Account 123456789012 · Region us-east-1/)).toBeInTheDocument();
+    expect(within(findingsTable).getByText(/Case Triage · anthropic\/api-key · Secret · Account 123456789012 · Region eu-west-1/)).toBeInTheDocument();
     fireEvent.click(within(liveFindingRow as HTMLElement).getByRole('button', { name: 'View details' }));
     const liveFindingDrawer = await screen.findByRole('dialog', { name: 'Finding details' });
     expect(within(liveFindingDrawer).getByText('Case Triage', { exact: true })).toBeInTheDocument();
     fireEvent.click(within(liveFindingDrawer).getByRole('button', { name: 'Close detail drawer' }));
     await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Finding details' })).not.toBeInTheDocument());
-    expect(within(findingsTable).getByText('High')).toBeInTheDocument();
+    expect(within(findingsTable).getAllByText('High')).toHaveLength(2);
     expect(within(findingsTable).getByText('Open')).toBeInTheDocument();
     expect(screen.queryByRole('table', { name: 'AWS secret-to-permission equivalence findings' })).not.toBeInTheDocument();
     await waitFor(() =>
@@ -8447,6 +8457,20 @@ describe('Domain-first app routes', () => {
                 lifecycle_status: 'open'
               },
               {
+                id: 'finding-aws-lambda-qualified-resource',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_lambda_function',
+                severity: 'low',
+                title: 'Qualified Lambda resource label',
+                human_summary: 'A Lambda finding with a qualified ARN resource.',
+                path: ['arn:aws:lambda:us-east-1:123456789012:function:payments:42'],
+                owner: 'AWS scanner',
+                evidence: { source: 'lambda-policy' },
+                remediation: 'Review the function policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
                 id: 'finding-aws-secret-colon-resource',
                 scan_id: 'scan-aws-complete',
                 type: 'aws_secretsmanager_secret',
@@ -8457,6 +8481,20 @@ describe('Domain-first app routes', () => {
                 owner: 'AWS scanner',
                 evidence: { source: 'secret-policy' },
                 remediation: 'Review the secret policy.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
+              },
+              {
+                id: 'finding-aws-iam-path-role',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_partition_role',
+                severity: 'low',
+                title: 'IAM path role',
+                human_summary: 'An IAM role with a service path.',
+                path: ['arn:aws:iam::123456789012:role/service-role/payments'],
+                owner: 'AWS scanner',
+                evidence: { source: 'iam-policy' },
+                remediation: 'Review the role policy.',
                 created_at: '2026-08-20T20:03:00Z',
                 lifecycle_status: 'open'
               },
@@ -8700,13 +8738,15 @@ describe('Domain-first app routes', () => {
     expect(within(findingsTable).getByText('shared-function · Lambda function · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
     expect(within(findingsTable).getByText('shared-function · Lambda function · Account 123456789012 · Region eu-west-1 · 1 evidence node')).toBeInTheDocument();
     expect(within(findingsTable).getByText('shared-function-colon · Lambda function · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('payments · Lambda function · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
     expect(within(findingsTable).getByText('database-password-abc123 · Secrets Manager secret · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
 
     for (const [title, href] of [
       ['Gov IAM role', 'https://console.amazonaws-us-gov.com/iam/home#/roles/gov-role'],
       ['China IAM role', 'https://console.amazonaws.cn/iam/home#/roles/cn-role'],
       ['ISO IAM role', 'https://console.c2s.ic.gov/iam/home#/roles/iso-role'],
-      ['ISO-B IAM role', 'https://console.sc2s.sgov.gov/iam/home#/roles/iso-b-role']
+      ['ISO-B IAM role', 'https://console.sc2s.sgov.gov/iam/home#/roles/iso-b-role'],
+      ['IAM path role', 'https://console.aws.amazon.com/iam/home#/roles/payments']
     ] as const) {
       const row = within(findingsTable).getByText(title, { exact: true }).closest('tr');
       expect(row).not.toBeNull();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18749,6 +18749,10 @@ function awsPersistedFindingScope(finding: ApiFinding): AWSPersistedFindingScope
     : readablePath || (global ? 'IAM identity' : 'Resource unavailable');
   const resourceType = awsFindingResourceType(service, resource || resourceLabel, finding.type, finding.title);
   const scopeLabel = `${accountID ? `Account ${accountID}` : 'Account unavailable'} · ${global ? 'Global' : region ? `Region ${region}` : 'Region unavailable'}`;
+  const fallbackIdentityKey =
+    resourceLabel !== 'Resource unavailable' && resourceLabel !== 'IAM identity'
+      ? `${accountID || 'account-unavailable'}:${resourceType}:${resourceLabel}:${global ? 'global' : region || 'region-unavailable'}`.toLowerCase()
+      : undefined;
   return {
     accountID,
     region,
@@ -18756,10 +18760,7 @@ function awsPersistedFindingScope(finding: ApiFinding): AWSPersistedFindingScope
     resourceARN,
     resourceLabel,
     resourceType,
-    identityKey:
-      resourceLabel !== 'Resource unavailable' && resourceLabel !== 'IAM identity'
-        ? `${accountID || 'account-unavailable'}:${resourceType}:${resourceLabel}:${global ? 'global' : region || 'region-unavailable'}`.toLowerCase()
-        : resourceARN,
+    identityKey: service === 'iam' ? fallbackIdentityKey : resourceARN || fallbackIdentityKey,
     scopeLabel,
     consoleLink: awsFindingConsoleLinkForResource(resourceARN, resourceType, resourceLabel, region)
   };

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -190,6 +190,7 @@ import {
   type ExecutiveReport,
   type ExecutiveReportDomain,
   type Finding as ApiFinding,
+  type FindingTriageEvent,
   type FindingLifecycleStatus,
   type GitHubConnectorStartResponse,
   type GitHubConnectionStatus,
@@ -232,6 +233,7 @@ import { SessionsList } from './components/auth/SessionsList';
 import { PermissionPreviewModal } from './components/connector/PermissionPreviewModal';
 import { ConfirmDestructiveModal, DangerZone, DangerZoneRow } from './components/settings/DangerZone';
 import {
+  DomainDetailDrawer,
   DomainDetailPanel,
   DomainCoverageCard,
   DomainDataTable,
@@ -12968,7 +12970,9 @@ const AWS_RISK_OPERATION_FILTERS: AWSRiskOperationFilterConfigMap = {
       options: [
         { label: 'All regions', value: 'all' },
         { label: 'Current region', value: 'current' },
-        { label: 'Unknown region', value: 'unknown' }
+        { label: 'Global resources', value: 'global' },
+        { label: 'Other regions', value: 'other' },
+        { label: 'Region unavailable', value: 'unknown' }
       ]
     },
     {
@@ -13135,6 +13139,16 @@ type AWSRiskOperationTableRow = AWSInventoryFilterable & {
   completeness?: string;
   evidenceBoundary?: string;
   technicalEvidence?: string[];
+  resourceARN?: string;
+  resourceLabel?: string;
+  resourceType?: string;
+  scopeLabel?: string;
+  identityKey?: string;
+  consoleLink?: string;
+  triageStatus?: string;
+  triageUpdatedAt?: string;
+  triageUpdatedBy?: string;
+  relatedRows?: AWSRiskOperationTableRow[];
 };
 
 function AWSRiskOperationFilterSet({
@@ -18103,66 +18117,6 @@ function AWSGraphEvidenceDrawer({ refs }: { refs: string[] }) {
   );
 }
 
-function AWSFindingTechnicalEvidenceDrawer({ row }: { row: AWSRiskOperationTableRow }) {
-  const refs = row.technicalEvidence?.filter(Boolean) ?? [];
-  return (
-    <details className="idt-aws-finding-technical-evidence">
-      <summary>Technical evidence{refs.length > 0 ? ` (${refs.length} refs)` : ''}</summary>
-      <dl>
-        <div>
-          <dt>Finding ID</dt>
-          <dd><code>{row.findingID || row.id}</code></dd>
-        </div>
-        <div>
-          <dt>Scan ID</dt>
-          <dd><code>{row.scanID || 'Unavailable'}</code></dd>
-        </div>
-        <div>
-          <dt>Scope</dt>
-          <dd>{row.accountID || 'Account unknown'} · {row.region || 'Region unknown'}</dd>
-        </div>
-        <div>
-          <dt>Observed</dt>
-          <dd>{row.observedAt || 'Unavailable'}</dd>
-        </div>
-        <div>
-          <dt>Provenance</dt>
-          <dd>{row.provenance || 'Unknown'}</dd>
-        </div>
-        <div>
-          <dt>Completeness</dt>
-          <dd>{awsPersistedFindingCompletenessLabel(row.completeness || 'unknown')}</dd>
-        </div>
-        {row.source ? (
-          <div>
-            <dt>Source</dt>
-            <dd>{row.source}</dd>
-          </div>
-        ) : null}
-        {row.evidenceBoundary ? (
-          <div>
-            <dt>Evidence boundary</dt>
-            <dd>{row.evidenceBoundary}</dd>
-          </div>
-        ) : null}
-        {row.confidence !== undefined ? (
-          <div>
-            <dt>Confidence</dt>
-            <dd>{formatConfidenceScore(row.confidence)}</dd>
-          </div>
-        ) : null}
-      </dl>
-      {refs.length > 0 ? (
-        <ul>
-          {refs.map((ref, index) => (
-            <li key={`${ref}-${index}`}><code>{ref}</code></li>
-          ))}
-        </ul>
-      ) : <p>No raw path or evidence references were returned.</p>}
-    </details>
-  );
-}
-
 function AWSFindingEvidenceCell({ row }: { row: AWSRiskOperationTableRow }) {
   const metadata = [
     row.source ? `Source: ${row.source}` : undefined,
@@ -18173,8 +18127,177 @@ function AWSFindingEvidenceCell({ row }: { row: AWSRiskOperationTableRow }) {
     <div className="idt-aws-finding-evidence-cell">
       <span>{row.evidence}</span>
       {metadata.length > 0 ? <small>{metadata.join(' · ')}</small> : null}
-      <AWSFindingTechnicalEvidenceDrawer row={row} />
     </div>
+  );
+}
+
+function awsFindingSeverityRank(value: string): number {
+  switch (normalizeValue(value).toLowerCase()) {
+    case 'critical': return 4;
+    case 'high': return 3;
+    case 'medium': return 2;
+    case 'low': return 1;
+    default: return 0;
+  }
+}
+
+function awsFindingAggregateStatus(rows: AWSRiskOperationTableRow[]): string {
+  if (rows.some((row) => row.status === 'open')) return 'open';
+  if (rows.some((row) => row.status === 'ack')) return 'ack';
+  if (rows.some((row) => row.status === 'queued')) return 'queued';
+  if (rows.some((row) => row.status === 'blocked')) return 'blocked';
+  if (rows.some((row) => row.status === 'resolved')) return 'resolved';
+  return rows[0]?.status || 'unavailable';
+}
+
+function groupAWSFindingRows(rows: AWSRiskOperationTableRow[]): AWSRiskOperationTableRow[] {
+  const groups = new Map<string, AWSRiskOperationTableRow[]>();
+  for (const row of rows) {
+    const key = row.identityKey ? `identity:${row.identityKey}` : `finding:${row.id}`;
+    const group = groups.get(key) ?? [];
+    group.push(row);
+    groups.set(key, group);
+  }
+  return Array.from(groups.entries()).map(([key, group]) => {
+    if (group.length === 1) return group[0];
+    const primary = [...group].sort((left, right) => awsFindingSeverityRank(right.category) - awsFindingSeverityRank(left.category))[0];
+    const orderedGroup = [primary, ...group.filter((row) => row !== primary)];
+    return {
+      ...primary,
+      id: `aws-identity-group:${key}`,
+      title: primary.resourceLabel || primary.title,
+      evidence: `${group.length} related risks detected for this identity.`,
+      blastRadius: `${primary.resourceLabel || primary.title} · ${primary.resourceType || 'AWS resource'} · ${primary.scopeLabel || primary.blastRadius}`,
+      status: awsFindingAggregateStatus(group),
+      relatedRows: orderedGroup,
+      technicalEvidence: [],
+      searchText: inventorySearchText(group.flatMap((row) => [row.title, row.resourceLabel, row.resourceARN, row.searchText]))
+    };
+  });
+}
+
+function AWSFindingDetailsDrawer({
+  open,
+  row,
+  showingPersistedScan,
+  scope,
+  onClose
+}: {
+  open: boolean;
+  row: AWSRiskOperationTableRow | null;
+  showingPersistedScan: boolean;
+  scope: ProductSession | null;
+  onClose: () => void;
+}) {
+  const representative = row?.relatedRows?.[0] ?? row;
+  const [history, setHistory] = useState<FindingTriageEvent[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyUnavailable, setHistoryUnavailable] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    if (!open || !showingPersistedScan || !representative?.findingID || !scope) {
+      setHistory([]);
+      setHistoryLoading(false);
+      setHistoryUnavailable(false);
+      return () => {
+        active = false;
+      };
+    }
+    setHistoryUnavailable(false);
+    setHistoryLoading(true);
+    apiClient
+      .listFindingHistory(representative.findingID, representative.scanID, 20, {
+        tenantID: scope.tenantID,
+        workspaceID: scope.workspaceID
+      })
+      .then((response) => {
+        if (active) setHistory(response.items ?? []);
+      })
+      .catch(() => {
+        if (active) {
+          setHistory([]);
+          setHistoryUnavailable(true);
+        }
+      })
+      .finally(() => {
+        if (active) setHistoryLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [open, representative?.findingID, representative?.scanID, scope?.tenantID, scope?.workspaceID, showingPersistedScan]);
+
+  return (
+    <DomainDetailDrawer open={open} title="Finding details" eyebrow="AWS risk" onClose={onClose}>
+      {row && representative ? (
+        <div className="idt-aws-finding-detail">
+          <div className="idt-aws-finding-detail-heading">
+            <h4>{row.title}</h4>
+            <AWSInventoryPill stage={row.stage} label={showingPersistedScan ? awsPersistedFindingStatusLabel(row.status) : formatTokenLabel(row.status)} />
+          </div>
+          <section>
+            <h5>Why it matters</h5>
+            <p>{representative.evidence}</p>
+          </section>
+          <section>
+            <h5>Affected resource</h5>
+            <dl>
+              <div><dt>Resource</dt><dd>{representative.resourceLabel || representative.title}</dd></div>
+              <div><dt>Type</dt><dd>{representative.resourceType || 'AWS resource'}</dd></div>
+              <div><dt>Scope</dt><dd>{representative.scopeLabel || representative.blastRadius}</dd></div>
+              {representative.resourceARN ? <div><dt>ARN</dt><dd><code>{representative.resourceARN}</code></dd></div> : null}
+            </dl>
+          </section>
+          <section>
+            <h5>Recommended action</h5>
+            <p>{representative.nextAction}</p>
+          </section>
+          {row.relatedRows && row.relatedRows.length > 1 ? (
+            <section>
+              <h5>Related risks ({row.relatedRows.length})</h5>
+              <ul className="idt-aws-finding-related-list">
+                {row.relatedRows.map((relatedRow) => (
+                  <li key={relatedRow.id}><strong>{relatedRow.title}</strong><span>{relatedRow.category} · {formatTokenLabel(relatedRow.status)}</span></li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+          <section>
+            <h5>Evidence</h5>
+            <dl>
+              <div><dt>Finding ID</dt><dd><code>{representative.findingID || representative.id}</code></dd></div>
+              <div><dt>Scan ID</dt><dd><code>{representative.scanID || 'Unavailable'}</code></dd></div>
+              <div><dt>Source</dt><dd>{representative.source || 'Unavailable'}</dd></div>
+              <div><dt>Completeness</dt><dd>{awsPersistedFindingCompletenessLabel(representative.completeness || 'unknown')}</dd></div>
+              {representative.confidence !== undefined ? <div><dt>Confidence</dt><dd>{formatConfidenceScore(representative.confidence)}</dd></div> : null}
+              <div><dt>Observed</dt><dd>{representative.observedAt || 'Unavailable'}</dd></div>
+              {representative.evidenceBoundary ? <div><dt>Boundary</dt><dd>{representative.evidenceBoundary}</dd></div> : null}
+            </dl>
+            {(row.relatedRows ?? [representative]).map((evidenceRow) => (
+              <details key={evidenceRow.id} className="idt-aws-finding-technical-evidence">
+                <summary>Technical evidence ({evidenceRow.technicalEvidence?.length ?? 0} refs)</summary>
+                {evidenceRow.technicalEvidence?.length ? (
+                  <ul>{evidenceRow.technicalEvidence.map((ref, index) => <li key={`${ref}-${index}`}><code>{ref}</code></li>)}</ul>
+                ) : <p>No raw path or evidence references were returned.</p>}
+              </details>
+            ))}
+          </section>
+          <section>
+            <h5>Ownership &amp; resolution</h5>
+            <dl>
+              <div><dt>Owner</dt><dd>{representative.owner || 'Unassigned'}</dd></div>
+              <div><dt>Status</dt><dd>{showingPersistedScan ? awsPersistedFindingStatusLabel(representative.status) : formatTokenLabel(representative.status)}</dd></div>
+              {representative.triageUpdatedAt ? <div><dt>Last updated</dt><dd>{formatDateLabel(representative.triageUpdatedAt)}{representative.triageUpdatedBy ? ` by ${representative.triageUpdatedBy}` : ''}</dd></div> : null}
+            </dl>
+            {historyLoading ? <p>Loading resolution history…</p> : historyUnavailable ? <p>Resolution history is unavailable for this finding.</p> : history.length > 0 ? (
+              <ol className="idt-aws-finding-history">{history.map((event) => <li key={event.id}><strong>{formatTokenLabel(event.from_status)} → {formatTokenLabel(event.to_status)}</strong><span>{formatDateLabel(event.created_at)}{event.actor ? ` · ${event.actor}` : ''}</span>{event.comment ? <p>{event.comment}</p> : null}</li>)}</ol>
+            ) : <p>No recorded triage changes.</p>}
+          </section>
+          {representative.consoleLink ? <a className="idt-aws-finding-console-link" href={representative.consoleLink} target="_blank" rel="noreferrer">Open in AWS Console <ExternalLink size={15} aria-hidden="true" /></a> : null}
+        </div>
+      ) : null}
+    </DomainDetailDrawer>
   );
 }
 
@@ -18189,13 +18312,14 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
   const secret = finding.secret_label || finding.secret_arn || finding.secret_node_id;
   const evidence = awsSecretPermissionEquivalenceEvidenceLabel(finding);
   const detailLink = awsSecretPermissionEquivalenceDetailLink(scope, environmentID, finding);
+  const scopeLabel = `${finding.account_id ? `Account ${finding.account_id}` : 'Account unavailable'} · ${finding.region ? `Region ${finding.region}` : 'Region unavailable'}`;
   return {
     id: finding.finding_id,
     title: awsSecretPermissionEquivalenceLabel(finding),
     category: formatTokenLabel(finding.severity),
     evidence,
-    owner: identity || 'Unknown identity',
-    blastRadius: `${awsAccountRegionInventoryLabel(finding.account_id, finding.region)} · ${identity || 'Unknown identity'} · ${secret}`,
+    owner: 'Unassigned',
+    blastRadius: `${secret} · Secret · ${scopeLabel}`,
     nextAction: finding.next_action,
     status: finding.status,
     stage: awsSecretPermissionEquivalenceStage(finding),
@@ -18209,6 +18333,11 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
     provenance: 'Live AWS analysis',
     completeness: awsSecretPermissionEquivalenceCompleteness(result),
     evidenceBoundary: finding.evidence_boundary,
+    resourceLabel: secret,
+    resourceType: 'Secret',
+    scopeLabel,
+    identityKey: identity || secret,
+    triageStatus: finding.status,
     technicalEvidence: [
       ...finding.evidence.map((evidence) => evidence.evidence_ref),
       ...finding.impacted_path.map((step) => step.node_id)
@@ -18216,7 +18345,7 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
     filters: {
       severity: finding.severity || 'unknown',
       account: connection?.account_id && connection.account_id === finding.account_id ? 'connected' : 'unknown',
-      region: connection?.region && connection.region === finding.region ? 'current' : 'unknown',
+      region: finding.region ? (connection?.region === finding.region ? 'current' : 'other') : 'unknown',
       evidence: awsSecretPermissionEquivalenceEvidenceFilterToken(finding),
       status: awsSecretPermissionEquivalenceFindingStatusFilterToken(finding.status)
     },
@@ -18360,18 +18489,6 @@ function awsPersistedFindingPathIsSerialized(value: string): boolean {
   return decoded.length > 120 || decoded.includes('aws:access:') || decoded.includes(' -> ') || value.includes('%');
 }
 
-function awsPersistedFindingAffectedResource(finding: ApiFinding): string {
-  const path = finding.path?.map((value) => normalizeValue(value)).filter(Boolean) ?? [];
-  if (path.length === 0) {
-    return 'Resource unavailable';
-  }
-  if (path.some(awsPersistedFindingPathIsSerialized)) {
-    return 'IAM permission path';
-  }
-  const firstPathNode = path[0];
-  return firstPathNode.length > 96 ? `${firstPathNode.slice(0, 93)}...` : firstPathNode;
-}
-
 function awsPersistedFindingCompletenessLabel(value: string): string {
   switch (value) {
     case 'partial':
@@ -18386,67 +18503,174 @@ function awsPersistedFindingCompletenessLabel(value: string): string {
 type AWSPersistedFindingScope = {
   accountID?: string;
   region?: string;
+  global: boolean;
+  resourceARN?: string;
+  resourceLabel: string;
+  resourceType: string;
+  identityKey?: string;
+  scopeLabel: string;
+  consoleLink?: string;
 };
 
 const AWS_FINDING_ACCOUNT_ID_PATTERN = /^\d{12}$/;
 const AWS_FINDING_REGION_PATTERN = /^(?:af|ap|ca|cn|eu|il|me|sa|us|mx|us-gov|us-iso|us-isob|eu-isoe)-[a-z0-9-]+-\d+$/;
 
-function awsPersistedFindingScope(finding: ApiFinding): AWSPersistedFindingScope {
-  const scope: AWSPersistedFindingScope = {};
+function decodeAWSFindingValue(value: string): string {
+  let decoded = value;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) {
+        break;
+      }
+      decoded = next;
+    } catch {
+      break;
+    }
+  }
+  return decoded;
+}
+
+function awsFindingARNFromValue(value: string): string | undefined {
+  const decoded = decodeAWSFindingValue(value);
+  const match = decoded.match(/arn:(?:aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):[^\s,]+/i);
+  return match?.[0].replace(/[)\],.;]+$/, '');
+}
+
+function awsFindingEvidenceStrings(finding: ApiFinding): string[] {
+  const values: string[] = [];
   const visited = new Set<object>();
-
-  const inspect = (value: unknown, key?: string): void => {
-    if (scope.accountID && scope.region) {
+  const inspect = (value: unknown): void => {
+    const normalized = normalizeValue(value);
+    if (normalized) {
+      values.push(normalized);
       return;
     }
-
-    const normalizedKey = key?.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-    const normalizedValue = normalizeValue(value);
-    if (normalizedValue) {
-      if (
-        normalizedKey &&
-        ['account', 'accountid', 'awsaccountid'].includes(normalizedKey) &&
-        AWS_FINDING_ACCOUNT_ID_PATTERN.test(normalizedValue)
-      ) {
-        scope.accountID ??= normalizedValue;
-      }
-      if (
-        normalizedKey &&
-        ['region', 'awsregion'].includes(normalizedKey) &&
-        AWS_FINDING_REGION_PATTERN.test(normalizedValue)
-      ) {
-        scope.region ??= normalizedValue;
-      }
-      if (normalizedValue.startsWith('arn:')) {
-        const arnParts = normalizedValue.split(':');
-        if (arnParts.length >= 6) {
-          const accountID = arnParts[4];
-          const region = arnParts[3];
-          if (AWS_FINDING_ACCOUNT_ID_PATTERN.test(accountID)) {
-            scope.accountID ??= accountID;
-          }
-          if (AWS_FINDING_REGION_PATTERN.test(region)) {
-            scope.region ??= region;
-          }
-        }
-      }
-      return;
-    }
-
     if (!value || typeof value !== 'object' || visited.has(value)) {
       return;
     }
     visited.add(value);
-    for (const [childKey, childValue] of Object.entries(value)) {
-      inspect(childValue, childKey);
+    for (const childValue of Object.values(value)) {
+      inspect(childValue);
     }
   };
-
   inspect(finding.evidence);
   for (const pathPart of finding.path ?? []) {
     inspect(pathPart);
   }
-  return scope;
+  return values;
+}
+
+function awsFindingResourceName(resource: string): string {
+  const normalized = decodeAWSFindingValue(resource).replace(/^\//, '');
+  const name = normalized.split('/').pop() || normalized.split(':').pop() || normalized;
+  return name.length > 100 ? `${name.slice(0, 97)}...` : name;
+}
+
+function awsFindingResourceType(service: string, resource: string, findingType: string, title = ''): string {
+  const normalizedResource = resource.toLowerCase();
+  const normalizedFindingType = `${findingType} ${title}`.toLowerCase();
+  if (service === 'iam' || normalizedFindingType.includes('iam')) {
+    if (normalizedResource.startsWith('role/')) return 'IAM role';
+    if (normalizedResource.startsWith('user/')) return 'IAM user';
+    if (normalizedResource.startsWith('group/')) return 'IAM group';
+    if (normalizedResource.startsWith('policy/')) return 'IAM policy';
+    if (normalizedFindingType.includes('role') || normalizedFindingType.includes('trust policy') || normalizedResource.includes('awsservicerole')) return 'IAM role';
+    return 'IAM identity';
+  }
+  const serviceLabels: Record<string, string> = {
+    s3: 'S3 bucket',
+    lambda: 'Lambda function',
+    secretsmanager: 'Secrets Manager secret',
+    kms: 'KMS key',
+    ec2: 'EC2 resource',
+    rds: 'RDS resource',
+    dynamodb: 'DynamoDB resource'
+  };
+  return serviceLabels[service] || (service ? `${formatTokenLabel(service)} resource` : 'AWS resource');
+}
+
+function awsFindingConsoleLink(arn: string | undefined, region: string | undefined): string | undefined {
+  if (!arn) return undefined;
+  const parts = arn.split(':');
+  if (parts.length < 6) return undefined;
+  const service = parts[2];
+  const resource = parts.slice(5).join(':');
+  const name = resource.split('/').slice(1).join('/') || resource.split(':').pop();
+  if (!name) return undefined;
+  if (service === 'iam' && resource.startsWith('role/')) {
+    return `https://console.aws.amazon.com/iam/home#/roles/${encodeURIComponent(name)}`;
+  }
+  if (service === 'iam' && resource.startsWith('user/')) {
+    return `https://console.aws.amazon.com/iam/home#/users/${encodeURIComponent(name)}`;
+  }
+  if (service === 's3') {
+    return `https://s3.console.aws.amazon.com/s3/buckets/${encodeURIComponent(name)}${region ? `?region=${encodeURIComponent(region)}` : ''}`;
+  }
+  return undefined;
+}
+
+function awsFindingConsoleLinkForResource(
+  arn: string | undefined,
+  resourceType: string,
+  resourceLabel: string,
+  region: string | undefined
+): string | undefined {
+  const arnLink = awsFindingConsoleLink(arn, region);
+  if (arnLink || !resourceLabel || resourceLabel === 'Resource unavailable' || resourceLabel === 'IAM identity') {
+    return arnLink;
+  }
+  if (resourceType === 'IAM role') {
+    return `https://console.aws.amazon.com/iam/home#/roles/${encodeURIComponent(resourceLabel)}`;
+  }
+  if (resourceType === 'IAM user') {
+    return `https://console.aws.amazon.com/iam/home#/users/${encodeURIComponent(resourceLabel)}`;
+  }
+  if (resourceType === 'S3 bucket') {
+    return `https://s3.console.aws.amazon.com/s3/buckets/${encodeURIComponent(resourceLabel)}${region ? `?region=${encodeURIComponent(region)}` : ''}`;
+  }
+  return undefined;
+}
+
+function awsPersistedFindingScope(finding: ApiFinding): AWSPersistedFindingScope {
+  const values = awsFindingEvidenceStrings(finding);
+  const arns = values.map(awsFindingARNFromValue).filter((value): value is string => Boolean(value));
+  const resourceARN = arns[0];
+  const arnParts = resourceARN?.split(':');
+  const service = arnParts?.[2] || '';
+  const resource = arnParts?.slice(5).join(':') || '';
+  const normalizedType = normalizeValue(finding.type).toLowerCase();
+  const global = service === 'iam' || normalizedType.includes('iam');
+  const accountID =
+    (arnParts?.[4] && AWS_FINDING_ACCOUNT_ID_PATTERN.test(arnParts[4]) ? arnParts[4] : undefined) ||
+    values.map(decodeAWSFindingValue).find((value) => AWS_FINDING_ACCOUNT_ID_PATTERN.test(value));
+  const region = global
+    ? undefined
+    : (arnParts?.[3] && AWS_FINDING_REGION_PATTERN.test(arnParts[3]) ? arnParts[3] : undefined) ||
+      values.map(decodeAWSFindingValue).find((value) => AWS_FINDING_REGION_PATTERN.test(value));
+  const readablePath = (finding.path ?? [])
+    .map((value) => decodeAWSFindingValue(normalizeValue(value)))
+    .map((value) => awsFindingARNFromValue(value) || value)
+    .find((value) => value && !awsPersistedFindingPathIsSerialized(value));
+  const resourceLabel = resourceARN
+    ? awsFindingResourceName(resource)
+    : readablePath || (global ? 'IAM identity' : 'Resource unavailable');
+  const resourceType = awsFindingResourceType(service, resource || resourceLabel, finding.type, finding.title);
+  const scopeLabel = `${accountID ? `Account ${accountID}` : 'Account unavailable'} · ${global ? 'Global' : region ? `Region ${region}` : 'Region unavailable'}`;
+  return {
+    accountID,
+    region,
+    global,
+    resourceARN,
+    resourceLabel,
+    resourceType,
+    identityKey:
+      resourceLabel !== 'Resource unavailable' && resourceLabel !== 'IAM identity'
+        ? `${accountID || 'account-unavailable'}:${resourceType}:${resourceLabel}`.toLowerCase()
+        : resourceARN,
+    scopeLabel,
+    consoleLink: awsFindingConsoleLinkForResource(resourceARN, resourceType, resourceLabel, region)
+  };
 }
 
 function awsPersistedFindingRiskOperationRow(
@@ -18457,8 +18681,6 @@ function awsPersistedFindingRiskOperationRow(
 ): AWSRiskOperationTableRow {
   const status = awsPersistedFindingStatus(finding);
   const findingScope = awsPersistedFindingScope(finding);
-  const account = findingScope.accountID ? `Account ${findingScope.accountID}` : 'Account unknown';
-  const region = findingScope.region ? `Region ${findingScope.region}` : 'Region unknown';
   const evidence = awsPersistedFindingEvidence(finding);
   const source = awsPersistedFindingSource(finding);
   const scanID = normalizeValue(finding.scan_id) || normalizeValue(persistedScan?.id);
@@ -18475,8 +18697,8 @@ function awsPersistedFindingRiskOperationRow(
     title: finding.title || formatTokenLabel(finding.type),
     category: formatTokenLabel(finding.severity),
     evidence,
-    owner: finding.owner || source,
-    blastRadius: `${account} · ${region} · ${awsPersistedFindingAffectedResource(finding)}${technicalEvidence.length > 0 ? ` · ${technicalEvidence.length} evidence node${technicalEvidence.length === 1 ? '' : 's'}` : ''}`,
+    owner: finding.triage?.assignee || (finding.owner && finding.owner !== source ? finding.owner : undefined) || 'Unassigned',
+    blastRadius: `${findingScope.resourceLabel} · ${findingScope.resourceType} · ${findingScope.scopeLabel}${technicalEvidence.length > 0 ? ` · ${technicalEvidence.length} evidence node${technicalEvidence.length === 1 ? '' : 's'}` : ''}`,
     nextAction: finding.remediation || 'Review the finding evidence and remediate the affected AWS resource.',
     status,
     stage: awsPersistedFindingStage(finding),
@@ -18491,10 +18713,19 @@ function awsPersistedFindingRiskOperationRow(
     completeness,
     evidenceBoundary,
     technicalEvidence,
+    resourceARN: findingScope.resourceARN,
+    resourceLabel: findingScope.resourceLabel,
+    resourceType: findingScope.resourceType,
+    scopeLabel: findingScope.scopeLabel,
+    identityKey: findingScope.identityKey,
+    consoleLink: findingScope.consoleLink,
+    triageStatus: finding.triage?.status,
+    triageUpdatedAt: finding.triage?.updated_at,
+    triageUpdatedBy: finding.triage?.updated_by,
     filters: {
       severity: normalizeValue(finding.severity).toLowerCase() || 'unknown',
       account: findingScope.accountID && findingScope.accountID === connection?.account_id ? 'connected' : 'unknown',
-      region: findingScope.region && findingScope.region === connection?.region ? 'current' : 'unknown',
+      region: findingScope.global ? 'global' : findingScope.region && findingScope.region === connection?.region ? 'current' : findingScope.region ? 'other' : 'unknown',
       evidence: Object.keys(finding.evidence ?? {}).length > 0 ? 'inventory-backed' : 'unavailable',
       status
     },
@@ -18505,6 +18736,9 @@ function awsPersistedFindingRiskOperationRow(
       finding.remediation,
       findingScope.accountID,
       findingScope.region,
+      findingScope.resourceLabel,
+      findingScope.resourceType,
+      findingScope.resourceARN,
       ...(finding.path ?? [])
     ])
   };
@@ -18559,7 +18793,10 @@ function AWSFindingsContent({
   const rows = showingPersistedScan
     ? persistedFindings?.map((finding) => awsPersistedFindingRiskOperationRow(finding, connection, persistedScan, persistedCompleteness)) ?? []
     : findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, findings, scope, environmentID, connection)) ?? [];
-  const displayedRows = filterAWSInventoryRows(rows, filters);
+  const filteredRows = filterAWSInventoryRows(rows, filters);
+  const displayedRows = groupAWSFindingRows(filteredRows);
+  const [selectedRowID, setSelectedRowID] = useState<string | null>(null);
+  const selectedRow = displayedRows.find((row) => row.id === selectedRowID) ?? null;
   const persistedScanReadyToLoad = Boolean(scope && environmentID);
   const liveFindingsReadyToLoad = Boolean(scope && environmentID && connection?.connected);
   const isLoading = loading || (showingPersistedScan && persistedScanReadyToLoad && !persistedFindings && !error) || (!showingPersistedScan && liveFindingsReadyToLoad && !findings && !error);
@@ -18632,10 +18869,18 @@ function AWSFindingsContent({
             { key: 'category', header: 'Severity', render: (row) => row.category },
             { key: 'evidence', header: 'Evidence', render: (row) => <AWSFindingEvidenceCell row={row} /> },
             { key: 'blast', header: 'Blast radius', render: (row) => row.blastRadius },
-            { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={showingPersistedScan ? awsPersistedFindingStatusLabel(row.status) : formatTokenLabel(row.status)} /> }
+            { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={showingPersistedScan ? awsPersistedFindingStatusLabel(row.status) : formatTokenLabel(row.status)} /> },
+            { key: 'action', header: 'Action', render: (row) => <button type="button" className="idt-aws-finding-view-details" onClick={() => setSelectedRowID(row.id)}>View details</button> }
           ]}
         />
       )}
+      <AWSFindingDetailsDrawer
+        open={Boolean(selectedRow)}
+        row={selectedRow}
+        showingPersistedScan={showingPersistedScan}
+        scope={scope}
+        onClose={() => setSelectedRowID(null)}
+      />
     </>
   );
 }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -13139,6 +13139,7 @@ type AWSRiskOperationTableRow = AWSInventoryFilterable & {
   completeness?: string;
   evidenceBoundary?: string;
   technicalEvidence?: string[];
+  identity?: string;
   resourceARN?: string;
   resourceLabel?: string;
   resourceType?: string;
@@ -18157,6 +18158,26 @@ function awsFindingAggregateStatus(rows: AWSRiskOperationTableRow[]): string {
   return rows[0]?.status || 'unavailable';
 }
 
+function awsFindingStatusContributesToAggregate(status: string, aggregateStatus: string): boolean {
+  const normalizedStatus = normalizeValue(status).toLowerCase();
+  switch (aggregateStatus) {
+    case 'open':
+      return normalizedStatus === 'open' || normalizedStatus === 'action_required';
+    case 'ack':
+      return normalizedStatus === 'ack';
+    case 'suppressed':
+      return normalizedStatus === 'suppressed';
+    case 'queued':
+      return normalizedStatus === 'queued' || normalizedStatus === 'review';
+    case 'blocked':
+      return normalizedStatus === 'blocked';
+    case 'resolved':
+      return normalizedStatus === 'resolved';
+    default:
+      return true;
+  }
+}
+
 function groupAWSFindingRows(rows: AWSRiskOperationTableRow[]): AWSRiskOperationTableRow[] {
   const groups = new Map<string, AWSRiskOperationTableRow[]>();
   for (const row of rows) {
@@ -18167,15 +18188,19 @@ function groupAWSFindingRows(rows: AWSRiskOperationTableRow[]): AWSRiskOperation
   }
   return Array.from(groups.entries()).map(([key, group]) => {
     if (group.length === 1) return group[0];
-    const primary = [...group].sort((left, right) => awsFindingSeverityRank(right.category) - awsFindingSeverityRank(left.category))[0];
+    const aggregateStatus = awsFindingAggregateStatus(group);
+    const statusRows = group.filter((row) => awsFindingStatusContributesToAggregate(row.status, aggregateStatus));
+    const primary = [...(statusRows.length > 0 ? statusRows : group)].sort(
+      (left, right) => awsFindingSeverityRank(right.category) - awsFindingSeverityRank(left.category)
+    )[0];
     const orderedGroup = [primary, ...group.filter((row) => row !== primary)];
     return {
       ...primary,
       id: `aws-identity-group:${key}`,
       title: primary.resourceLabel || primary.title,
       evidence: `${group.length} related risks detected for this identity.`,
-      blastRadius: `${primary.resourceLabel || primary.title} · ${primary.resourceType || 'AWS resource'} · ${primary.scopeLabel || primary.blastRadius}`,
-      status: awsFindingAggregateStatus(group),
+      blastRadius: `${primary.identity ? `${primary.identity} · ` : ''}${primary.resourceLabel || primary.title} · ${primary.resourceType || 'AWS resource'} · ${primary.scopeLabel || primary.blastRadius}`,
+      status: aggregateStatus,
       relatedRows: orderedGroup,
       technicalEvidence: [],
       searchText: inventorySearchText(group.flatMap((row) => [row.title, row.resourceLabel, row.resourceARN, row.searchText]))
@@ -18258,6 +18283,7 @@ function AWSFindingDetailsDrawer({
             <dl>
               <div><dt>Resource</dt><dd>{representative.resourceLabel || representative.title}</dd></div>
               <div><dt>Type</dt><dd>{representative.resourceType || 'AWS resource'}</dd></div>
+              {representative.identity ? <div><dt>Identity</dt><dd>{representative.identity}</dd></div> : null}
               <div><dt>Scope</dt><dd>{representative.scopeLabel || representative.blastRadius}</dd></div>
               {representative.resourceARN ? <div><dt>ARN</dt><dd><code>{representative.resourceARN}</code></dd></div> : null}
             </dl>
@@ -18342,8 +18368,9 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
     title: awsSecretPermissionEquivalenceLabel(finding),
     category: formatTokenLabel(finding.severity),
     evidence,
+    identity,
     owner: 'Unassigned',
-    blastRadius: `${secret} · Secret · ${scopeLabel}`,
+    blastRadius: `${identity || 'Identity unavailable'} · ${secret} · Secret · ${scopeLabel}`,
     nextAction: finding.next_action,
     status: finding.status,
     stage: awsSecretPermissionEquivalenceStage(finding),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18587,7 +18587,8 @@ function awsFindingEvidenceStrings(finding: ApiFinding): string[] {
 
 function awsFindingResourceName(resource: string): string {
   const normalized = decodeAWSFindingValue(resource).replace(/^\//, '');
-  const name = normalized.split('/').pop() || normalized.split(':').pop() || normalized;
+  const lastSeparator = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf(':'));
+  const name = lastSeparator >= 0 ? normalized.slice(lastSeparator + 1) : normalized;
   return name.length > 100 ? `${name.slice(0, 97)}...` : name;
 }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -17164,6 +17164,14 @@ function awsSecretPermissionEquivalenceIdentityLabel(finding: AWSSecretPermissio
   );
 }
 
+function awsSecretPermissionEquivalenceIdentityKey(finding: AWSSecretPermissionEquivalenceFinding): string {
+  const stableIdentity =
+    [finding.principal_arn, finding.identity_node_id, finding.agent_id, finding.workload_id]
+      .map(normalizeValue)
+      .find(Boolean) || normalizeValue(finding.finding_id);
+  return [finding.account_id, finding.region, stableIdentity].map(normalizeValue).filter(Boolean).join(':').toLowerCase();
+}
+
 function awsSecretPermissionEquivalencePathLabel(finding: AWSSecretPermissionEquivalenceFinding): string {
   const labels = finding.impacted_path.map((step) => step.label || step.node_id).filter(Boolean);
   if (labels.length >= 2) {
@@ -18387,7 +18395,7 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
     resourceLabel: secret,
     resourceType: 'Secret',
     scopeLabel,
-    identityKey: identity || secret,
+    identityKey: awsSecretPermissionEquivalenceIdentityKey(finding),
     triageStatus: finding.status,
     technicalEvidence: [
       ...finding.evidence.map((evidence) => evidence.evidence_ref),
@@ -18612,10 +18620,15 @@ function awsFindingEvidenceStrings(finding: ApiFinding): string[] {
   return values;
 }
 
-function awsFindingResourceName(resource: string): string {
+function awsFindingResourceName(resource: string, service = ''): string {
   const normalized = decodeAWSFindingValue(resource).replace(/^\//, '');
-  const lastSeparator = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf(':'));
-  const name = lastSeparator >= 0 ? normalized.slice(lastSeparator + 1) : normalized;
+  const name =
+    service === 'lambda' && normalized.toLowerCase().startsWith('function:')
+      ? normalized.slice('function:'.length).split(':')[0]
+      : (() => {
+          const lastSeparator = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf(':'));
+          return lastSeparator >= 0 ? normalized.slice(lastSeparator + 1) : normalized;
+        })();
   return name.length > 100 ? `${name.slice(0, 97)}...` : name;
 }
 
@@ -18676,10 +18689,12 @@ function awsFindingConsoleLink(arn: string | undefined, region: string | undefin
   const name = resource.split('/').slice(1).join('/') || resource.split(':').pop();
   if (!name) return undefined;
   if (service === 'iam' && resource.startsWith('role/')) {
-    return `https://${AWS_CONSOLE_HOSTS[partition]}/iam/home#/roles/${encodeURIComponent(name)}`;
+    const roleName = resource.slice('role/'.length).split('/').pop();
+    return roleName ? `https://${AWS_CONSOLE_HOSTS[partition]}/iam/home#/roles/${encodeURIComponent(roleName)}` : undefined;
   }
   if (service === 'iam' && resource.startsWith('user/')) {
-    return `https://${AWS_CONSOLE_HOSTS[partition]}/iam/home#/users/${encodeURIComponent(name)}`;
+    const userName = resource.slice('user/'.length).split('/').pop();
+    return userName ? `https://${AWS_CONSOLE_HOSTS[partition]}/iam/home#/users/${encodeURIComponent(userName)}` : undefined;
   }
   if (service === 's3') {
     return `https://${AWS_S3_CONSOLE_HOSTS[partition]}/s3/buckets/${encodeURIComponent(name)}${region ? `?region=${encodeURIComponent(region)}` : ''}`;
@@ -18730,7 +18745,7 @@ function awsPersistedFindingScope(finding: ApiFinding): AWSPersistedFindingScope
     .map((value) => awsFindingARNFromValue(value) || value)
     .find((value) => value && !awsPersistedFindingPathIsSerialized(value));
   const resourceLabel = resourceARN
-    ? awsFindingResourceName(resource)
+    ? awsFindingResourceName(resource, service)
     : readablePath || (global ? 'IAM identity' : 'Resource unavailable');
   const resourceType = awsFindingResourceType(service, resource || resourceLabel, finding.type, finding.title);
   const scopeLabel = `${accountID ? `Account ${accountID}` : 'Account unavailable'} · ${global ? 'Global' : region ? `Region ${region}` : 'Region unavailable'}`;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -17779,6 +17779,7 @@ function awsSecretPermissionEquivalenceRegionFilterToken(
     case 'current':
       return connection?.region || undefined;
     case 'unknown':
+    case 'other':
       return undefined;
     default:
       return awsSecretPermissionEquivalenceFilterToken(value);
@@ -17789,14 +17790,18 @@ function awsSecretPermissionEquivalenceFindingsQuery(
   filters: AWSInventoryFilterState,
   connection: AWSConnectionStatus | null
 ): Partial<AWSSecretPermissionEquivalenceQuery> {
-  return {
+  const query: Partial<AWSSecretPermissionEquivalenceQuery> = {
     accountID: awsSecretPermissionEquivalenceAccountFilterToken(filters.account, connection),
-    region: awsSecretPermissionEquivalenceRegionFilterToken(filters.region, connection),
     evidence: awsSecretPermissionEquivalenceFilterToken(filters.evidence),
     search: normalizeFilterValue(filters.search ?? '') || undefined,
     severity: awsSecretPermissionEquivalenceFilterToken(filters.severity),
     status: awsSecretPermissionEquivalenceStatusFilterToken(filters.status)
   };
+  const region = awsSecretPermissionEquivalenceRegionFilterToken(filters.region, connection);
+  if (region) {
+    query.region = region;
+  }
+  return query;
 }
 
 function awsGovernanceAuditReportingQueryFromFilters(filters: AWSInventoryFilterState): Partial<AWSGovernanceAuditReportingQuery> {
@@ -18142,11 +18147,13 @@ function awsFindingSeverityRank(value: string): number {
 }
 
 function awsFindingAggregateStatus(rows: AWSRiskOperationTableRow[]): string {
-  if (rows.some((row) => row.status === 'open')) return 'open';
-  if (rows.some((row) => row.status === 'ack')) return 'ack';
-  if (rows.some((row) => row.status === 'queued')) return 'queued';
-  if (rows.some((row) => row.status === 'blocked')) return 'blocked';
-  if (rows.some((row) => row.status === 'resolved')) return 'resolved';
+  const statuses = new Set(rows.map((row) => normalizeValue(row.status).toLowerCase()));
+  if (statuses.has('open') || statuses.has('action_required')) return 'open';
+  if (statuses.has('ack')) return 'ack';
+  if (statuses.has('suppressed')) return 'suppressed';
+  if (statuses.has('queued') || statuses.has('review')) return 'queued';
+  if (statuses.has('blocked')) return 'blocked';
+  if (statuses.has('resolved')) return 'resolved';
   return rows[0]?.status || 'unavailable';
 }
 
@@ -18189,10 +18196,16 @@ function AWSFindingDetailsDrawer({
   scope: ProductSession | null;
   onClose: () => void;
 }) {
-  const representative = row?.relatedRows?.[0] ?? row;
+  const relatedRows = row?.relatedRows ?? (row ? [row] : []);
+  const [selectedRelatedRowID, setSelectedRelatedRowID] = useState<string | null>(null);
   const [history, setHistory] = useState<FindingTriageEvent[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyUnavailable, setHistoryUnavailable] = useState(false);
+  const representative = relatedRows.find((relatedRow) => relatedRow.id === selectedRelatedRowID) ?? relatedRows[0] ?? null;
+
+  useEffect(() => {
+    setSelectedRelatedRowID(relatedRows[0]?.id ?? null);
+  }, [open, row?.id]);
 
   useEffect(() => {
     let active = true;
@@ -18233,8 +18246,8 @@ function AWSFindingDetailsDrawer({
       {row && representative ? (
         <div className="idt-aws-finding-detail">
           <div className="idt-aws-finding-detail-heading">
-            <h4>{row.title}</h4>
-            <AWSInventoryPill stage={row.stage} label={showingPersistedScan ? awsPersistedFindingStatusLabel(row.status) : formatTokenLabel(row.status)} />
+            <h4>{representative.title}</h4>
+            <AWSInventoryPill stage={representative.stage} label={showingPersistedScan ? awsPersistedFindingStatusLabel(representative.status) : formatTokenLabel(representative.status)} />
           </div>
           <section>
             <h5>Why it matters</h5>
@@ -18253,12 +18266,23 @@ function AWSFindingDetailsDrawer({
             <h5>Recommended action</h5>
             <p>{representative.nextAction}</p>
           </section>
-          {row.relatedRows && row.relatedRows.length > 1 ? (
+          {relatedRows.length > 1 ? (
             <section>
-              <h5>Related risks ({row.relatedRows.length})</h5>
+              <h5>Related risks ({relatedRows.length})</h5>
               <ul className="idt-aws-finding-related-list">
-                {row.relatedRows.map((relatedRow) => (
-                  <li key={relatedRow.id}><strong>{relatedRow.title}</strong><span>{relatedRow.category} · {formatTokenLabel(relatedRow.status)}</span></li>
+                {relatedRows.map((relatedRow) => (
+                  <li key={relatedRow.id}>
+                    <button
+                      type="button"
+                      className="idt-aws-finding-related-button"
+                      aria-label={`View details for ${relatedRow.title}`}
+                      aria-pressed={relatedRow.id === representative.id}
+                      onClick={() => setSelectedRelatedRowID(relatedRow.id)}
+                    >
+                      <strong>{relatedRow.title}</strong>
+                      <span>{relatedRow.category} · {formatTokenLabel(relatedRow.status)}</span>
+                    </button>
+                  </li>
                 ))}
               </ul>
             </section>
@@ -18274,14 +18298,14 @@ function AWSFindingDetailsDrawer({
               <div><dt>Observed</dt><dd>{representative.observedAt || 'Unavailable'}</dd></div>
               {representative.evidenceBoundary ? <div><dt>Boundary</dt><dd>{representative.evidenceBoundary}</dd></div> : null}
             </dl>
-            {(row.relatedRows ?? [representative]).map((evidenceRow) => (
-              <details key={evidenceRow.id} className="idt-aws-finding-technical-evidence">
-                <summary>Technical evidence ({evidenceRow.technicalEvidence?.length ?? 0} refs)</summary>
-                {evidenceRow.technicalEvidence?.length ? (
-                  <ul>{evidenceRow.technicalEvidence.map((ref, index) => <li key={`${ref}-${index}`}><code>{ref}</code></li>)}</ul>
-                ) : <p>No raw path or evidence references were returned.</p>}
-              </details>
-            ))}
+            <details className="idt-aws-finding-technical-evidence">
+              <summary>Technical evidence ({representative.technicalEvidence?.length ?? 0} refs)</summary>
+              {representative.technicalEvidence?.length ? (
+                <ul>{representative.technicalEvidence.map((ref, index) => <li key={`${ref}-${index}`}><code>{ref}</code></li>)}</ul>
+              ) : (
+                <p>No raw path or evidence references were returned.</p>
+              )}
+            </details>
           </section>
           <section>
             <h5>Ownership &amp; resolution</h5>
@@ -18590,22 +18614,47 @@ function awsFindingResourceType(service: string, resource: string, findingType: 
   return serviceLabels[service] || (service ? `${formatTokenLabel(service)} resource` : 'AWS resource');
 }
 
+type AWSConsolePartition = 'aws' | 'aws-us-gov' | 'aws-cn' | 'aws-iso' | 'aws-iso-b';
+
+const AWS_CONSOLE_HOSTS: Record<AWSConsolePartition, string> = {
+  aws: 'console.aws.amazon.com',
+  'aws-us-gov': 'console.amazonaws-us-gov.com',
+  'aws-cn': 'console.amazonaws.cn',
+  'aws-iso': 'console.c2s.ic.gov',
+  'aws-iso-b': 'console.sc2s.sgov.gov'
+};
+
+const AWS_S3_CONSOLE_HOSTS: Record<AWSConsolePartition, string> = {
+  aws: 's3.console.aws.amazon.com',
+  'aws-us-gov': 's3.console.amazonaws-us-gov.com',
+  'aws-cn': 's3.console.amazonaws.cn',
+  'aws-iso': 'console.c2s.ic.gov',
+  'aws-iso-b': 'console.sc2s.sgov.gov'
+};
+
+function awsConsolePartition(arn: string): AWSConsolePartition | undefined {
+  const partition = arn.split(':')[1] as AWSConsolePartition | undefined;
+  return partition && Object.prototype.hasOwnProperty.call(AWS_CONSOLE_HOSTS, partition) ? partition : undefined;
+}
+
 function awsFindingConsoleLink(arn: string | undefined, region: string | undefined): string | undefined {
   if (!arn) return undefined;
   const parts = arn.split(':');
   if (parts.length < 6) return undefined;
+  const partition = awsConsolePartition(arn);
+  if (!partition) return undefined;
   const service = parts[2];
   const resource = parts.slice(5).join(':');
   const name = resource.split('/').slice(1).join('/') || resource.split(':').pop();
   if (!name) return undefined;
   if (service === 'iam' && resource.startsWith('role/')) {
-    return `https://console.aws.amazon.com/iam/home#/roles/${encodeURIComponent(name)}`;
+    return `https://${AWS_CONSOLE_HOSTS[partition]}/iam/home#/roles/${encodeURIComponent(name)}`;
   }
   if (service === 'iam' && resource.startsWith('user/')) {
-    return `https://console.aws.amazon.com/iam/home#/users/${encodeURIComponent(name)}`;
+    return `https://${AWS_CONSOLE_HOSTS[partition]}/iam/home#/users/${encodeURIComponent(name)}`;
   }
   if (service === 's3') {
-    return `https://s3.console.aws.amazon.com/s3/buckets/${encodeURIComponent(name)}${region ? `?region=${encodeURIComponent(region)}` : ''}`;
+    return `https://${AWS_S3_CONSOLE_HOSTS[partition]}/s3/buckets/${encodeURIComponent(name)}${region ? `?region=${encodeURIComponent(region)}` : ''}`;
   }
   return undefined;
 }
@@ -18666,7 +18715,7 @@ function awsPersistedFindingScope(finding: ApiFinding): AWSPersistedFindingScope
     resourceType,
     identityKey:
       resourceLabel !== 'Resource unavailable' && resourceLabel !== 'IAM identity'
-        ? `${accountID || 'account-unavailable'}:${resourceType}:${resourceLabel}`.toLowerCase()
+        ? `${accountID || 'account-unavailable'}:${resourceType}:${resourceLabel}:${global ? 'global' : region || 'region-unavailable'}`.toLowerCase()
         : resourceARN,
     scopeLabel,
     consoleLink: awsFindingConsoleLinkForResource(resourceARN, resourceType, resourceLabel, region)

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -33360,6 +33360,126 @@ html[data-theme='light'] .idt-danger-modal-typed input {
   line-height: 1.35;
 }
 
+.idt-aws-finding-view-details {
+  border: 1px solid rgba(145, 126, 255, 0.65);
+  border-radius: 0.35rem;
+  padding: 0.35rem 0.55rem;
+  background: rgba(111, 89, 255, 0.12);
+  color: var(--idt-text, #f6f7f8);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.idt-aws-finding-view-details:hover,
+.idt-aws-finding-view-details:focus-visible {
+  border-color: rgba(174, 161, 255, 0.95);
+  background: rgba(111, 89, 255, 0.24);
+}
+
+.idt-aws-finding-detail {
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-aws-finding-detail-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.idt-aws-finding-detail-heading h4,
+.idt-aws-finding-detail h5 {
+  margin: 0;
+}
+
+.idt-aws-finding-detail section {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+}
+
+.idt-aws-finding-detail section > p {
+  margin: 0;
+  color: var(--idt-text-muted, #aeb8c9);
+  line-height: 1.5;
+}
+
+.idt-aws-finding-detail dl {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+}
+
+.idt-aws-finding-detail dl div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.idt-aws-finding-detail dt {
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.idt-aws-finding-detail dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-finding-detail code {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.idt-aws-finding-related-list,
+.idt-aws-finding-history {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+  padding-left: 1.15rem;
+}
+
+.idt-aws-finding-related-list li,
+.idt-aws-finding-history li {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.idt-aws-finding-related-list span,
+.idt-aws-finding-history span {
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.76rem;
+}
+
+.idt-aws-finding-history p {
+  margin: 0.15rem 0 0;
+  color: var(--idt-text-muted, #aeb8c9);
+}
+
+.idt-aws-finding-console-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  width: fit-content;
+  border-radius: 0.35rem;
+  padding: 0.5rem 0.7rem;
+  background: var(--idt-accent, #7c63ff);
+  color: #fff;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.idt-aws-finding-console-link:hover,
+.idt-aws-finding-console-link:focus-visible {
+  filter: brightness(1.1);
+}
+
 .idt-aws-finding-technical-evidence {
   border: 1px solid rgba(154, 164, 190, 0.28);
   border-radius: 0.35rem;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -33450,6 +33450,26 @@ html[data-theme='light'] .idt-danger-modal-typed input {
   gap: 0.15rem;
 }
 
+.idt-aws-finding-related-button {
+  display: grid;
+  gap: 0.15rem;
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 0.35rem;
+  padding: 0.35rem 0.45rem;
+  color: inherit;
+  text-align: left;
+  background: transparent;
+  cursor: pointer;
+}
+
+.idt-aws-finding-related-button:hover,
+.idt-aws-finding-related-button:focus-visible,
+.idt-aws-finding-related-button[aria-pressed='true'] {
+  border-color: rgba(174, 161, 255, 0.65);
+  background: rgba(111, 89, 255, 0.16);
+}
+
 .idt-aws-finding-related-list span,
 .idt-aws-finding-history span {
   color: var(--idt-text-muted, #aeb8c9);


### PR DESCRIPTION
## Summary

Improves the AWS findings experience around scope accuracy, evidence readability, resource navigation, and triage. The change keeps findings auditable while making grouped risks easier to review and act on.

## What changed

- Normalize IAM scope to `Global` and keep regional resources tied to their actual region.
- Replace raw ARN and permission-path data in the table with compact resource, type, account, and scope summaries.
- Strip resource-type prefixes from colon-form ARNs so Lambda and Secrets Manager labels show the actual resource name.
- Keep technical evidence in the finding details drawer instead of expanding large payloads inside table rows.
- Let operators select each related risk in a grouped finding so its own impact, recommended action, ownership, status, history, IDs, and evidence are shown.
- Preserve AWS Console navigation for commercial, GovCloud, China, ISO, and ISO-B partitions.
- Normalize live `action_required` and `review` statuses before grouping, and apply explicit status precedence including suppressed findings.
- Prevent the synthetic `Other regions` UI option from being sent as a literal backend region query.
- Include region in the grouping identity for regional resources so same-name resources in different regions remain separate.

## Verification

- `npm test -- --run src/productShell.test.tsx` — 318 tests passed
- `npm run build` — production build and 40 prerendered routes passed
- `git diff --check upstream/dev...HEAD` — passed

All live review comments were evaluated. Valid comments were fixed with regression coverage; duplicate and outdated comments are documented in the review replies.