### PR TITLE
Polish AWS findings triage experience

### DIFF
--- a/web/src/components/app/DomainFoundation.test.tsx
+++ b/web/src/components/app/DomainFoundation.test.tsx
@@ -410,15 +410,23 @@ describe('DomainFoundation', () => {
       value: () => ({ width: 448 } as DOMRect)
     });
 
+    const resizeHandle = screen.getByRole('button', { name: 'Resize detail drawer' });
+    fireEvent.keyDown(resizeHandle, { key: 'ArrowLeft' });
+    expect(drawer.style.getPropertyValue('--idt-domain-drawer-width')).toBe('472px');
+
     fireEvent.click(expandButton);
     expect(drawer).toHaveClass('is-expanded');
+    expect(drawer.style.getPropertyValue('--idt-domain-drawer-width')).toBe('');
     expect(screen.getByRole('button', { name: 'Restore detail drawer' })).toBeInTheDocument();
 
-    const resizeHandle = screen.getByRole('button', { name: 'Resize detail drawer' });
     fireEvent.keyDown(resizeHandle, { key: 'ArrowLeft' });
     expect(drawer.style.getPropertyValue('--idt-domain-drawer-width')).toBe('472px');
     fireEvent.keyDown(resizeHandle, { key: 'ArrowRight' });
     expect(drawer.style.getPropertyValue('--idt-domain-drawer-width')).toBe('448px');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restore detail drawer' }));
+    expect(drawer).not.toHaveClass('is-expanded');
+    expect(drawer.style.getPropertyValue('--idt-domain-drawer-width')).toBe('472px');
 
     unmount();
     expect(document.body.style.overflow).toBe('');

--- a/web/src/components/app/DomainFoundation.test.tsx
+++ b/web/src/components/app/DomainFoundation.test.tsx
@@ -405,13 +405,20 @@ describe('DomainFoundation', () => {
     expect(drawer).not.toHaveClass('is-expanded');
     expect(document.body.style.overflow).toBe('hidden');
 
+    Object.defineProperty(drawer, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: 448 } as DOMRect)
+    });
+
     fireEvent.click(expandButton);
     expect(drawer).toHaveClass('is-expanded');
     expect(screen.getByRole('button', { name: 'Restore detail drawer' })).toBeInTheDocument();
 
     const resizeHandle = screen.getByRole('button', { name: 'Resize detail drawer' });
     fireEvent.keyDown(resizeHandle, { key: 'ArrowLeft' });
-    expect(drawer.style.getPropertyValue('--idt-domain-drawer-width')).toMatch(/px/);
+    expect(drawer.style.getPropertyValue('--idt-domain-drawer-width')).toBe('472px');
+    fireEvent.keyDown(resizeHandle, { key: 'ArrowRight' });
+    expect(drawer.style.getPropertyValue('--idt-domain-drawer-width')).toBe('448px');
 
     unmount();
     expect(document.body.style.overflow).toBe('');

--- a/web/src/components/app/DomainFoundation.test.tsx
+++ b/web/src/components/app/DomainFoundation.test.tsx
@@ -393,6 +393,30 @@ describe('DomainFoundation', () => {
     expect(document.activeElement).toBe(opener);
   });
 
+  it('supports expanding and keyboard resizing the detail drawer', () => {
+    const { unmount } = render(
+      <DomainDetailDrawer open title="Identity detail" onClose={() => undefined} resizable expandable>
+        <p>Identity payload</p>
+      </DomainDetailDrawer>
+    );
+
+    const drawer = screen.getByText('Identity payload').closest<HTMLElement>('.idt-domain-drawer')!;
+    const expandButton = screen.getByRole('button', { name: 'Expand detail drawer' });
+    expect(drawer).not.toHaveClass('is-expanded');
+    expect(document.body.style.overflow).toBe('hidden');
+
+    fireEvent.click(expandButton);
+    expect(drawer).toHaveClass('is-expanded');
+    expect(screen.getByRole('button', { name: 'Restore detail drawer' })).toBeInTheDocument();
+
+    const resizeHandle = screen.getByRole('button', { name: 'Resize detail drawer' });
+    fireEvent.keyDown(resizeHandle, { key: 'ArrowLeft' });
+    expect(drawer.style.getPropertyValue('--idt-domain-drawer-width')).toMatch(/px/);
+
+    unmount();
+    expect(document.body.style.overflow).toBe('');
+  });
+
   it('closes the drawer when swiped off screen on touch devices', () => {
     const onClose = vi.fn();
     render(

--- a/web/src/components/app/DomainFoundation.test.tsx
+++ b/web/src/components/app/DomainFoundation.test.tsx
@@ -368,6 +368,27 @@ describe('DomainFoundation', () => {
     expect(document.activeElement).toBe(approveButton);
   });
 
+  it('does not trap focus on a hidden resize handle', () => {
+    render(
+      <DomainDetailDrawer open title="Identity detail" onClose={() => undefined} resizable footer={<button type="button">Approve</button>}>
+        <a href="/inventory">View inventory</a>
+      </DomainDetailDrawer>
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Identity detail' });
+    const closeButton = screen.getByRole('button', { name: 'Close detail drawer' });
+    const approveButton = screen.getByRole('button', { name: 'Approve' });
+    const resizeHandle = screen.getByRole('button', { name: 'Resize detail drawer' });
+    resizeHandle.style.display = 'none';
+
+    approveButton.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+    expect(document.activeElement).toBe(closeButton);
+
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(approveButton);
+  });
+
   it('restores focus to the prior element when the drawer closes', () => {
     function Host() {
       const [open, setOpen] = useState(false);

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -842,7 +842,9 @@ export function DomainDetailDrawer({
   onClose,
   closeLabel = 'Close detail drawer',
   children,
-  footer
+  footer,
+  resizable = false,
+  expandable = false
 }: {
   open: boolean;
   title: string;
@@ -851,12 +853,17 @@ export function DomainDetailDrawer({
   closeLabel?: string;
   children: ReactNode;
   footer?: ReactNode;
+  resizable?: boolean;
+  expandable?: boolean;
 }) {
   const drawerRef = useRef<HTMLElement | null>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
   const [dragOffset, setDragOffset] = useState(0);
   const [isSwiping, setIsSwiping] = useState(false);
+  const [drawerWidth, setDrawerWidth] = useState<number | null>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
   const dragOffsetRef = useRef(0);
+  const resizeRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null);
   const dragRef = useRef<{
     pointerId: number;
     startX: number;
@@ -884,10 +891,27 @@ export function DomainDetailDrawer({
 
   useEffect(() => {
     if (!open) {
+      return;
+    }
+    const body = document.body;
+    const previousOverflow = body.style.overflow;
+    body.classList.add('idt-domain-drawer-open');
+    body.style.overflow = 'hidden';
+    return () => {
+      body.classList.remove('idt-domain-drawer-open');
+      body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
       setDragOffset(0);
       dragOffsetRef.current = 0;
       setIsSwiping(false);
       dragRef.current = null;
+      setDrawerWidth(null);
+      setIsExpanded(false);
+      resizeRef.current = null;
     }
   }, [open]);
 
@@ -984,8 +1008,66 @@ export function DomainDetailDrawer({
     setDragOffset(nextOffset);
   };
 
+  const getDrawerWidthBounds = useCallback(() => {
+    const viewportWidth = typeof window === 'undefined' ? 1024 : window.innerWidth;
+    return {
+      min: Math.min(360, viewportWidth * 0.9),
+      max: Math.min(1120, viewportWidth * 0.86)
+    };
+  }, []);
+
+  const handleResizePointerDown = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const { min, max } = getDrawerWidthBounds();
+    const currentWidth = drawerRef.current?.getBoundingClientRect().width || drawerWidth || Math.min(560, max);
+    resizeRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: Math.min(max, Math.max(min, currentWidth))
+    };
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  };
+
+  const handleResizePointerMove = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    const resize = resizeRef.current;
+    if (!resize) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    const { min, max } = getDrawerWidthBounds();
+    const nextWidth = Math.min(max, Math.max(min, resize.startWidth + resize.startX - event.clientX));
+    setDrawerWidth(nextWidth);
+  };
+
+  const finishResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    const resize = resizeRef.current;
+    if (!resize) {
+      return;
+    }
+    event.stopPropagation();
+    resizeRef.current = null;
+    event.currentTarget.releasePointerCapture?.(resize.pointerId);
+  };
+
+  const handleResizeKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    const { min, max } = getDrawerWidthBounds();
+    const currentWidth = drawerWidth ?? Math.min(560, max);
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End') {
+      event.preventDefault();
+      const nextWidth = event.key === 'Home'
+        ? min
+        : event.key === 'End'
+          ? max
+          : currentWidth + (event.key === 'ArrowLeft' ? 24 : -24);
+      setDrawerWidth(Math.min(max, Math.max(min, nextWidth)));
+    }
+  };
+
   const drawerStyle = {
-    '--idt-domain-drawer-swipe-x': `${dragOffset}px`
+    '--idt-domain-drawer-swipe-x': `${dragOffset}px`,
+    ...(drawerWidth ? { '--idt-domain-drawer-width': `${drawerWidth}px` } : {})
   } as CSSProperties;
 
   if (!open) {
@@ -995,7 +1077,7 @@ export function DomainDetailDrawer({
     <div className="idt-domain-drawer-root" role="dialog" aria-modal="true" aria-label={title} onKeyDown={handleKeyDown}>
       <button type="button" className="idt-domain-drawer-scrim" aria-hidden="true" tabIndex={-1} onClick={onClose} />
       <aside
-        className={classNames(['idt-domain-drawer', isSwiping ? 'is-swiping' : ''])}
+        className={classNames(['idt-domain-drawer', isSwiping ? 'is-swiping' : '', isExpanded ? 'is-expanded' : ''])}
         onPointerCancel={() => finishSwipe()}
         onPointerDown={handleDrawerPointerDown}
         onPointerMove={handleDrawerPointerMove}
@@ -1009,10 +1091,37 @@ export function DomainDetailDrawer({
             {eyebrow ? <p className="idt-app-kicker">{eyebrow}</p> : null}
             <h3>{title}</h3>
           </div>
-          <button type="button" className="idt-domain-drawer-close" onClick={onClose} aria-label={closeLabel}>
-            ESC
-          </button>
+          <div className="idt-domain-drawer-header-actions">
+            {expandable ? (
+              <button
+                type="button"
+                className="idt-domain-drawer-expand"
+                onClick={() => setIsExpanded((value) => !value)}
+                aria-label={isExpanded ? 'Restore detail drawer' : 'Expand detail drawer'}
+                title={isExpanded ? 'Restore detail drawer' : 'Expand detail drawer'}
+              >
+                {isExpanded ? 'RESTORE' : 'EXPAND'}
+              </button>
+            ) : null}
+            <button type="button" className="idt-domain-drawer-close" onClick={onClose} aria-label={closeLabel}>
+              ESC
+            </button>
+          </div>
         </header>
+        {resizable ? (
+          <button
+            type="button"
+            className="idt-domain-drawer-resize-handle"
+            aria-label="Resize detail drawer"
+            aria-orientation="vertical"
+            title="Resize detail drawer"
+            onPointerDown={handleResizePointerDown}
+            onPointerMove={handleResizePointerMove}
+            onPointerUp={finishResize}
+            onPointerCancel={finishResize}
+            onKeyDown={handleResizeKeyDown}
+          />
+        ) : null}
         <div className="idt-domain-drawer-body">{children}</div>
         {footer ? <footer>{footer}</footer> : null}
       </aside>

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -830,9 +830,13 @@ function getDomainDrawerFocusable(root: HTMLElement | null): HTMLElement[] {
   if (!root) {
     return [];
   }
-  return Array.from(root.querySelectorAll<HTMLElement>(DOMAIN_DRAWER_FOCUSABLE_SELECTOR)).filter(
-    (el) => el.getAttribute('aria-hidden') !== 'true'
-  );
+  return Array.from(root.querySelectorAll<HTMLElement>(DOMAIN_DRAWER_FOCUSABLE_SELECTOR)).filter((element) => {
+    if (element.hidden || element.getAttribute('aria-hidden') === 'true') {
+      return false;
+    }
+    const style = window.getComputedStyle(element);
+    return style.display !== 'none' && style.visibility !== 'hidden';
+  });
 }
 
 export function DomainDetailDrawer({

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -861,6 +861,7 @@ export function DomainDetailDrawer({
   const [dragOffset, setDragOffset] = useState(0);
   const [isSwiping, setIsSwiping] = useState(false);
   const [drawerWidth, setDrawerWidth] = useState<number | null>(null);
+  const [drawerWidthBeforeExpand, setDrawerWidthBeforeExpand] = useState<number | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const dragOffsetRef = useRef(0);
   const resizeRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null);
@@ -910,6 +911,7 @@ export function DomainDetailDrawer({
       setIsSwiping(false);
       dragRef.current = null;
       setDrawerWidth(null);
+      setDrawerWidthBeforeExpand(null);
       setIsExpanded(false);
       resizeRef.current = null;
     }
@@ -1070,6 +1072,18 @@ export function DomainDetailDrawer({
     ...(drawerWidth ? { '--idt-domain-drawer-width': `${drawerWidth}px` } : {})
   } as CSSProperties;
 
+  const toggleExpanded = () => {
+    if (isExpanded) {
+      setDrawerWidth(drawerWidthBeforeExpand);
+      setDrawerWidthBeforeExpand(null);
+      setIsExpanded(false);
+      return;
+    }
+    setDrawerWidthBeforeExpand(drawerWidth);
+    setDrawerWidth(null);
+    setIsExpanded(true);
+  };
+
   if (!open) {
     return null;
   }
@@ -1097,7 +1111,7 @@ export function DomainDetailDrawer({
                 type="button"
                 className="idt-domain-drawer-expand"
                 onPointerDown={(event) => event.stopPropagation()}
-                onClick={() => setIsExpanded((value) => !value)}
+                onClick={toggleExpanded}
                 aria-label={isExpanded ? 'Restore detail drawer' : 'Expand detail drawer'}
                 title={isExpanded ? 'Restore detail drawer' : 'Expand detail drawer'}
               >

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -1053,7 +1053,7 @@ export function DomainDetailDrawer({
 
   const handleResizeKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
     const { min, max } = getDrawerWidthBounds();
-    const currentWidth = drawerWidth ?? Math.min(560, max);
+    const currentWidth = drawerWidth ?? (drawerRef.current?.getBoundingClientRect().width || Math.min(560, max));
     if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End') {
       event.preventDefault();
       const nextWidth = event.key === 'Home'
@@ -1096,6 +1096,7 @@ export function DomainDetailDrawer({
               <button
                 type="button"
                 className="idt-domain-drawer-expand"
+                onPointerDown={(event) => event.stopPropagation()}
                 onClick={() => setIsExpanded((value) => !value)}
                 aria-label={isExpanded ? 'Restore detail drawer' : 'Expand detail drawer'}
                 title={isExpanded ? 'Restore detail drawer' : 'Expand detail drawer'}
@@ -1113,7 +1114,6 @@ export function DomainDetailDrawer({
             type="button"
             className="idt-domain-drawer-resize-handle"
             aria-label="Resize detail drawer"
-            aria-orientation="vertical"
             title="Resize detail drawer"
             onPointerDown={handleResizePointerDown}
             onPointerMove={handleResizePointerMove}

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8703,6 +8703,20 @@ describe('Domain-first app routes', () => {
                 remediation: 'Assign an accountable owner to the role.',
                 created_at: '2026-08-20T20:03:00Z',
                 lifecycle_status: 'open'
+              },
+              {
+                id: 'finding-aws-unknown-severity',
+                scan_id: 'scan-aws-complete',
+                type: 'aws_iam_role',
+                severity: 'informational',
+                title: 'Unclassified IAM role signal',
+                human_summary: 'The severity is not mapped to a supported priority.',
+                path: ['unclassified-role'],
+                owner: 'AWS scanner',
+                evidence: { source: 'iam-policy', account_id: '123456789012', region: 'us-east-1' },
+                remediation: 'Review the signal classification.',
+                created_at: '2026-08-20T20:03:00Z',
+                lifecycle_status: 'open'
               }
             ],
             next_cursor: 'aws-findings-page-2'
@@ -8724,6 +8738,7 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByText('AWS findings')).toBeInTheDocument();
     expect(screen.getByText(/source completeness could not be verified/i)).toBeInTheDocument();
+    expect(within(await screen.findByRole('region', { name: 'Finding priority summary' })).getByText('Unknown')).toBeInTheDocument();
     const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
     expect(within(findingsTable).getByText('production-role', { exact: true })).toBeInTheDocument();
     const overprivilegedRow = within(findingsTable).getByText('production-role', { exact: true }).closest('tr');

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8738,7 +8738,9 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByText('AWS findings')).toBeInTheDocument();
     expect(screen.getByText(/source completeness could not be verified/i)).toBeInTheDocument();
-    expect(within(await screen.findByRole('region', { name: 'Finding priority summary' })).getByText('Unknown')).toBeInTheDocument();
+    const prioritySummary = await screen.findByRole('region', { name: 'Finding priority summary' });
+    expect(within(prioritySummary).getByText('Unknown')).toBeInTheDocument();
+    expect(within(prioritySummary).getByText('20 risk signals · 18 affected resources')).toBeInTheDocument();
     const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
     expect(within(findingsTable).getByText('production-role', { exact: true })).toBeInTheDocument();
     const overprivilegedRow = within(findingsTable).getByText('production-role', { exact: true }).closest('tr');

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8771,7 +8771,8 @@ describe('Domain-first app routes', () => {
     fireEvent.click(within(findingDrawer).getByRole('button', { name: 'Close detail drawer' }));
     await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Finding details' })).not.toBeInTheDocument());
     expect(within(findingsTable).getByText('Public S3 bucket')).toBeInTheDocument();
-    expect(within(overprivilegedRow as HTMLElement).getByText('Medium')).toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).getByText('High')).toBeInTheDocument();
+    expect(within(overprivilegedRow as HTMLElement).queryByText('Medium')).not.toBeInTheDocument();
     expect(within(overprivilegedRow as HTMLElement).getByText('Open')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Acknowledged')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Resolved')).toBeInTheDocument();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8722,8 +8722,8 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText('Showing findings from this AWS scan')).toBeInTheDocument();
-    expect(screen.getByText(/could not verify source completeness/i)).toBeInTheDocument();
+    expect(await screen.findByText('AWS findings')).toBeInTheDocument();
+    expect(screen.getByText(/source completeness could not be verified/i)).toBeInTheDocument();
     const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
     expect(within(findingsTable).getByText('production-role', { exact: true })).toBeInTheDocument();
     const overprivilegedRow = within(findingsTable).getByText('production-role', { exact: true }).closest('tr');
@@ -8763,11 +8763,11 @@ describe('Domain-first app routes', () => {
     expect(within(findingsTable).getByText('Blocked')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Suppressed')).toBeInTheDocument();
     expect(within(findingsTable).queryByText(/Region unknown/i)).not.toBeInTheDocument();
-    expect(within(findingsTable).getByText('shared-function · Lambda function · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('shared-function · Lambda function · Account 123456789012 · Region eu-west-1 · 1 evidence node')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('shared-function-colon · Lambda function · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('payments · Lambda function · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('database-password-abc123 · Secrets Manager secret · Account 123456789012 · Region us-east-1 · 1 evidence node')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('shared-function · Lambda function · Account 123456789012 · Region us-east-1')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('shared-function · Lambda function · Account 123456789012 · Region eu-west-1')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('shared-function-colon · Lambda function · Account 123456789012 · Region us-east-1')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('payments · Lambda function · Account 123456789012 · Region us-east-1')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('database-password-abc123 · Secrets Manager secret · Account 123456789012 · Region us-east-1')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Production database secret', { exact: true })).toBeInTheDocument();
     expect(within(findingsTable).getByText('Staging database secret', { exact: true })).toBeInTheDocument();
 
@@ -8860,7 +8860,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText('Showing findings from this AWS scan')).toBeInTheDocument();
+    expect(await screen.findByText('AWS findings')).toBeInTheDocument();
     expect(await screen.findByText('Historical IAM finding')).toBeInTheDocument();
 
     fireEvent.change(screen.getByRole('combobox', { name: 'Account' }), { target: { value: 'unknown' } });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18156,17 +18156,37 @@ function AWSFindingStatusBadge({ status, showingPersistedScan }: { status: strin
   return <span className="idt-aws-finding-status">{label}</span>;
 }
 
-function AWSFindingSeveritySummary({ rows, displayedCount }: { rows: AWSRiskOperationTableRow[]; displayedCount: number }) {
-  const counts = ['critical', 'high', 'medium', 'low'].map((severity) => ({
+function awsFindingResourceKey(row: AWSRiskOperationTableRow): string {
+  const resourceARN = normalizeValue(row.resourceARN);
+  if (resourceARN) {
+    return `arn:${resourceARN}`;
+  }
+  const resourceParts = [row.resourceType, row.resourceLabel, row.accountID, row.scopeLabel].map(normalizeValue);
+  if (resourceParts.some(Boolean)) {
+    return `resource:${resourceParts.join('|')}`;
+  }
+  const identityKey = normalizeValue(row.identityKey);
+  return identityKey ? `identity:${identityKey}` : `finding:${row.id}`;
+}
+
+function awsFindingDistinctResourceCount(rows: AWSRiskOperationTableRow[]): number {
+  return new Set(rows.map(awsFindingResourceKey)).size;
+}
+
+function AWSFindingSeveritySummary({ rows, resourceCount }: { rows: AWSRiskOperationTableRow[]; resourceCount: number }) {
+  const counts = ['critical', 'high', 'medium', 'low', 'unknown'].map((severity) => ({
     severity,
-    count: rows.filter((row) => normalizeValue(row.category).toLowerCase() === severity).length
+    count: rows.filter((row) => {
+      const normalized = normalizeValue(row.category).toLowerCase();
+      return normalized === severity || (severity === 'unknown' && !['critical', 'high', 'medium', 'low'].includes(normalized));
+    }).length
   }));
   return (
     <section className="idt-aws-finding-summary" aria-label="Finding priority summary">
       <div className="idt-aws-finding-summary-heading">
         <div>
           <p className="idt-app-kicker">Priority overview</p>
-          <strong>{rows.length} risk signals · {displayedCount} affected resources</strong>
+          <strong>{rows.length} risk signals · {resourceCount} affected resources</strong>
         </div>
         <span className="idt-aws-finding-summary-note">Sorted by severity</span>
       </div>
@@ -18965,7 +18985,7 @@ function AWSFindingsContent({
           </p>
         </DomainStatusPanel>
       ) : null}
-      {displayedRows.length > 0 ? <AWSFindingSeveritySummary rows={filteredRows} displayedCount={displayedRows.length} /> : null}
+      {displayedRows.length > 0 ? <AWSFindingSeveritySummary rows={filteredRows} resourceCount={awsFindingDistinctResourceCount(filteredRows)} /> : null}
       <AWSRiskOperationFilterSet routeID="findings" filters={filters} onChange={onFiltersChange} />
       {error ? (
         <DomainErrorState

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18158,6 +18158,11 @@ function AWSFindingStatusBadge({ status, showingPersistedScan }: { status: strin
 }
 
 function awsFindingResourceKey(row: AWSRiskOperationTableRow): string {
+  const identityKey = normalizeValue(row.identityKey);
+  const normalizedResourceType = normalizeValue(row.resourceType).toLowerCase();
+  if (identityKey && normalizedResourceType.startsWith('iam ')) {
+    return `identity:${identityKey}`;
+  }
   const resourceARN = normalizeValue(row.resourceARN);
   if (resourceARN) {
     return `arn:${resourceARN}`;
@@ -18166,7 +18171,6 @@ function awsFindingResourceKey(row: AWSRiskOperationTableRow): string {
   if (resourceParts.some(Boolean)) {
     return `resource:${resourceParts.join('|')}`;
   }
-  const identityKey = normalizeValue(row.identityKey);
   return identityKey ? `identity:${identityKey}` : `finding:${row.id}`;
 }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -888,7 +888,7 @@ export const PRODUCT_DOMAIN_CONFIGS: Record<SourceProvider, ProductDomainConfig>
       productDomainRoute('observability', 'Observability', 'observability', 'Observability', '', 'Platform health, metrics, traces, and alerts for AWS collection and governance.'),
       productDomainRoute('ga-demo', 'GA Demo', 'ga-demo', 'GA Demo', '', 'End-to-end AWS operator walkthrough, permission docs, and GA readiness checks.'),
       productDomainRoute('graph', 'Graph', 'graph', 'Graph', '', 'How AWS roles can reach things, visualised.'),
-      productDomainRoute('findings', 'Findings', 'findings', 'Findings', '', 'Risks Identrail found in your AWS setup.'),
+      productDomainRoute('findings', 'Findings', 'findings', 'Findings', '', 'Prioritized AWS risks for the connected scope.'),
       productDomainRoute('remediation', 'Remediation', 'remediation', 'Remediation', '', 'AWS fixes Identrail prepares for you to approve.'),
       productDomainRoute('outcomes', 'Outcomes', 'outcomes', 'Outcomes', '', 'Executive outcome view for coverage, risk reduction, verified fixes, enforcement, and remaining exposure.'),
       productDomainRoute('governance', 'Governance', 'governance', 'Governance', '', "Advice on AWS access. Identrail won't apply changes for you.")
@@ -12709,7 +12709,7 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     routeID: 'findings',
     title: 'Findings',
     eyebrow: '',
-    description: 'Risks Identrail found in your AWS setup.',
+    description: 'Prioritized AWS risks for the connected scope.',
     statusLabel: '',
     currentCapability: '',
     plannedCapability: '',
@@ -18145,6 +18145,43 @@ function AWSFindingEvidenceCell({ row }: { row: AWSRiskOperationTableRow }) {
   );
 }
 
+function AWSFindingSeverityBadge({ severity }: { severity: string }) {
+  const normalized = normalizeValue(severity).toLowerCase();
+  const tone = ['critical', 'high', 'medium', 'low'].includes(normalized) ? normalized : 'unknown';
+  return <span className={`idt-aws-finding-severity is-${tone}`}>{formatTokenLabel(severity)}</span>;
+}
+
+function AWSFindingStatusBadge({ status, showingPersistedScan }: { status: string; showingPersistedScan: boolean }) {
+  const label = showingPersistedScan ? awsPersistedFindingStatusLabel(status) : formatTokenLabel(status);
+  return <span className="idt-aws-finding-status">{label}</span>;
+}
+
+function AWSFindingSeveritySummary({ rows, displayedCount }: { rows: AWSRiskOperationTableRow[]; displayedCount: number }) {
+  const counts = ['critical', 'high', 'medium', 'low'].map((severity) => ({
+    severity,
+    count: rows.filter((row) => normalizeValue(row.category).toLowerCase() === severity).length
+  }));
+  return (
+    <section className="idt-aws-finding-summary" aria-label="Finding priority summary">
+      <div className="idt-aws-finding-summary-heading">
+        <div>
+          <p className="idt-app-kicker">Priority overview</p>
+          <strong>{rows.length} risk signals · {displayedCount} affected resources</strong>
+        </div>
+        <span className="idt-aws-finding-summary-note">Sorted by severity</span>
+      </div>
+      <div className="idt-aws-finding-severity-summary">
+        {counts.map(({ severity, count }) => (
+          <div className="idt-aws-finding-severity-summary-item" key={severity}>
+            <AWSFindingSeverityBadge severity={severity} />
+            <strong>{count}</strong>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function awsFindingSeverityRank(value: string): number {
   switch (normalizeValue(value).toLowerCase()) {
     case 'critical': return 4;
@@ -18201,7 +18238,12 @@ function groupAWSFindingRows(rows: AWSRiskOperationTableRow[]): AWSRiskOperation
     const primary = [...(statusRows.length > 0 ? statusRows : group)].sort(
       (left, right) => awsFindingSeverityRank(right.category) - awsFindingSeverityRank(left.category)
     )[0];
-    const orderedGroup = [primary, ...group.filter((row) => row !== primary)];
+    const orderedGroup = [
+      primary,
+      ...group
+        .filter((row) => row !== primary)
+        .sort((left, right) => awsFindingSeverityRank(right.category) - awsFindingSeverityRank(left.category) || left.title.localeCompare(right.title))
+    ];
     return {
       ...primary,
       id: `aws-identity-group:${key}`,
@@ -18275,12 +18317,15 @@ function AWSFindingDetailsDrawer({
   }, [open, representative?.findingID, representative?.scanID, scope?.tenantID, scope?.workspaceID, showingPersistedScan]);
 
   return (
-    <DomainDetailDrawer open={open} title="Finding details" eyebrow="AWS risk" onClose={onClose}>
+    <DomainDetailDrawer open={open} title="Finding details" eyebrow="AWS risk" onClose={onClose} resizable expandable>
       {row && representative ? (
         <div className="idt-aws-finding-detail">
           <div className="idt-aws-finding-detail-heading">
             <h4>{representative.title}</h4>
-            <AWSInventoryPill stage={representative.stage} label={showingPersistedScan ? awsPersistedFindingStatusLabel(representative.status) : formatTokenLabel(representative.status)} />
+            <div className="idt-aws-finding-detail-badges">
+              <AWSFindingSeverityBadge severity={representative.category} />
+              <AWSFindingStatusBadge status={representative.status} showingPersistedScan={showingPersistedScan} />
+            </div>
           </div>
           <section>
             <h5>Why it matters</h5>
@@ -18352,7 +18397,13 @@ function AWSFindingDetailsDrawer({
               <ol className="idt-aws-finding-history">{history.map((event) => <li key={event.id}><strong>{formatTokenLabel(event.from_status)} → {formatTokenLabel(event.to_status)}</strong><span>{formatDateLabel(event.created_at)}{event.actor ? ` · ${event.actor}` : ''}</span>{event.comment ? <p>{event.comment}</p> : null}</li>)}</ol>
             ) : <p>No recorded triage changes.</p>}
           </section>
-          {representative.consoleLink ? <a className="idt-aws-finding-console-link" href={representative.consoleLink} target="_blank" rel="noreferrer">Open in AWS Console <ExternalLink size={15} aria-hidden="true" /></a> : null}
+          {representative.consoleLink ? (
+            <a className="idt-aws-finding-console-link" href={representative.consoleLink} target="_blank" rel="noreferrer">
+              Open in AWS Console <ExternalLink size={15} aria-hidden="true" />
+            </a>
+          ) : (
+            <p className="idt-aws-finding-console-unavailable">No direct AWS Console link is available for this resource type.</p>
+          )}
         </div>
       ) : null}
     </DomainDetailDrawer>
@@ -18791,7 +18842,7 @@ function awsPersistedFindingRiskOperationRow(
     category: formatTokenLabel(finding.severity),
     evidence,
     owner: finding.triage?.assignee || (finding.owner && finding.owner !== source ? finding.owner : undefined) || 'Unassigned',
-    blastRadius: `${findingScope.resourceLabel} · ${findingScope.resourceType} · ${findingScope.scopeLabel}${technicalEvidence.length > 0 ? ` · ${technicalEvidence.length} evidence node${technicalEvidence.length === 1 ? '' : 's'}` : ''}`,
+    blastRadius: `${findingScope.resourceLabel} · ${findingScope.resourceType} · ${findingScope.scopeLabel}`,
     nextAction: finding.remediation || 'Review the finding evidence and remediate the affected AWS resource.',
     status,
     stage: awsPersistedFindingStage(finding),
@@ -18887,7 +18938,9 @@ function AWSFindingsContent({
     ? persistedFindings?.map((finding) => awsPersistedFindingRiskOperationRow(finding, connection, persistedScan, persistedCompleteness)) ?? []
     : findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, findings, scope, environmentID, connection)) ?? [];
   const filteredRows = filterAWSInventoryRows(rows, filters);
-  const displayedRows = groupAWSFindingRows(filteredRows);
+  const displayedRows = groupAWSFindingRows(filteredRows).sort(
+    (left, right) => awsFindingSeverityRank(right.category) - awsFindingSeverityRank(left.category) || left.title.localeCompare(right.title) || left.id.localeCompare(right.id)
+  );
   const [selectedRowID, setSelectedRowID] = useState<string | null>(null);
   const selectedRow = displayedRows.find((row) => row.id === selectedRowID) ?? null;
   const persistedScanReadyToLoad = Boolean(scope && environmentID);
@@ -18898,20 +18951,21 @@ function AWSFindingsContent({
     <>
       {showingPersistedScan && persistedScan ? (
         <DomainStatusPanel
-          eyebrow="Discovery result"
-          title="Showing findings from this AWS scan"
+          eyebrow="Scan result"
+          title="AWS findings"
           status={`${persistedScan.finding_count} finding${persistedScan.finding_count === 1 ? '' : 's'}`}
           tone={persistedScanPartial || persistedScanCoverageUnknown ? 'warning' : 'success'}
         >
           <p>
             {persistedScanPartial
-              ? 'The scan completed with some unavailable sources. These findings are valid for the evidence Identrail collected; review coverage gaps before treating the result as complete.'
+              ? 'Partial coverage: some AWS sources were unavailable. Review coverage before treating this result as complete.'
               : persistedScanCoverageUnknown
-                ? 'These findings come directly from the completed AWS discovery run, but Identrail could not verify source completeness. Run discovery again if you need a fresh coverage check.'
-                : 'These findings come directly from the completed AWS discovery run.'}
+                ? 'Source completeness could not be verified. Run discovery again if you need a fresh coverage check.'
+                : 'Complete coverage for the sources included in this scan.'}
           </p>
         </DomainStatusPanel>
       ) : null}
+      {displayedRows.length > 0 ? <AWSFindingSeveritySummary rows={filteredRows} displayedCount={displayedRows.length} /> : null}
       <AWSRiskOperationFilterSet routeID="findings" filters={filters} onChange={onFiltersChange} />
       {error ? (
         <DomainErrorState
@@ -18959,10 +19013,10 @@ function AWSFindingsContent({
           }
           columns={[
             { key: 'title', header: 'Finding', render: (row) => row.detailLink ? <Link to={row.detailLink}>{row.title}</Link> : <strong>{row.title}</strong> },
-            { key: 'category', header: 'Severity', render: (row) => row.category },
+            { key: 'category', header: 'Severity', render: (row) => <AWSFindingSeverityBadge severity={row.category} /> },
             { key: 'evidence', header: 'Evidence', render: (row) => <AWSFindingEvidenceCell row={row} /> },
             { key: 'blast', header: 'Blast radius', render: (row) => row.blastRadius },
-            { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={showingPersistedScan ? awsPersistedFindingStatusLabel(row.status) : formatTokenLabel(row.status)} /> },
+            { key: 'status', header: 'Status', render: (row) => <AWSFindingStatusBadge status={row.status} showingPersistedScan={showingPersistedScan} /> },
             { key: 'action', header: 'Action', render: (row) => <button type="button" className="idt-aws-finding-view-details" onClick={() => setSelectedRowID(row.id)}>View details</button> }
           ]}
         />

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -13121,6 +13121,7 @@ type AWSRiskOperationTableRow = AWSInventoryFilterable & {
   id: string;
   title: string;
   category: string;
+  maxSeverity?: string;
   evidence: string;
   owner: string;
   blastRadius: string;
@@ -18212,6 +18213,10 @@ function awsFindingSeverityRank(value: string): number {
   }
 }
 
+function awsFindingDisplaySeverity(row: AWSRiskOperationTableRow): string {
+  return row.maxSeverity || row.category;
+}
+
 function awsFindingAggregateStatus(rows: AWSRiskOperationTableRow[]): string {
   const statuses = new Set(rows.map((row) => normalizeValue(row.status).toLowerCase()));
   if (statuses.has('open') || statuses.has('action_required')) return 'open';
@@ -18258,6 +18263,10 @@ function groupAWSFindingRows(rows: AWSRiskOperationTableRow[]): AWSRiskOperation
     const primary = [...(statusRows.length > 0 ? statusRows : group)].sort(
       (left, right) => awsFindingSeverityRank(right.category) - awsFindingSeverityRank(left.category)
     )[0];
+    const maxSeverity = group.reduce(
+      (highest, row) => awsFindingSeverityRank(row.category) > awsFindingSeverityRank(highest) ? row.category : highest,
+      group[0].category
+    );
     const orderedGroup = [
       primary,
       ...group
@@ -18268,6 +18277,7 @@ function groupAWSFindingRows(rows: AWSRiskOperationTableRow[]): AWSRiskOperation
       ...primary,
       id: `aws-identity-group:${key}`,
       title: primary.resourceLabel || primary.title,
+      maxSeverity,
       evidence: `${group.length} related risks detected for this identity.`,
       blastRadius: `${primary.identity ? `${primary.identity} · ` : ''}${primary.resourceLabel || primary.title} · ${primary.resourceType || 'AWS resource'} · ${primary.scopeLabel || primary.blastRadius}`,
       status: aggregateStatus,
@@ -18959,7 +18969,7 @@ function AWSFindingsContent({
     : findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, findings, scope, environmentID, connection)) ?? [];
   const filteredRows = filterAWSInventoryRows(rows, filters);
   const displayedRows = groupAWSFindingRows(filteredRows).sort(
-    (left, right) => awsFindingSeverityRank(right.category) - awsFindingSeverityRank(left.category) || left.title.localeCompare(right.title) || left.id.localeCompare(right.id)
+    (left, right) => awsFindingSeverityRank(awsFindingDisplaySeverity(right)) - awsFindingSeverityRank(awsFindingDisplaySeverity(left)) || left.title.localeCompare(right.title) || left.id.localeCompare(right.id)
   );
   const [selectedRowID, setSelectedRowID] = useState<string | null>(null);
   const selectedRow = displayedRows.find((row) => row.id === selectedRowID) ?? null;
@@ -19033,7 +19043,7 @@ function AWSFindingsContent({
           }
           columns={[
             { key: 'title', header: 'Finding', render: (row) => row.detailLink ? <Link to={row.detailLink}>{row.title}</Link> : <strong>{row.title}</strong> },
-            { key: 'category', header: 'Severity', render: (row) => <AWSFindingSeverityBadge severity={row.category} /> },
+            { key: 'category', header: 'Severity', render: (row) => <AWSFindingSeverityBadge severity={awsFindingDisplaySeverity(row)} /> },
             { key: 'evidence', header: 'Evidence', render: (row) => <AWSFindingEvidenceCell row={row} /> },
             { key: 'blast', header: 'Blast radius', render: (row) => row.blastRadius },
             { key: 'status', header: 'Status', render: (row) => <AWSFindingStatusBadge status={row.status} showingPersistedScan={showingPersistedScan} /> },

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -26093,8 +26093,11 @@ button.idt-domain-finding-card:focus-visible {
   position: relative;
   display: flex;
   flex-direction: column;
-  width: min(28rem, 100%);
+  width: min(var(--idt-domain-drawer-width, 28rem), 100%);
+  min-width: min(22rem, 100%);
+  max-width: 86vw;
   max-height: 100%;
+  min-height: 0;
   border-left: 1px solid var(--app-border);
   background: #080809;
   color: var(--app-text);
@@ -26103,6 +26106,10 @@ button.idt-domain-finding-card:focus-visible {
   touch-action: pan-y;
   transform: translateX(var(--idt-domain-drawer-swipe-x, 0));
   transition: transform 180ms var(--idt-motion-ease);
+}
+
+.idt-domain-drawer.is-expanded {
+  width: min(72rem, 86vw);
 }
 
 .idt-domain-drawer.is-swiping {
@@ -26115,12 +26122,23 @@ button.idt-domain-finding-card:focus-visible {
 }
 
 .idt-domain-drawer header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
   padding: 1rem;
   border-bottom: 1px solid var(--app-border-soft);
+  background: #080809;
+}
+
+.idt-domain-drawer-header-actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.4rem;
 }
 
 .idt-domain-drawer header h3 {
@@ -26155,9 +26173,68 @@ button.idt-domain-finding-card:focus-visible {
   outline: none;
 }
 
+.idt-domain-drawer-expand {
+  min-width: 2.45rem;
+  height: 1.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 7px;
+  padding: 0 0.55rem;
+  background: rgba(255, 255, 255, 0.045);
+  color: rgba(245, 247, 248, 0.86);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.idt-domain-drawer-expand:hover,
+.idt-domain-drawer-expand:focus-visible {
+  border-color: rgba(174, 161, 255, 0.75);
+  background: rgba(111, 89, 255, 0.16);
+  color: #ffffff;
+  outline: none;
+}
+
+.idt-domain-drawer-resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -0.65rem;
+  z-index: 3;
+  width: 1.3rem;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: ew-resize;
+  touch-action: none;
+}
+
+.idt-domain-drawer-resize-handle::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0.18rem;
+  height: 3.4rem;
+  border-radius: 999px;
+  background: rgba(174, 161, 255, 0.56);
+  content: '';
+  transform: translate(-50%, -50%);
+}
+
+.idt-domain-drawer-resize-handle:hover::after,
+.idt-domain-drawer-resize-handle:focus-visible::after {
+  background: rgba(204, 196, 255, 0.96);
+}
+
+.idt-domain-drawer-resize-handle:focus-visible {
+  outline: none;
+}
+
 .idt-domain-drawer-body {
   flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
+  overscroll-behavior: contain;
   padding: 1rem;
   color: var(--app-text);
 }
@@ -26190,6 +26267,17 @@ button.idt-domain-finding-card:focus-visible {
 
   .idt-domain-remediation-aside {
     align-items: flex-start;
+  }
+
+  .idt-domain-drawer,
+  .idt-domain-drawer.is-expanded {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .idt-domain-drawer-resize-handle {
+    display: none;
   }
 }
 
@@ -30365,6 +30453,11 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   transition: opacity 160ms ease;
 }
 
+body.idt-domain-drawer-open .idt-app-scroll-navigator {
+  opacity: 0 !important;
+  visibility: hidden !important;
+}
+
 .idt-app-scroll-navigator-thumb {
   position: absolute;
   top: 0;
@@ -33351,7 +33444,7 @@ html[data-theme='light'] .idt-danger-modal-typed input {
 .idt-aws-finding-evidence-cell {
   display: grid;
   gap: 0.35rem;
-  min-width: 15rem;
+  min-width: 12rem;
 }
 
 .idt-aws-finding-evidence-cell > small {
@@ -33370,12 +33463,131 @@ html[data-theme='light'] .idt-danger-modal-typed input {
   font-size: 0.75rem;
   font-weight: 700;
   white-space: nowrap;
+  cursor: pointer;
 }
 
 .idt-aws-finding-view-details:hover,
 .idt-aws-finding-view-details:focus-visible {
   border-color: rgba(174, 161, 255, 0.95);
   background: rgba(111, 89, 255, 0.24);
+}
+
+.idt-aws-finding-severity,
+.idt-aws-finding-status {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.2rem 0.48rem;
+  font-size: 0.7rem;
+  font-weight: 800;
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+.idt-aws-finding-severity.is-critical {
+  border-color: rgba(248, 113, 113, 0.72);
+  background: rgba(220, 38, 38, 0.2);
+  color: #ffb4b4;
+}
+
+.idt-aws-finding-severity.is-high {
+  border-color: rgba(251, 171, 64, 0.72);
+  background: rgba(234, 139, 20, 0.18);
+  color: #ffd18d;
+}
+
+.idt-aws-finding-severity.is-medium {
+  border-color: rgba(250, 204, 21, 0.68);
+  background: rgba(245, 180, 25, 0.16);
+  color: #ffe38c;
+}
+
+.idt-aws-finding-severity.is-low {
+  border-color: rgba(96, 165, 250, 0.68);
+  background: rgba(59, 130, 246, 0.16);
+  color: #b5d8ff;
+}
+
+.idt-aws-finding-severity.is-unknown {
+  border-color: rgba(148, 163, 184, 0.58);
+  background: rgba(100, 116, 139, 0.16);
+  color: #d1d9e6;
+}
+
+.idt-aws-finding-status {
+  border-color: rgba(148, 163, 184, 0.5);
+  background: rgba(100, 116, 139, 0.13);
+  color: #d6deea;
+}
+
+.idt-aws-finding-summary {
+  display: grid;
+  gap: 0.8rem;
+  margin-bottom: 0.9rem;
+  border: 1px solid rgba(124, 99, 255, 0.25);
+  border-radius: 0.5rem;
+  padding: 0.9rem 1rem;
+  background: rgba(18, 20, 42, 0.72);
+}
+
+.idt-aws-finding-summary-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-aws-finding-summary-heading strong {
+  display: block;
+  margin-top: 0.2rem;
+  color: var(--idt-text, #f6f7f8);
+}
+
+.idt-aws-finding-summary-note {
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.idt-aws-finding-severity-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.idt-aws-finding-severity-summary-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 0;
+  border: 1px solid rgba(154, 164, 190, 0.2);
+  border-radius: 0.35rem;
+  padding: 0.48rem 0.55rem;
+  background: rgba(4, 8, 18, 0.24);
+}
+
+.idt-aws-finding-severity-summary-item > strong {
+  color: var(--idt-text, #f6f7f8);
+  font-size: 0.9rem;
+}
+
+.idt-aws-finding-detail-badges {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.35rem;
+}
+
+.idt-aws-finding-console-unavailable {
+  margin: 0;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 0.35rem;
+  padding: 0.55rem 0.65rem;
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.78rem;
 }
 
 .idt-aws-finding-detail {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -26109,7 +26109,7 @@ button.idt-domain-finding-card:focus-visible {
 }
 
 .idt-domain-drawer.is-expanded {
-  width: min(72rem, 86vw);
+  width: min(var(--idt-domain-drawer-width, 72rem), 86vw);
 }
 
 .idt-domain-drawer.is-swiping {
@@ -33542,7 +33542,7 @@ html[data-theme='light'] .idt-danger-modal-typed input {
 .idt-aws-finding-summary-heading strong {
   display: block;
   margin-top: 0.2rem;
-  color: var(--idt-text, #f6f7f8);
+  color: var(--app-text);
 }
 
 .idt-aws-finding-summary-note {
@@ -33553,7 +33553,7 @@ html[data-theme='light'] .idt-danger-modal-typed input {
 
 .idt-aws-finding-severity-summary {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 0.6rem;
 }
 
@@ -33570,8 +33570,22 @@ html[data-theme='light'] .idt-danger-modal-typed input {
 }
 
 .idt-aws-finding-severity-summary-item > strong {
-  color: var(--idt-text, #f6f7f8);
+  color: var(--app-text);
   font-size: 0.9rem;
+}
+
+@media (max-width: 720px) {
+  .idt-aws-finding-summary-heading {
+    flex-direction: column;
+  }
+
+  .idt-aws-finding-summary-note {
+    white-space: normal;
+  }
+
+  .idt-aws-finding-severity-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .idt-aws-finding-detail-badges {


### PR DESCRIPTION
## Summary

- prioritize AWS finding groups from Critical to High, Medium, and Low
- separate severity from lifecycle status with clear, accessible badges and a compact priority summary
- tighten the findings header and scan-result messaging, including honest partial and unknown coverage states
- keep the main table scannable by replacing raw evidence paths with normalized resource and scope summaries
- keep technical evidence, related risks, ownership, history, recommended action, and AWS Console navigation in a resizable and expandable details drawer
- lock background scrolling while the drawer is open and hide the decorative page scroll rail so the drawer has one clear scroll context
- add regression coverage for sorting, grouped presentation, drawer resizing/expansion, and state restoration

## Linked issue

Refs #1824

## Verification

- `./node_modules/.bin/vitest run --pool=threads --maxWorkers=1`
- `npm run build`
- 617 web tests passed
- production build passed and prerendered 40 routes

The build reports the existing large-chunk advisory only; it does not fail the build.