### PR TITLE
[AWS Findings] Improve managed-role signal quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 ## Unreleased
+- Improve AWS IAM finding signal quality for AWS-managed service-linked roles
+  and the Identrail connector role (#1825). Expected Security Lake, Support,
+  Trusted Advisor, and Organizations roles no longer emit generic stale,
+  ownerless, or overprivileged noise, while unexpected trust and customer
+  policy changes remain visible as one correlated anomaly. Connector findings
+  now validate the expected account, external-ID condition, and read-only
+  policy boundary, keep the external ID out of evidence, and report confidence,
+  exploitability, actionability, provenance, and evidence completeness
+  separately from severity.
 - Make the AWS connector release and organization rollout production-ready.
   Hosted releases now pin one `dev` commit across migrations, API, worker, and
   an immutable CloudFormation template, enable the registration provider, and

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -26245,6 +26245,19 @@ components:
           type: number
           format: double
           description: Deterministic analyst-facing confidence score for the finding, from 0.0 to 1.0.
+        actionability:
+          type: string
+          enum: [action_required, review, observe_only]
+          description: Operational handling state, kept separate from impact severity.
+        exploitability:
+          type: string
+          enum: [confirmed, plausible, unknown, none_observed]
+        evidence_completeness:
+          type: string
+          description: Completeness of the evidence used to classify the finding.
+        provenance:
+          type: string
+          description: Stable origin of the finding classification.
         title: { type: string }
         human_summary: { type: string }
         path:
@@ -26924,6 +26937,15 @@ components:
         id: { type: string }
         provider: { type: string }
         type: { type: string }
+        identity_kind:
+          type: string
+          enum: [standard, service_linked, connector]
+        managed_by:
+          type: string
+          enum: [customer, aws_service, identrail_connector]
+        actionability:
+          type: string
+          enum: [action_required, review, observe_only]
         name: { type: string }
         arn: { type: string }
         owner_hint: { type: string }

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -925,7 +925,7 @@ func (p *PostgresStore) UpsertFindings(ctx context.Context, scanID string, findi
 		if err != nil {
 			return fmt.Errorf("marshal finding path: %w", err)
 		}
-		evidenceJSON, err := json.Marshal(finding.Evidence)
+		evidenceJSON, err := json.Marshal(findingEvidenceForPersistence(finding))
 		if err != nil {
 			return fmt.Errorf("marshal finding evidence: %w", err)
 		}
@@ -5556,6 +5556,7 @@ func findingsFromSQLRows(rows rowsScanner) ([]domain.Finding, error) {
 				return nil, fmt.Errorf("decode finding evidence: %w", err)
 			}
 		}
+		hydrateFindingMetadataFromEvidence(&finding)
 		result = append(result, finding)
 	}
 	if err := rows.Err(); err != nil {
@@ -5643,12 +5644,80 @@ func findingsWithTriageFromSQLRows(rows rowsScanner, now time.Time) ([]domain.Fi
 				return nil, fmt.Errorf("decode filtered finding evidence: %w", err)
 			}
 		}
+		hydrateFindingMetadataFromEvidence(&finding)
 		result = append(result, finding)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("filtered finding rows: %w", err)
 	}
 	return result, nil
+}
+
+func findingEvidenceForPersistence(finding domain.Finding) map[string]any {
+	evidence := make(map[string]any, len(finding.Evidence)+8)
+	for key, value := range finding.Evidence {
+		evidence[key] = value
+	}
+	if finding.ConfidenceScore != 0 {
+		evidence["confidence_score"] = finding.ConfidenceScore
+	}
+	if finding.Actionability != "" {
+		evidence["actionability"] = finding.Actionability
+	}
+	if finding.Exploitability != "" {
+		evidence["exploitability"] = finding.Exploitability
+	}
+	if finding.EvidenceCompleteness != "" {
+		evidence["evidence_completeness"] = finding.EvidenceCompleteness
+	}
+	if finding.Provenance != "" {
+		evidence["provenance"] = finding.Provenance
+	}
+	if finding.AdapterSource != "" {
+		evidence["adapter_source"] = finding.AdapterSource
+	}
+	if finding.ConfidenceState != "" {
+		evidence["confidence_state"] = finding.ConfidenceState
+	}
+	if finding.EvidenceVersion != "" {
+		evidence["evidence_version"] = finding.EvidenceVersion
+	}
+	return evidence
+}
+
+func hydrateFindingMetadataFromEvidence(finding *domain.Finding) {
+	if finding == nil || len(finding.Evidence) == 0 {
+		return
+	}
+	if confidence, ok := finding.Evidence["confidence_score"].(float64); ok {
+		finding.ConfidenceScore = confidence
+	} else if confidence, ok := finding.Evidence["confidence"].(float64); ok {
+		// Older AWS rows used the display-oriented evidence key.
+		finding.ConfidenceScore = confidence
+	}
+	if value, ok := finding.Evidence["actionability"].(string); ok {
+		finding.Actionability = domain.FindingActionability(value)
+	}
+	if value, ok := finding.Evidence["exploitability"].(string); ok {
+		finding.Exploitability = domain.FindingExploitability(value)
+	}
+	if value, ok := finding.Evidence["evidence_completeness"].(string); ok {
+		finding.EvidenceCompleteness = value
+	}
+	if value, ok := finding.Evidence["provenance"].(string); ok {
+		finding.Provenance = value
+	}
+	if value, ok := finding.Evidence["adapter_source"].(string); ok {
+		finding.AdapterSource = value
+	} else if value, ok := finding.Evidence["source"].(string); ok {
+		finding.AdapterSource = value
+	}
+	if value, ok := finding.Evidence["confidence_state"].(string); ok {
+		finding.ConfidenceState = value
+	}
+	if value, ok := finding.Evidence["evidence_version"].(string); ok {
+		finding.EvidenceVersion = value
+	}
 }
 
 func findingOrderClause(sortBy string, desc bool) string {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"regexp"
@@ -14,6 +16,30 @@ import (
 	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/providers"
 )
+
+type jsonSubsetMatcher map[string]any
+
+func (m jsonSubsetMatcher) Match(value driver.Value) bool {
+	var encoded []byte
+	switch typed := value.(type) {
+	case []byte:
+		encoded = typed
+	case string:
+		encoded = []byte(typed)
+	default:
+		return false
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return false
+	}
+	for key, expected := range m {
+		if !reflect.DeepEqual(decoded[key], expected) {
+			return false
+		}
+	}
+	return true
+}
 
 func TestPostgresStoreCreateAndCompleteScan(t *testing.T) {
 	db, mock, err := sqlmock.New()
@@ -105,20 +131,37 @@ func TestPostgresStoreUpsertFindings(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO findings").
-		WithArgs("scan-1", "f1", "risky_trust_policy", "high", "Risky trust", "summary", sqlmock.AnyArg(), sqlmock.AnyArg(), "fix", sqlmock.AnyArg()).
+		WithArgs("scan-1", "f1", "risky_trust_policy", "high", "Risky trust", "summary", sqlmock.AnyArg(), jsonSubsetMatcher{
+			"confidence_score":      0.95,
+			"actionability":         "review",
+			"exploitability":        "plausible",
+			"evidence_completeness": "complete",
+			"provenance":            "aws_iam_inventory",
+			"adapter_source":        "aws_iam_rule_engine",
+			"confidence_state":      "inventory_backed",
+			"evidence_version":      "aws-finding-v2",
+		}, "fix", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
 	findings := []domain.Finding{{
-		ID:           "f1",
-		Type:         domain.FindingRiskyTrustPolicy,
-		Severity:     domain.SeverityHigh,
-		Title:        "Risky trust",
-		HumanSummary: "summary",
-		Path:         []string{"a", "b"},
-		Evidence:     map[string]any{"k": "v"},
-		Remediation:  "fix",
-		CreatedAt:    time.Now(),
+		ID:                   "f1",
+		Type:                 domain.FindingRiskyTrustPolicy,
+		Severity:             domain.SeverityHigh,
+		ConfidenceScore:      0.95,
+		Actionability:        domain.FindingActionabilityReview,
+		Exploitability:       domain.FindingExploitabilityPlausible,
+		EvidenceCompleteness: "complete",
+		Provenance:           "aws_iam_inventory",
+		Title:                "Risky trust",
+		HumanSummary:         "summary",
+		Path:                 []string{"a", "b"},
+		Evidence:             map[string]any{"k": "v"},
+		Remediation:          "fix",
+		CreatedAt:            time.Now(),
+		AdapterSource:        "aws_iam_rule_engine",
+		ConfidenceState:      "inventory_backed",
+		EvidenceVersion:      "aws-finding-v2",
 	}}
 
 	if err := store.UpsertFindings(defaultScopeContext(), "scan-1", findings); err != nil {
@@ -255,7 +298,7 @@ func TestPostgresStoreListScansAndFindings(t *testing.T) {
 	}
 
 	findingsRows := sqlmock.NewRows([]string{"scan_id", "finding_id", "type", "severity", "title", "human_summary", "path", "evidence", "remediation", "created_at"}).
-		AddRow("scan-1", "f1", "ownerless_identity", "medium", "Ownerless", "summary", []byte("[\"x\"]"), []byte("{\"a\":1}"), "fix", now)
+		AddRow("scan-1", "f1", "ownerless_identity", "medium", "Ownerless", "summary", []byte("[\"x\"]"), []byte(`{"confidence_score":0.95,"actionability":"review","exploitability":"plausible","evidence_completeness":"complete","provenance":"aws_iam_inventory","adapter_source":"aws_iam_rule_engine","confidence_state":"inventory_backed","evidence_version":"aws-finding-v2"}`), "fix", now)
 	mock.ExpectQuery("SELECT f.scan_id, f.finding_id, f.type").WithArgs("default", "default", 100).WillReturnRows(findingsRows)
 
 	findings, err := store.ListFindings(defaultScopeContext(), 100)
@@ -264,6 +307,10 @@ func TestPostgresStoreListScansAndFindings(t *testing.T) {
 	}
 	if len(findings) != 1 || findings[0].ID != "f1" {
 		t.Fatalf("unexpected findings: %+v", findings)
+	}
+	metadata := findings[0]
+	if metadata.ConfidenceScore != 0.95 || metadata.Actionability != domain.FindingActionabilityReview || metadata.Exploitability != domain.FindingExploitabilityPlausible || metadata.EvidenceCompleteness != "complete" || metadata.Provenance != "aws_iam_inventory" || metadata.AdapterSource != "aws_iam_rule_engine" || metadata.ConfidenceState != "inventory_backed" || metadata.EvidenceVersion != "aws-finding-v2" {
+		t.Fatalf("finding metadata did not survive the Postgres row boundary: %+v", metadata)
 	}
 
 	allFindingsRows := sqlmock.NewRows([]string{"scan_id", "finding_id", "type", "severity", "title", "human_summary", "path", "evidence", "remediation", "created_at"}).

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -130,6 +130,44 @@ const (
 	AgentTypeUnknown AgentType = "agent"
 )
 
+// IdentityKind distinguishes customer-controlled identities from identities
+// whose lifecycle is owned by a cloud service or a known connector.
+type IdentityKind string
+
+const (
+	IdentityKindStandard      IdentityKind = "standard"
+	IdentityKindServiceLinked IdentityKind = "service_linked"
+	IdentityKindConnector     IdentityKind = "connector"
+)
+
+// IdentityManagedBy records the control plane responsible for an identity.
+type IdentityManagedBy string
+
+const (
+	IdentityManagedByCustomer   IdentityManagedBy = "customer"
+	IdentityManagedByAWSService IdentityManagedBy = "aws_service"
+	IdentityManagedByIdentrail  IdentityManagedBy = "identrail_connector"
+)
+
+// FindingActionability separates operational next action from impact severity.
+type FindingActionability string
+
+const (
+	FindingActionabilityActionRequired FindingActionability = "action_required"
+	FindingActionabilityReview         FindingActionability = "review"
+	FindingActionabilityObserveOnly    FindingActionability = "observe_only"
+)
+
+// FindingExploitability describes whether evidence demonstrates a usable path.
+type FindingExploitability string
+
+const (
+	FindingExploitabilityConfirmed FindingExploitability = "confirmed"
+	FindingExploitabilityPlausible FindingExploitability = "plausible"
+	FindingExploitabilityUnknown   FindingExploitability = "unknown"
+	FindingExploitabilityNone      FindingExploitability = "none_observed"
+)
+
 // RuntimeEventType identifies observed action semantics during scan execution.
 type RuntimeEventType string
 
@@ -200,16 +238,19 @@ func DefaultFindingTriage() FindingTriage {
 
 // Identity is a normalized machine identity across providers.
 type Identity struct {
-	ID         string            `json:"id"`
-	Provider   Provider          `json:"provider"`
-	Type       IdentityType      `json:"type"`
-	Name       string            `json:"name"`
-	ARN        string            `json:"arn"`
-	OwnerHint  string            `json:"owner_hint"`
-	CreatedAt  time.Time         `json:"created_at"`
-	LastUsedAt *time.Time        `json:"last_used_at,omitempty"`
-	Tags       map[string]string `json:"tags,omitempty"`
-	RawRef     string            `json:"raw_ref"`
+	ID            string               `json:"id"`
+	Provider      Provider             `json:"provider"`
+	Type          IdentityType         `json:"type"`
+	IdentityKind  IdentityKind         `json:"identity_kind,omitempty"`
+	ManagedBy     IdentityManagedBy    `json:"managed_by,omitempty"`
+	Actionability FindingActionability `json:"actionability,omitempty"`
+	Name          string               `json:"name"`
+	ARN           string               `json:"arn"`
+	OwnerHint     string               `json:"owner_hint"`
+	CreatedAt     time.Time            `json:"created_at"`
+	LastUsedAt    *time.Time           `json:"last_used_at,omitempty"`
+	Tags          map[string]string    `json:"tags,omitempty"`
+	RawRef        string               `json:"raw_ref"`
 }
 
 // Workload is a compute entity that can execute with one or more identities.
@@ -313,6 +354,10 @@ type Finding struct {
 	Type                 FindingType                `json:"type"`
 	Severity             FindingSeverity            `json:"severity"`
 	ConfidenceScore      float64                    `json:"confidence_score,omitempty"`
+	Actionability        FindingActionability       `json:"actionability,omitempty"`
+	Exploitability       FindingExploitability      `json:"exploitability,omitempty"`
+	EvidenceCompleteness string                     `json:"evidence_completeness,omitempty"`
+	Provenance           string                     `json:"provenance,omitempty"`
 	Title                string                     `json:"title"`
 	HumanSummary         string                     `json:"human_summary"`
 	Path                 []string                   `json:"path,omitempty"`

--- a/internal/providers/aws/model.go
+++ b/internal/providers/aws/model.go
@@ -24,12 +24,13 @@ type iamPolicyDocument struct {
 type iamPolicyStatements []iamPolicyStatement
 
 type iamPolicyStatement struct {
-	Effect    string         `json:"Effect"`
-	Action    any            `json:"Action,omitempty"`
-	NotAction any            `json:"NotAction,omitempty"`
-	Resource  any            `json:"Resource,omitempty"`
-	Principal any            `json:"Principal,omitempty"`
-	Condition map[string]any `json:"Condition,omitempty"`
+	Effect      string         `json:"Effect"`
+	Action      any            `json:"Action,omitempty"`
+	NotAction   any            `json:"NotAction,omitempty"`
+	Resource    any            `json:"Resource,omitempty"`
+	NotResource any            `json:"NotResource,omitempty"`
+	Principal   any            `json:"Principal,omitempty"`
+	Condition   map[string]any `json:"Condition,omitempty"`
 }
 
 func (s *iamPolicyStatements) UnmarshalJSON(data []byte) error {

--- a/internal/providers/aws/model.go
+++ b/internal/providers/aws/model.go
@@ -26,6 +26,7 @@ type iamPolicyStatements []iamPolicyStatement
 type iamPolicyStatement struct {
 	Effect    string         `json:"Effect"`
 	Action    any            `json:"Action,omitempty"`
+	NotAction any            `json:"NotAction,omitempty"`
 	Resource  any            `json:"Resource,omitempty"`
 	Principal any            `json:"Principal,omitempty"`
 	Condition map[string]any `json:"Condition,omitempty"`

--- a/internal/providers/aws/model.go
+++ b/internal/providers/aws/model.go
@@ -9,8 +9,10 @@ import (
 
 // IAMPermissionPolicy stores an identity permission policy with provider-native JSON.
 type IAMPermissionPolicy struct {
-	Name     string `json:"name"`
-	Document string `json:"document"`
+	Name           string `json:"name"`
+	ARN            string `json:"arn,omitempty"`
+	AttachmentType string `json:"attachment_type,omitempty"`
+	Document       string `json:"document"`
 }
 
 // iamPolicyDocument models the subset of IAM policy grammar used in phase 1.
@@ -22,10 +24,11 @@ type iamPolicyDocument struct {
 type iamPolicyStatements []iamPolicyStatement
 
 type iamPolicyStatement struct {
-	Effect    string `json:"Effect"`
-	Action    any    `json:"Action,omitempty"`
-	Resource  any    `json:"Resource,omitempty"`
-	Principal any    `json:"Principal,omitempty"`
+	Effect    string         `json:"Effect"`
+	Action    any            `json:"Action,omitempty"`
+	Resource  any            `json:"Resource,omitempty"`
+	Principal any            `json:"Principal,omitempty"`
+	Condition map[string]any `json:"Condition,omitempty"`
 }
 
 func (s *iamPolicyStatements) UnmarshalJSON(data []byte) error {
@@ -156,4 +159,17 @@ func parseAWSPrincipals(principal any) []string {
 		return nil
 	}
 	return dedupeStrings(parseStringList(values))
+}
+
+func parsePrincipalType(principal any, principalType string) []string {
+	principalMap, ok := principal.(map[string]any)
+	if !ok {
+		return nil
+	}
+	for key, value := range principalMap {
+		if strings.EqualFold(strings.TrimSpace(key), principalType) {
+			return dedupeStrings(parseStringList(value))
+		}
+	}
+	return nil
 }

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -17,6 +17,7 @@ const (
 	identityIDKey        = "identity_id"
 	statementsKey        = "statements"
 	notActionsKey        = "not_actions"
+	notResourcesKey      = "not_resources"
 	principalsKey        = "principals"
 	servicePrincipalsKey = "service_principals"
 	policyARNKey         = "policy_arn"
@@ -1787,7 +1788,8 @@ func normalizePermissionPolicies(identityID string, policies []IAMPermissionPoli
 			actions := parseStringList(statement.Action)
 			notActions := parseStringList(statement.NotAction)
 			resources := parseStringList(statement.Resource)
-			if (len(actions) == 0 && len(notActions) == 0) || len(resources) == 0 {
+			notResources := parseStringList(statement.NotResource)
+			if (len(actions) == 0 && len(notActions) == 0) || (len(resources) == 0 && len(notResources) == 0) {
 				continue
 			}
 			normalized, ok := normalizedStatement(statement.Effect, actions, resources)
@@ -1796,6 +1798,9 @@ func normalizePermissionPolicies(identityID string, policies []IAMPermissionPoli
 			}
 			if len(notActions) > 0 {
 				normalized[notActionsKey] = dedupeStrings(notActions)
+			}
+			if len(notResources) > 0 {
+				normalized[notResourcesKey] = dedupeStrings(notResources)
 			}
 			statements = append(statements, normalized)
 		}

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -16,6 +16,7 @@ const (
 	policyTypeTrust      = "trust"
 	identityIDKey        = "identity_id"
 	statementsKey        = "statements"
+	notActionsKey        = "not_actions"
 	principalsKey        = "principals"
 	servicePrincipalsKey = "service_principals"
 	policyARNKey         = "policy_arn"
@@ -1784,13 +1785,17 @@ func normalizePermissionPolicies(identityID string, policies []IAMPermissionPoli
 		statements := make([]map[string]any, 0, len(doc.Statement))
 		for _, statement := range doc.Statement {
 			actions := parseStringList(statement.Action)
+			notActions := parseStringList(statement.NotAction)
 			resources := parseStringList(statement.Resource)
-			if len(actions) == 0 || len(resources) == 0 {
+			if (len(actions) == 0 && len(notActions) == 0) || len(resources) == 0 {
 				continue
 			}
 			normalized, ok := normalizedStatement(statement.Effect, actions, resources)
 			if !ok {
 				continue
+			}
+			if len(notActions) > 0 {
+				normalized[notActionsKey] = dedupeStrings(notActions)
 			}
 			statements = append(statements, normalized)
 		}

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -11,12 +11,15 @@ import (
 )
 
 const (
-	policyTypeKey   = "policy_type"
-	policyTypePerm  = "permission"
-	policyTypeTrust = "trust"
-	identityIDKey   = "identity_id"
-	statementsKey   = "statements"
-	principalsKey   = "principals"
+	policyTypeKey        = "policy_type"
+	policyTypePerm       = "permission"
+	policyTypeTrust      = "trust"
+	identityIDKey        = "identity_id"
+	statementsKey        = "statements"
+	principalsKey        = "principals"
+	servicePrincipalsKey = "service_principals"
+	policyARNKey         = "policy_arn"
+	attachmentTypeKey    = "attachment_type"
 )
 
 // RoleNormalizer transforms raw IAM role assets into provider-agnostic entities.
@@ -309,18 +312,22 @@ func normalizeIAMRoleAsset(asset providers.RawAsset, index int, bundle *provider
 
 	identityID := identityIDFromARN(arn)
 	if _, exists := identitySeen[identityID]; !exists {
+		identityKind, managedBy, actionability := classifyIAMRoleIdentity(role)
 		identitySeen[identityID] = struct{}{}
 		bundle.Identities = append(bundle.Identities, domain.Identity{
-			ID:         identityID,
-			Provider:   domain.ProviderAWS,
-			Type:       domain.IdentityTypeRole,
-			Name:       strings.TrimSpace(role.Name),
-			ARN:        arn,
-			OwnerHint:  ownerHintFromTags(role.Tags),
-			CreatedAt:  derefTimeOrZero(role.CreatedAt),
-			LastUsedAt: role.LastUsedAt,
-			Tags:       copyTags(role.Tags),
-			RawRef:     asset.SourceID,
+			ID:            identityID,
+			Provider:      domain.ProviderAWS,
+			Type:          domain.IdentityTypeRole,
+			IdentityKind:  identityKind,
+			ManagedBy:     managedBy,
+			Actionability: actionability,
+			Name:          strings.TrimSpace(role.Name),
+			ARN:           arn,
+			OwnerHint:     ownerHintFromTags(role.Tags),
+			CreatedAt:     derefTimeOrZero(role.CreatedAt),
+			LastUsedAt:    role.LastUsedAt,
+			Tags:          copyTags(role.Tags),
+			RawRef:        asset.SourceID,
 		})
 	}
 
@@ -1798,9 +1805,11 @@ func normalizePermissionPolicies(identityID string, policies []IAMPermissionPoli
 			Name:     policy.Name,
 			Document: []byte(policy.Document),
 			Normalized: map[string]any{
-				policyTypeKey: policyTypePerm,
-				identityIDKey: identityID,
-				statementsKey: statements,
+				policyTypeKey:     policyTypePerm,
+				identityIDKey:     identityID,
+				statementsKey:     statements,
+				policyARNKey:      strings.TrimSpace(policy.ARN),
+				attachmentTypeKey: strings.TrimSpace(policy.AttachmentType),
 			},
 			RawRef: identityID,
 		})
@@ -1818,14 +1827,17 @@ func normalizeTrustPolicy(identityID, rawTrustDocument string) (*domain.Policy, 
 	}
 
 	principals := make([]string, 0, len(doc.Statement))
+	servicePrincipals := make([]string, 0, len(doc.Statement))
 	for _, statement := range doc.Statement {
 		if !strings.EqualFold(statement.Effect, "allow") {
 			continue
 		}
 		principals = append(principals, parseAWSPrincipals(statement.Principal)...)
+		servicePrincipals = append(servicePrincipals, parsePrincipalType(statement.Principal, "Service")...)
 	}
 	principals = dedupeStrings(principals)
-	if len(principals) == 0 {
+	servicePrincipals = dedupeStrings(servicePrincipals)
+	if len(principals) == 0 && len(servicePrincipals) == 0 {
 		return nil, nil
 	}
 
@@ -1835,9 +1847,10 @@ func normalizeTrustPolicy(identityID, rawTrustDocument string) (*domain.Policy, 
 		Name:     "assume-role-trust",
 		Document: []byte(rawTrustDocument),
 		Normalized: map[string]any{
-			policyTypeKey: policyTypeTrust,
-			identityIDKey: identityID,
-			principalsKey: principals,
+			policyTypeKey:        policyTypeTrust,
+			identityIDKey:        identityID,
+			principalsKey:        principals,
+			servicePrincipalsKey: servicePrincipals,
 		},
 		RawRef: identityID,
 	}, nil

--- a/internal/providers/aws/role_classification.go
+++ b/internal/providers/aws/role_classification.go
@@ -1,0 +1,413 @@
+package aws
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/providers"
+)
+
+const (
+	identrailConnectorRoleName = "IdentrailReadOnly"
+	awsFindingProvenance       = "aws_iam_inventory"
+	awsFindingAdapterSource    = "aws_iam_rule_engine"
+	awsFindingEvidenceVersion  = "aws-finding-v2"
+)
+
+type serviceLinkedRoleExpectation struct {
+	RoleName         string
+	ServicePrincipal string
+}
+
+var expectedServiceLinkedRoles = map[string]serviceLinkedRoleExpectation{
+	"awsserviceroleforamazonsecuritylake": {
+		RoleName:         "AWSServiceRoleForAmazonSecurityLake",
+		ServicePrincipal: "securitylake.amazonaws.com",
+	},
+	"awsserviceroleforsupport": {
+		RoleName:         "AWSServiceRoleForSupport",
+		ServicePrincipal: "support.amazonaws.com",
+	},
+	"awsservicerolefortrustedadvisor": {
+		RoleName:         "AWSServiceRoleForTrustedAdvisor",
+		ServicePrincipal: "trustedadvisor.amazonaws.com",
+	},
+	"awsservicerolefororganizations": {
+		RoleName:         "AWSServiceRoleForOrganizations",
+		ServicePrincipal: "organizations.amazonaws.com",
+	},
+}
+
+// ConnectorRoleExpectation is the live connector contract used to distinguish
+// expected cross-account trust from actual trust drift. ExternalID is compared
+// in memory and is never copied into finding evidence.
+type ConnectorRoleExpectation struct {
+	RoleARN          string
+	AccountID        string
+	TrustedAccountID string
+	ExternalID       string
+}
+
+func classifyIAMRoleIdentity(role IAMRole) (domain.IdentityKind, domain.IdentityManagedBy, domain.FindingActionability) {
+	name := strings.TrimSpace(role.Name)
+	if isIdentrailConnectorRole(name, role.Tags) {
+		return domain.IdentityKindConnector, domain.IdentityManagedByIdentrail, domain.FindingActionabilityReview
+	}
+	if strings.HasPrefix(strings.ToLower(name), "awsservicerolefor") || strings.Contains(strings.ToLower(strings.TrimSpace(role.Path)), "/aws-service-role/") {
+		return domain.IdentityKindServiceLinked, domain.IdentityManagedByAWSService, domain.FindingActionabilityObserveOnly
+	}
+	return domain.IdentityKindStandard, domain.IdentityManagedByCustomer, domain.FindingActionabilityActionRequired
+}
+
+func isIdentrailConnectorRole(name string, tags map[string]string) bool {
+	if strings.EqualFold(strings.TrimSpace(name), identrailConnectorRoleName) {
+		return true
+	}
+	for key := range tags {
+		if strings.EqualFold(strings.TrimSpace(key), "IdentrailConnectorMode") {
+			return true
+		}
+	}
+	return false
+}
+
+func expectedServiceLinkedRole(identity domain.Identity) (serviceLinkedRoleExpectation, bool) {
+	expectation, ok := expectedServiceLinkedRoles[strings.ToLower(strings.TrimSpace(identity.Name))]
+	return expectation, ok
+}
+
+func isExpectedAWSManagedPolicyARN(policyARN string) bool {
+	parts := strings.Split(strings.TrimSpace(policyARN), ":")
+	return len(parts) >= 6 && parts[2] == "iam" && parts[4] == "aws" && strings.HasPrefix(strings.ToLower(parts[5]), "policy/aws-service-role/")
+}
+
+func permissionPoliciesForIdentity(bundle providers.NormalizedBundle, identityID string) []domain.Policy {
+	policies := make([]domain.Policy, 0)
+	for _, policy := range bundle.Policies {
+		policyType, _ := policy.Normalized[policyTypeKey].(string)
+		policyIdentityID, _ := policy.Normalized[identityIDKey].(string)
+		if policyType == policyTypePerm && policyIdentityID == identityID {
+			policies = append(policies, policy)
+		}
+	}
+	return policies
+}
+
+func trustPolicyForIdentity(bundle providers.NormalizedBundle, identityID string) *domain.Policy {
+	for i := range bundle.Policies {
+		policy := &bundle.Policies[i]
+		policyType, _ := policy.Normalized[policyTypeKey].(string)
+		policyIdentityID, _ := policy.Normalized[identityIDKey].(string)
+		if policyType == policyTypeTrust && policyIdentityID == identityID {
+			return policy
+		}
+	}
+	return nil
+}
+
+type trustPolicyFacts struct {
+	AWSPrincipals     []string
+	ServicePrincipals []string
+	OtherPrincipals   []string
+	ExternalIDs       []string
+	AllowsAssumeRole  bool
+}
+
+func inspectTrustPolicy(policy *domain.Policy) trustPolicyFacts {
+	if policy == nil {
+		return trustPolicyFacts{}
+	}
+	doc, err := parsePolicyDocument(string(policy.Document))
+	if err != nil {
+		return trustPolicyFacts{}
+	}
+	facts := trustPolicyFacts{}
+	for _, statement := range doc.Statement {
+		if !strings.EqualFold(strings.TrimSpace(statement.Effect), "allow") {
+			continue
+		}
+		for _, action := range parseStringList(statement.Action) {
+			if strings.EqualFold(strings.TrimSpace(action), "sts:AssumeRole") {
+				facts.AllowsAssumeRole = true
+			}
+		}
+		facts.AWSPrincipals = append(facts.AWSPrincipals, parseAWSPrincipals(statement.Principal)...)
+		facts.ServicePrincipals = append(facts.ServicePrincipals, parsePrincipalType(statement.Principal, "Service")...)
+		facts.OtherPrincipals = append(facts.OtherPrincipals, parsePrincipalType(statement.Principal, "Federated")...)
+		facts.OtherPrincipals = append(facts.OtherPrincipals, parsePrincipalType(statement.Principal, "CanonicalUser")...)
+		facts.ExternalIDs = append(facts.ExternalIDs, conditionValues(statement.Condition, "sts:ExternalId")...)
+	}
+	facts.AWSPrincipals = sortedUniqueStrings(facts.AWSPrincipals)
+	facts.ServicePrincipals = sortedUniqueStrings(facts.ServicePrincipals)
+	facts.OtherPrincipals = sortedUniqueStrings(facts.OtherPrincipals)
+	facts.ExternalIDs = sortedUniqueStrings(facts.ExternalIDs)
+	return facts
+}
+
+func conditionValues(condition map[string]any, wantedKey string) []string {
+	values := []string{}
+	for _, operatorValue := range condition {
+		operatorMap, ok := operatorValue.(map[string]any)
+		if !ok {
+			continue
+		}
+		for key, value := range operatorMap {
+			if strings.EqualFold(strings.TrimSpace(key), wantedKey) {
+				values = append(values, parseStringList(value)...)
+			}
+		}
+	}
+	return sortedUniqueStrings(values)
+}
+
+func sortedUniqueStrings(values []string) []string {
+	values = dedupeStrings(values)
+	sort.Strings(values)
+	return values
+}
+
+func expectedServiceLinkedRoleSignals(bundle providers.NormalizedBundle, identity domain.Identity, expectation serviceLinkedRoleExpectation, hasBroadAccess bool) []string {
+	signals := []string{}
+	facts := inspectTrustPolicy(trustPolicyForIdentity(bundle, identity.ID))
+	if !facts.AllowsAssumeRole || len(facts.ServicePrincipals) != 1 || !strings.EqualFold(facts.ServicePrincipals[0], expectation.ServicePrincipal) || len(facts.AWSPrincipals) > 0 || len(facts.OtherPrincipals) > 0 {
+		signals = append(signals, "unexpected_trust")
+	}
+	customerPolicy := false
+	for _, policy := range permissionPoliciesForIdentity(bundle, identity.ID) {
+		policyARN, _ := policy.Normalized[policyARNKey].(string)
+		attachmentType, _ := policy.Normalized[attachmentTypeKey].(string)
+		if !isExpectedAWSManagedPolicyARN(policyARN) || !strings.EqualFold(strings.TrimSpace(attachmentType), "managed") {
+			customerPolicy = true
+			break
+		}
+	}
+	if customerPolicy {
+		signals = append(signals, "customer_added_policy")
+		if hasBroadAccess {
+			signals = append(signals, "unexpected_permission_reachability")
+		}
+	}
+	return sortedUniqueStrings(signals)
+}
+
+func connectorRoleSignals(bundle providers.NormalizedBundle, identity domain.Identity, expectation ConnectorRoleExpectation) (signals []string, completeness string) {
+	completeness = "complete"
+	if expectedARN := strings.TrimSpace(expectation.RoleARN); expectedARN != "" && !strings.EqualFold(strings.TrimSpace(identity.ARN), expectedARN) {
+		signals = append(signals, "connector_role_mismatch")
+	}
+	if expectedAccount := strings.TrimSpace(expectation.AccountID); expectedAccount != "" && accountIDFromARN(identity.ARN) != expectedAccount {
+		signals = append(signals, "connector_account_mismatch")
+	}
+
+	policy := trustPolicyForIdentity(bundle, identity.ID)
+	facts := inspectTrustPolicy(policy)
+	if policy == nil {
+		completeness = "partial"
+		signals = append(signals, "trust_evidence_missing")
+	} else {
+		expectedTrustedAccount := strings.TrimSpace(expectation.TrustedAccountID)
+		if expectedTrustedAccount == "" {
+			completeness = "partial"
+			signals = append(signals, "trusted_account_expectation_missing")
+		} else if !facts.AllowsAssumeRole || len(facts.AWSPrincipals) != 1 || accountIDFromPrincipal(facts.AWSPrincipals[0]) != expectedTrustedAccount || len(facts.ServicePrincipals) > 0 || len(facts.OtherPrincipals) > 0 {
+			signals = append(signals, "unexpected_trust")
+		}
+
+		expectedExternalID := strings.TrimSpace(expectation.ExternalID)
+		if expectedExternalID == "" {
+			completeness = "partial"
+			signals = append(signals, "external_id_expectation_missing")
+		} else if len(facts.ExternalIDs) != 1 || facts.ExternalIDs[0] != expectedExternalID {
+			signals = append(signals, "external_id_mismatch")
+		}
+	}
+
+	permissionPolicies := permissionPoliciesForIdentity(bundle, identity.ID)
+	if len(permissionPolicies) == 0 {
+		completeness = "partial"
+		signals = append(signals, "permission_evidence_missing")
+	} else if connectorPermissionScopeExpanded(permissionPolicies) {
+		signals = append(signals, "permission_scope_expanded")
+	}
+	return sortedUniqueStrings(signals), completeness
+}
+
+func connectorPermissionScopeExpanded(policies []domain.Policy) bool {
+	for _, policy := range policies {
+		statements, err := parseNormalizedStatements(policy.Normalized[statementsKey])
+		if err != nil {
+			return true
+		}
+		for _, statement := range statements {
+			effect, _ := statement["effect"].(string)
+			if !strings.EqualFold(effect, "Allow") {
+				continue
+			}
+			for _, action := range parseStringList(statement["actions"]) {
+				if !isConnectorReadOnlyAction(action) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func isConnectorReadOnlyAction(action string) bool {
+	action = strings.TrimSpace(action)
+	parts := strings.SplitN(action, ":", 2)
+	if len(parts) != 2 || strings.Contains(parts[1], "*") {
+		return false
+	}
+	operation := strings.ToLower(parts[1])
+	for _, prefix := range []string{"get", "list", "describe", "batchget", "lookup", "search", "simulate"} {
+		if strings.HasPrefix(operation, prefix) {
+			return true
+		}
+	}
+	return strings.EqualFold(action, "iam:GenerateServiceLastAccessedDetails")
+}
+
+func managedRoleAnomalyFinding(identity domain.Identity, expectation serviceLinkedRoleExpectation, signals []string, now time.Time) domain.Finding {
+	finding := domain.Finding{
+		ID:                   findingID(domain.FindingRiskyTrustPolicy, identity.ID, strings.Join(signals, ",")),
+		Type:                 domain.FindingRiskyTrustPolicy,
+		Severity:             domain.SeverityHigh,
+		ConfidenceScore:      0.95,
+		Actionability:        domain.FindingActionabilityReview,
+		Exploitability:       domain.FindingExploitabilityPlausible,
+		EvidenceCompleteness: "complete",
+		Provenance:           awsFindingProvenance,
+		Title:                fmt.Sprintf("AWS-managed role anomaly: %s", displayIdentity(identity)),
+		HumanSummary:         "This expected AWS service-linked role differs from its managed trust or policy boundary and needs investigation without directly editing the role.",
+		Path:                 []string{identity.ID},
+		Evidence: map[string]any{
+			"identity_id":                identity.ID,
+			"identity_arn":               identity.ARN,
+			"expected_service_principal": expectation.ServicePrincipal,
+			"contributing_signals":       signals,
+		},
+		Remediation: "Review the owning AWS service configuration and CloudTrail history. Restore the service-linked role through the AWS service workflow instead of editing it directly.",
+		CreatedAt:   now,
+	}
+	decorateAWSFinding(&finding, identity, signals, now)
+	return finding
+}
+
+func connectorTrustReviewFinding(identity domain.Identity, signals []string, completeness string, now time.Time) domain.Finding {
+	actionability := domain.FindingActionabilityObserveOnly
+	severity := domain.SeverityInfo
+	exploitability := domain.FindingExploitabilityNone
+	title := fmt.Sprintf("Connector trust review: %s", displayIdentity(identity))
+	summary := "The Identrail connector role matches the expected account, external-ID trust condition, and read-only permission boundary."
+	remediation := "No direct AWS change is recommended. Continue monitoring the connector trust and read-only policy for drift."
+	invalid := false
+	for _, signal := range signals {
+		if !strings.HasSuffix(signal, "_missing") {
+			invalid = true
+			break
+		}
+	}
+	if invalid {
+		actionability = domain.FindingActionabilityActionRequired
+		severity = domain.SeverityHigh
+		exploitability = domain.FindingExploitabilityPlausible
+		title = fmt.Sprintf("Connector role configuration drift: %s", displayIdentity(identity))
+		summary = "The Identrail connector role no longer matches its expected account, external-ID trust, or read-only permission boundary."
+		remediation = "Restore the connector trust and collector policy from the Identrail onboarding template. Do not add permissions or weaken the external-ID condition."
+	} else if len(signals) > 0 {
+		actionability = domain.FindingActionabilityReview
+		exploitability = domain.FindingExploitabilityUnknown
+		summary = "The role is recognized as the Identrail connector, but available evidence is insufficient to prove that every trust and read-only policy invariant still matches."
+		remediation = "Refresh connector validation and the IAM policy inventory before treating the role as safe."
+	}
+	confidence := 0.95
+	if !invalid && completeness != "complete" {
+		confidence = 0.72
+	}
+	finding := domain.Finding{
+		ID:                   findingID(domain.FindingRiskyTrustPolicy, identity.ID, "connector-review|"+strings.Join(signals, ",")),
+		Type:                 domain.FindingRiskyTrustPolicy,
+		Severity:             severity,
+		ConfidenceScore:      confidence,
+		Actionability:        actionability,
+		Exploitability:       exploitability,
+		EvidenceCompleteness: completeness,
+		Provenance:           awsFindingProvenance,
+		Title:                title,
+		HumanSummary:         summary,
+		Path:                 []string{identity.ID},
+		Evidence: map[string]any{
+			"identity_id":                 identity.ID,
+			"identity_arn":                identity.ARN,
+			"external_id_condition_valid": !stringSliceContains(signals, "external_id_expectation_missing") && !stringSliceContains(signals, "external_id_mismatch"),
+			"contributing_signals":        signals,
+		},
+		Remediation: remediation,
+		CreatedAt:   now,
+	}
+	decorateAWSFinding(&finding, identity, signals, now)
+	return finding
+}
+
+func stringSliceContains(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func decorateAWSFinding(finding *domain.Finding, identity domain.Identity, signals []string, now time.Time) {
+	if finding == nil {
+		return
+	}
+	if finding.ConfidenceScore == 0 {
+		finding.ConfidenceScore = 0.9
+	}
+	if finding.Actionability == "" {
+		finding.Actionability = domain.FindingActionabilityActionRequired
+	}
+	if finding.Exploitability == "" {
+		finding.Exploitability = domain.FindingExploitabilityUnknown
+	}
+	if finding.EvidenceCompleteness == "" {
+		finding.EvidenceCompleteness = "complete"
+	}
+	if finding.Provenance == "" {
+		finding.Provenance = awsFindingProvenance
+	}
+	finding.AdapterSource = awsFindingAdapterSource
+	finding.ConfidenceState = "inventory_backed"
+	finding.EvidenceVersion = awsFindingEvidenceVersion
+	if finding.Evidence == nil {
+		finding.Evidence = map[string]any{}
+	}
+	identityKind := identity.IdentityKind
+	if identityKind == "" {
+		identityKind = domain.IdentityKindStandard
+	}
+	managedBy := identity.ManagedBy
+	if managedBy == "" {
+		managedBy = domain.IdentityManagedByCustomer
+	}
+	finding.Evidence["account_id"] = accountIDFromARN(identity.ARN)
+	finding.Evidence["region"] = "global"
+	finding.Evidence["source"] = awsFindingAdapterSource
+	finding.Evidence["observed_at"] = now.Format(time.RFC3339)
+	finding.Evidence["provenance"] = finding.Provenance
+	finding.Evidence["confidence"] = finding.ConfidenceScore
+	finding.Evidence["identity_kind"] = identityKind
+	finding.Evidence["managed_by"] = managedBy
+	finding.Evidence["actionability"] = finding.Actionability
+	finding.Evidence["exploitability"] = finding.Exploitability
+	finding.Evidence["evidence_completeness"] = finding.EvidenceCompleteness
+	finding.Evidence["evidence_boundary"] = "IAM role inventory, trust policy, and collected permission policies"
+	if len(signals) > 0 {
+		finding.Evidence["contributing_signals"] = sortedUniqueStrings(signals)
+	}
+}

--- a/internal/providers/aws/role_classification.go
+++ b/internal/providers/aws/role_classification.go
@@ -56,7 +56,7 @@ func classifyIAMRoleIdentity(role IAMRole) (domain.IdentityKind, domain.Identity
 	if isIdentrailConnectorRole(name, role.Tags) {
 		return domain.IdentityKindConnector, domain.IdentityManagedByIdentrail, domain.FindingActionabilityReview
 	}
-	if strings.HasPrefix(strings.ToLower(name), "awsservicerolefor") || strings.Contains(strings.ToLower(strings.TrimSpace(role.Path)), "/aws-service-role/") {
+	if isServiceLinkedRoleARN(role.ARN) {
 		return domain.IdentityKindServiceLinked, domain.IdentityManagedByAWSService, domain.FindingActionabilityObserveOnly
 	}
 	return domain.IdentityKindStandard, domain.IdentityManagedByCustomer, domain.FindingActionabilityActionRequired
@@ -76,7 +76,24 @@ func isIdentrailConnectorRole(name string, tags map[string]string) bool {
 
 func expectedServiceLinkedRole(identity domain.Identity) (serviceLinkedRoleExpectation, bool) {
 	expectation, ok := expectedServiceLinkedRoles[strings.ToLower(strings.TrimSpace(identity.Name))]
-	return expectation, ok
+	if !ok || !matchesExpectedServiceLinkedRoleARN(identity.ARN, expectation) {
+		return serviceLinkedRoleExpectation{}, false
+	}
+	return expectation, true
+}
+
+func isServiceLinkedRoleARN(roleARN string) bool {
+	parts := strings.Split(strings.TrimSpace(roleARN), ":")
+	return len(parts) == 6 && parts[2] == "iam" && strings.HasPrefix(parts[5], "role/aws-service-role/")
+}
+
+func matchesExpectedServiceLinkedRoleARN(roleARN string, expectation serviceLinkedRoleExpectation) bool {
+	parts := strings.Split(strings.TrimSpace(roleARN), ":")
+	if len(parts) != 6 || parts[2] != "iam" || strings.TrimSpace(parts[4]) == "" {
+		return false
+	}
+	expectedResource := "role/aws-service-role/" + expectation.ServicePrincipal + "/" + expectation.RoleName
+	return parts[5] == expectedResource
 }
 
 func isExpectedAWSManagedPolicyARN(policyARN string) bool {
@@ -118,6 +135,7 @@ type trustPolicyFacts struct {
 
 type trustAssumeRoleBinding struct {
 	Actions                    []string
+	NotActions                 []string
 	AWSPrincipals              []string
 	ServicePrincipals          []string
 	OtherPrincipals            []string
@@ -139,19 +157,21 @@ func inspectTrustPolicy(policy *domain.Policy) trustPolicyFacts {
 			continue
 		}
 		actions := sortedUniqueStrings(parseStringList(statement.Action))
+		notActions := sortedUniqueStrings(parseStringList(statement.NotAction))
 		awsPrincipals := parseAWSPrincipals(statement.Principal)
 		servicePrincipals := parsePrincipalType(statement.Principal, "Service")
 		otherPrincipals := append(parsePrincipalType(statement.Principal, "Federated"), parsePrincipalType(statement.Principal, "CanonicalUser")...)
-		facts.AWSPrincipals = append(facts.AWSPrincipals, awsPrincipals...)
-		facts.ServicePrincipals = append(facts.ServicePrincipals, servicePrincipals...)
-		facts.OtherPrincipals = append(facts.OtherPrincipals, otherPrincipals...)
-		if !actionsAllowAssumeRole(actions) {
+		if !statementAllowsAssumeRole(actions, notActions) {
 			continue
 		}
 		facts.AllowsAssumeRole = true
+		facts.AWSPrincipals = append(facts.AWSPrincipals, awsPrincipals...)
+		facts.ServicePrincipals = append(facts.ServicePrincipals, servicePrincipals...)
+		facts.OtherPrincipals = append(facts.OtherPrincipals, otherPrincipals...)
 		externalIDEquals, hasOtherExternalIDOperator := inspectExternalIDConditions(statement.Condition)
 		facts.AssumeRoleBindings = append(facts.AssumeRoleBindings, trustAssumeRoleBinding{
 			Actions:                    actions,
+			NotActions:                 notActions,
 			AWSPrincipals:              sortedUniqueStrings(awsPrincipals),
 			ServicePrincipals:          sortedUniqueStrings(servicePrincipals),
 			OtherPrincipals:            sortedUniqueStrings(otherPrincipals),
@@ -167,12 +187,26 @@ func inspectTrustPolicy(policy *domain.Policy) trustPolicyFacts {
 
 func actionsAllowAssumeRole(actions []string) bool {
 	for _, action := range actions {
-		switch strings.ToLower(strings.TrimSpace(action)) {
-		case "sts:assumerole", "sts:*", "*":
+		if iamActionPatternMatches(strings.ToLower(strings.TrimSpace(action)), "sts:assumerole") {
 			return true
 		}
 	}
 	return false
+}
+
+func statementAllowsAssumeRole(actions, notActions []string) bool {
+	if actionsAllowAssumeRole(actions) {
+		return true
+	}
+	if len(notActions) == 0 {
+		return false
+	}
+	for _, action := range notActions {
+		if iamActionPatternMatches(strings.ToLower(strings.TrimSpace(action)), "sts:assumerole") {
+			return false
+		}
+	}
+	return true
 }
 
 func inspectExternalIDConditions(condition map[string]any) ([]string, bool) {
@@ -275,7 +309,7 @@ func connectorTrustBindingStatus(facts trustPolicyFacts, trustedAccountID, exter
 		return false, false
 	}
 	binding := facts.AssumeRoleBindings[0]
-	trustValid := len(binding.Actions) == 1 && strings.EqualFold(binding.Actions[0], "sts:AssumeRole") &&
+	trustValid := len(binding.Actions) == 1 && len(binding.NotActions) == 0 && strings.EqualFold(binding.Actions[0], "sts:AssumeRole") &&
 		len(binding.AWSPrincipals) == 1 && isAccountRootPrincipal(binding.AWSPrincipals[0], trustedAccountID) &&
 		len(binding.ServicePrincipals) == 0 && len(binding.OtherPrincipals) == 0
 	externalIDValid := len(binding.ExternalIDEquals) == 1 && binding.ExternalIDEquals[0] == externalID && !binding.HasOtherExternalIDOperator
@@ -303,6 +337,9 @@ func connectorPermissionScopeExpanded(policies []domain.Policy) bool {
 				continue
 			}
 			if len(parseStringList(statement[notActionsKey])) > 0 {
+				return true
+			}
+			if len(parseStringList(statement[notResourcesKey])) > 0 {
 				return true
 			}
 			for _, action := range parseStringList(statement["actions"]) {

--- a/internal/providers/aws/role_classification.go
+++ b/internal/providers/aws/role_classification.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	connectoraws "github.com/identrail/identrail/internal/connectors/aws"
 	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/providers"
 )
@@ -110,11 +109,20 @@ func trustPolicyForIdentity(bundle providers.NormalizedBundle, identityID string
 }
 
 type trustPolicyFacts struct {
-	AWSPrincipals     []string
-	ServicePrincipals []string
-	OtherPrincipals   []string
-	ExternalIDs       []string
-	AllowsAssumeRole  bool
+	AWSPrincipals      []string
+	ServicePrincipals  []string
+	OtherPrincipals    []string
+	AllowsAssumeRole   bool
+	AssumeRoleBindings []trustAssumeRoleBinding
+}
+
+type trustAssumeRoleBinding struct {
+	Actions                    []string
+	AWSPrincipals              []string
+	ServicePrincipals          []string
+	OtherPrincipals            []string
+	ExternalIDEquals           []string
+	HasOtherExternalIDOperator bool
 }
 
 func inspectTrustPolicy(policy *domain.Policy) trustPolicyFacts {
@@ -130,38 +138,63 @@ func inspectTrustPolicy(policy *domain.Policy) trustPolicyFacts {
 		if !strings.EqualFold(strings.TrimSpace(statement.Effect), "allow") {
 			continue
 		}
-		for _, action := range parseStringList(statement.Action) {
-			if strings.EqualFold(strings.TrimSpace(action), "sts:AssumeRole") {
-				facts.AllowsAssumeRole = true
-			}
+		actions := sortedUniqueStrings(parseStringList(statement.Action))
+		awsPrincipals := parseAWSPrincipals(statement.Principal)
+		servicePrincipals := parsePrincipalType(statement.Principal, "Service")
+		otherPrincipals := append(parsePrincipalType(statement.Principal, "Federated"), parsePrincipalType(statement.Principal, "CanonicalUser")...)
+		facts.AWSPrincipals = append(facts.AWSPrincipals, awsPrincipals...)
+		facts.ServicePrincipals = append(facts.ServicePrincipals, servicePrincipals...)
+		facts.OtherPrincipals = append(facts.OtherPrincipals, otherPrincipals...)
+		if !actionsAllowAssumeRole(actions) {
+			continue
 		}
-		facts.AWSPrincipals = append(facts.AWSPrincipals, parseAWSPrincipals(statement.Principal)...)
-		facts.ServicePrincipals = append(facts.ServicePrincipals, parsePrincipalType(statement.Principal, "Service")...)
-		facts.OtherPrincipals = append(facts.OtherPrincipals, parsePrincipalType(statement.Principal, "Federated")...)
-		facts.OtherPrincipals = append(facts.OtherPrincipals, parsePrincipalType(statement.Principal, "CanonicalUser")...)
-		facts.ExternalIDs = append(facts.ExternalIDs, conditionValues(statement.Condition, "sts:ExternalId")...)
+		facts.AllowsAssumeRole = true
+		externalIDEquals, hasOtherExternalIDOperator := inspectExternalIDConditions(statement.Condition)
+		facts.AssumeRoleBindings = append(facts.AssumeRoleBindings, trustAssumeRoleBinding{
+			Actions:                    actions,
+			AWSPrincipals:              sortedUniqueStrings(awsPrincipals),
+			ServicePrincipals:          sortedUniqueStrings(servicePrincipals),
+			OtherPrincipals:            sortedUniqueStrings(otherPrincipals),
+			ExternalIDEquals:           externalIDEquals,
+			HasOtherExternalIDOperator: hasOtherExternalIDOperator,
+		})
 	}
 	facts.AWSPrincipals = sortedUniqueStrings(facts.AWSPrincipals)
 	facts.ServicePrincipals = sortedUniqueStrings(facts.ServicePrincipals)
 	facts.OtherPrincipals = sortedUniqueStrings(facts.OtherPrincipals)
-	facts.ExternalIDs = sortedUniqueStrings(facts.ExternalIDs)
 	return facts
 }
 
-func conditionValues(condition map[string]any, wantedKey string) []string {
-	values := []string{}
-	for _, operatorValue := range condition {
+func actionsAllowAssumeRole(actions []string) bool {
+	for _, action := range actions {
+		switch strings.ToLower(strings.TrimSpace(action)) {
+		case "sts:assumerole", "sts:*", "*":
+			return true
+		}
+	}
+	return false
+}
+
+func inspectExternalIDConditions(condition map[string]any) ([]string, bool) {
+	equalsValues := []string{}
+	hasOtherOperator := false
+	for operator, operatorValue := range condition {
 		operatorMap, ok := operatorValue.(map[string]any)
 		if !ok {
 			continue
 		}
 		for key, value := range operatorMap {
-			if strings.EqualFold(strings.TrimSpace(key), wantedKey) {
-				values = append(values, parseStringList(value)...)
+			if !strings.EqualFold(strings.TrimSpace(key), "sts:ExternalId") {
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(operator), "StringEquals") {
+				equalsValues = append(equalsValues, parseStringList(value)...)
+			} else {
+				hasOtherOperator = true
 			}
 		}
 	}
-	return sortedUniqueStrings(values)
+	return sortedUniqueStrings(equalsValues), hasOtherOperator
 }
 
 func sortedUniqueStrings(values []string) []string {
@@ -210,18 +243,19 @@ func connectorRoleSignals(bundle providers.NormalizedBundle, identity domain.Ide
 		signals = append(signals, "trust_evidence_missing")
 	} else {
 		expectedTrustedAccount := strings.TrimSpace(expectation.TrustedAccountID)
+		expectedExternalID := strings.TrimSpace(expectation.ExternalID)
+		trustValid, externalIDValid := connectorTrustBindingStatus(facts, expectedTrustedAccount, expectedExternalID)
 		if expectedTrustedAccount == "" {
 			completeness = "partial"
 			signals = append(signals, "trusted_account_expectation_missing")
-		} else if !facts.AllowsAssumeRole || len(facts.AWSPrincipals) != 1 || accountIDFromPrincipal(facts.AWSPrincipals[0]) != expectedTrustedAccount || len(facts.ServicePrincipals) > 0 || len(facts.OtherPrincipals) > 0 {
+		} else if !trustValid {
 			signals = append(signals, "unexpected_trust")
 		}
 
-		expectedExternalID := strings.TrimSpace(expectation.ExternalID)
 		if expectedExternalID == "" {
 			completeness = "partial"
 			signals = append(signals, "external_id_expectation_missing")
-		} else if len(facts.ExternalIDs) != 1 || facts.ExternalIDs[0] != expectedExternalID {
+		} else if !externalIDValid {
 			signals = append(signals, "external_id_mismatch")
 		}
 	}
@@ -234,6 +268,23 @@ func connectorRoleSignals(bundle providers.NormalizedBundle, identity domain.Ide
 		signals = append(signals, "permission_scope_expanded")
 	}
 	return sortedUniqueStrings(signals), completeness
+}
+
+func connectorTrustBindingStatus(facts trustPolicyFacts, trustedAccountID, externalID string) (bool, bool) {
+	if len(facts.AssumeRoleBindings) != 1 {
+		return false, false
+	}
+	binding := facts.AssumeRoleBindings[0]
+	trustValid := len(binding.Actions) == 1 && strings.EqualFold(binding.Actions[0], "sts:AssumeRole") &&
+		len(binding.AWSPrincipals) == 1 && isAccountRootPrincipal(binding.AWSPrincipals[0], trustedAccountID) &&
+		len(binding.ServicePrincipals) == 0 && len(binding.OtherPrincipals) == 0
+	externalIDValid := len(binding.ExternalIDEquals) == 1 && binding.ExternalIDEquals[0] == externalID && !binding.HasOtherExternalIDOperator
+	return trustValid, externalIDValid
+}
+
+func isAccountRootPrincipal(principal, accountID string) bool {
+	parts := strings.Split(strings.TrimSpace(principal), ":")
+	return len(parts) == 6 && parts[0] == "arn" && parts[2] == "iam" && parts[4] == strings.TrimSpace(accountID) && parts[5] == "root"
 }
 
 func connectorPermissionScopeExpanded(policies []domain.Policy) bool {
@@ -251,6 +302,9 @@ func connectorPermissionScopeExpanded(policies []domain.Policy) bool {
 			if !strings.EqualFold(effect, "Allow") {
 				continue
 			}
+			if len(parseStringList(statement[notActionsKey])) > 0 {
+				return true
+			}
 			for _, action := range parseStringList(statement["actions"]) {
 				if _, ok := allowedActions[strings.ToLower(strings.TrimSpace(action))]; !ok {
 					return true
@@ -262,22 +316,49 @@ func connectorPermissionScopeExpanded(policies []domain.Policy) bool {
 }
 
 func expectedConnectorPermissionActions() (map[string]struct{}, error) {
-	document, err := connectoraws.ReadOnlyPolicyDocument()
-	if err != nil {
-		return nil, err
-	}
-	policy, err := parsePolicyDocument(string(document))
-	if err != nil {
-		return nil, err
-	}
 	actions := map[string]struct{}{}
-	for _, statement := range policy.Statement {
-		if !strings.EqualFold(strings.TrimSpace(statement.Effect), "allow") {
-			continue
-		}
-		for _, action := range parseStringList(statement.Action) {
-			actions[strings.ToLower(strings.TrimSpace(action))] = struct{}{}
-		}
+	// This is the deployed CloudFormation role contract, not the broader
+	// collector capability catalog. The template-parity regression test makes
+	// any future action change explicit in both producers and consumers.
+	for _, action := range []string{
+		"iam:GetAccountSummary",
+		"iam:GetPolicy",
+		"iam:GetPolicyVersion",
+		"iam:GetRole",
+		"iam:GetRolePolicy",
+		"iam:ListAccountAliases",
+		"iam:ListAttachedRolePolicies",
+		"iam:ListRolePolicies",
+		"iam:ListRoles",
+		"iam:SimulatePrincipalPolicy",
+		"ec2:DescribeIamInstanceProfileAssociations",
+		"ec2:DescribeInstances",
+		"ec2:DescribeRegions",
+		"s3:GetBucketAcl",
+		"s3:GetBucketPolicy",
+		"s3:GetBucketPublicAccessBlock",
+		"s3:ListAllMyBuckets",
+		"kms:DescribeKey",
+		"kms:GetKeyPolicy",
+		"kms:ListKeys",
+		"sqs:GetQueueAttributes",
+		"sqs:ListQueues",
+		"sqs:ListQueueTags",
+		"sns:GetSubscriptionAttributes",
+		"sns:GetTopicAttributes",
+		"sns:ListSubscriptionsByTopic",
+		"sns:ListTagsForResource",
+		"sns:ListTopics",
+		"sts:GetCallerIdentity",
+		"organizations:DescribeOrganization",
+		"organizations:ListAccountsForParent",
+		"organizations:ListDelegatedAdministrators",
+		"organizations:ListDelegatedServicesForAccount",
+		"organizations:ListOrganizationalUnitsForParent",
+		"organizations:ListRoots",
+		"cloudformation:ListStackInstances",
+	} {
+		actions[strings.ToLower(action)] = struct{}{}
 	}
 	if len(actions) == 0 {
 		return nil, fmt.Errorf("Identrail connector policy has no allowed actions")

--- a/internal/providers/aws/role_classification.go
+++ b/internal/providers/aws/role_classification.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	connectoraws "github.com/identrail/identrail/internal/connectors/aws"
 	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/providers"
 )
@@ -236,6 +237,10 @@ func connectorRoleSignals(bundle providers.NormalizedBundle, identity domain.Ide
 }
 
 func connectorPermissionScopeExpanded(policies []domain.Policy) bool {
+	allowedActions, err := expectedConnectorPermissionActions()
+	if err != nil {
+		return true
+	}
 	for _, policy := range policies {
 		statements, err := parseNormalizedStatements(policy.Normalized[statementsKey])
 		if err != nil {
@@ -247,7 +252,7 @@ func connectorPermissionScopeExpanded(policies []domain.Policy) bool {
 				continue
 			}
 			for _, action := range parseStringList(statement["actions"]) {
-				if !isConnectorReadOnlyAction(action) {
+				if _, ok := allowedActions[strings.ToLower(strings.TrimSpace(action))]; !ok {
 					return true
 				}
 			}
@@ -256,19 +261,28 @@ func connectorPermissionScopeExpanded(policies []domain.Policy) bool {
 	return false
 }
 
-func isConnectorReadOnlyAction(action string) bool {
-	action = strings.TrimSpace(action)
-	parts := strings.SplitN(action, ":", 2)
-	if len(parts) != 2 || strings.Contains(parts[1], "*") {
-		return false
+func expectedConnectorPermissionActions() (map[string]struct{}, error) {
+	document, err := connectoraws.ReadOnlyPolicyDocument()
+	if err != nil {
+		return nil, err
 	}
-	operation := strings.ToLower(parts[1])
-	for _, prefix := range []string{"get", "list", "describe", "batchget", "lookup", "search", "simulate"} {
-		if strings.HasPrefix(operation, prefix) {
-			return true
+	policy, err := parsePolicyDocument(string(document))
+	if err != nil {
+		return nil, err
+	}
+	actions := map[string]struct{}{}
+	for _, statement := range policy.Statement {
+		if !strings.EqualFold(strings.TrimSpace(statement.Effect), "allow") {
+			continue
+		}
+		for _, action := range parseStringList(statement.Action) {
+			actions[strings.ToLower(strings.TrimSpace(action))] = struct{}{}
 		}
 	}
-	return strings.EqualFold(action, "iam:GenerateServiceLastAccessedDetails")
+	if len(actions) == 0 {
+		return nil, fmt.Errorf("Identrail connector policy has no allowed actions")
+	}
+	return actions, nil
 }
 
 func managedRoleAnomalyFinding(identity domain.Identity, expectation serviceLinkedRoleExpectation, signals []string, now time.Time) domain.Finding {

--- a/internal/providers/aws/rules.go
+++ b/internal/providers/aws/rules.go
@@ -35,8 +35,9 @@ type RuleOption func(*RuleSet)
 
 // RuleSet evaluates deterministic risk findings for AWS identities.
 type RuleSet struct {
-	now        func() time.Time
-	staleAfter time.Duration
+	now                  func() time.Time
+	staleAfter           time.Duration
+	connectorExpectation ConnectorRoleExpectation
 }
 
 var _ providers.RiskRuleSet = (*RuleSet)(nil)
@@ -67,6 +68,19 @@ func WithStaleAfter(staleAfter time.Duration) RuleOption {
 	return func(r *RuleSet) {
 		if staleAfter > 0 {
 			r.staleAfter = staleAfter
+		}
+	}
+}
+
+// WithConnectorRoleExpectation supplies the live connector invariants used to
+// validate known connector trust without exposing the external ID in output.
+func WithConnectorRoleExpectation(expectation ConnectorRoleExpectation) RuleOption {
+	return func(r *RuleSet) {
+		r.connectorExpectation = ConnectorRoleExpectation{
+			RoleARN:          strings.TrimSpace(expectation.RoleARN),
+			AccountID:        strings.TrimSpace(expectation.AccountID),
+			TrustedAccountID: strings.TrimSpace(expectation.TrustedAccountID),
+			ExternalID:       strings.TrimSpace(expectation.ExternalID),
 		}
 	}
 }
@@ -126,10 +140,32 @@ func (r *RuleSet) Evaluate(ctx context.Context, bundle providers.NormalizedBundl
 	}
 
 	findings := make([]domain.Finding, 0, len(bundle.Identities)*2)
+	specialIdentity := make(map[string]bool, len(bundle.Identities))
 
 	for _, identity := range sortedIdentities(bundle.Identities) {
 		if err := ctx.Err(); err != nil {
 			return nil, err
+		}
+
+		if r.isConnectorRole(identity) {
+			specialIdentity[identity.ID] = true
+			signals, completeness := connectorRoleSignals(bundle, identity, r.connectorExpectation)
+			if len(overprivileged[identity.ID]) > 0 && connectorPermissionScopeExpanded(permissionPoliciesForIdentity(bundle, identity.ID)) {
+				signals = append(signals, "unexpected_permission_reachability")
+			}
+			findings = append(findings, connectorTrustReviewFinding(identity, sortedUniqueStrings(signals), completeness, now))
+			continue
+		}
+		if expectation, ok := expectedServiceLinkedRole(identity); ok {
+			specialIdentity[identity.ID] = true
+			signals := expectedServiceLinkedRoleSignals(bundle, identity, expectation, len(overprivileged[identity.ID]) > 0)
+			if len(riskyTrust[identity.ID]) > 0 {
+				signals = append(signals, "unexpected_external_trust")
+			}
+			if len(signals) > 0 {
+				findings = append(findings, managedRoleAnomalyFinding(identity, expectation, sortedUniqueStrings(signals), now))
+			}
+			continue
 		}
 
 		if isIdentityOwnerless(identity) {
@@ -141,6 +177,9 @@ func (r *RuleSet) Evaluate(ctx context.Context, bundle providers.NormalizedBundl
 	}
 
 	for identityID, risks := range overprivileged {
+		if specialIdentity[identityID] {
+			continue
+		}
 		identity, exists := identityByID[identityID]
 		if !exists {
 			continue
@@ -149,6 +188,9 @@ func (r *RuleSet) Evaluate(ctx context.Context, bundle providers.NormalizedBundl
 	}
 
 	for identityID, principals := range riskyTrust {
+		if specialIdentity[identityID] {
+			continue
+		}
 		identity, exists := identityByID[identityID]
 		if !exists {
 			continue
@@ -157,6 +199,9 @@ func (r *RuleSet) Evaluate(ctx context.Context, bundle providers.NormalizedBundl
 	}
 
 	for identityID, principals := range riskyTrust {
+		if specialIdentity[identityID] {
+			continue
+		}
 		risks := sortAccessRisks(overprivileged[identityID])
 		if len(risks) == 0 {
 			continue
@@ -171,6 +216,27 @@ func (r *RuleSet) Evaluate(ctx context.Context, bundle providers.NormalizedBundl
 		findings = append(findings, escalationFinding(identity, dedupeStrings(principals), risks[0], now))
 	}
 
+	for i := range findings {
+		identityID, _ := findings[i].Evidence["identity_id"].(string)
+		identity, exists := identityByID[identityID]
+		if !exists {
+			continue
+		}
+		signals := []string{string(findings[i].Type)}
+		if existing, ok := findings[i].Evidence["contributing_signals"].([]string); ok {
+			signals = existing
+		}
+		switch findings[i].Type {
+		case domain.FindingEscalationPath:
+			findings[i].Exploitability = domain.FindingExploitabilityConfirmed
+		case domain.FindingOverPrivileged, domain.FindingRiskyTrustPolicy:
+			if findings[i].Exploitability == "" {
+				findings[i].Exploitability = domain.FindingExploitabilityPlausible
+			}
+		}
+		decorateAWSFinding(&findings[i], identity, signals, now)
+	}
+
 	sort.Slice(findings, func(i, j int) bool {
 		if findings[i].Severity == findings[j].Severity {
 			if findings[i].Type == findings[j].Type {
@@ -182,6 +248,14 @@ func (r *RuleSet) Evaluate(ctx context.Context, bundle providers.NormalizedBundl
 	})
 
 	return findings, nil
+}
+
+func (r *RuleSet) isConnectorRole(identity domain.Identity) bool {
+	expectedARN := strings.TrimSpace(r.connectorExpectation.RoleARN)
+	if expectedARN != "" && strings.EqualFold(strings.TrimSpace(identity.ARN), expectedARN) {
+		return true
+	}
+	return identity.IdentityKind == domain.IdentityKindConnector || strings.EqualFold(strings.TrimSpace(identity.Name), identrailConnectorRoleName)
 }
 
 func sortedIdentities(identities []domain.Identity) []domain.Identity {

--- a/internal/providers/aws/rules.go
+++ b/internal/providers/aws/rules.go
@@ -252,10 +252,10 @@ func (r *RuleSet) Evaluate(ctx context.Context, bundle providers.NormalizedBundl
 
 func (r *RuleSet) isConnectorRole(identity domain.Identity) bool {
 	expectedARN := strings.TrimSpace(r.connectorExpectation.RoleARN)
-	if expectedARN != "" && strings.EqualFold(strings.TrimSpace(identity.ARN), expectedARN) {
-		return true
-	}
-	return identity.IdentityKind == domain.IdentityKindConnector || strings.EqualFold(strings.TrimSpace(identity.Name), identrailConnectorRoleName)
+	expectedAccountID := strings.TrimSpace(r.connectorExpectation.AccountID)
+	return expectedARN != "" && expectedAccountID != "" &&
+		strings.EqualFold(strings.TrimSpace(identity.ARN), expectedARN) &&
+		accountIDFromARN(identity.ARN) == expectedAccountID
 }
 
 func sortedIdentities(identities []domain.Identity) []domain.Identity {

--- a/internal/providers/aws/rules_test.go
+++ b/internal/providers/aws/rules_test.go
@@ -355,6 +355,41 @@ func TestRuleSetSuppressesDefaultNoiseForExpectedServiceLinkedRoles(t *testing.T
 	}
 }
 
+func TestRuleSetRequiresExpectedServiceLinkedRoleARNPath(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		arn  string
+	}{
+		{name: "name only", arn: "arn:aws:iam::123456789012:role/AWSServiceRoleForSupport"},
+		{name: "wrong service path", arn: "arn:aws:iam::123456789012:role/aws-service-role/ec2.amazonaws.com/AWSServiceRoleForSupport"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			role := IAMRole{
+				ARN:                      tc.arn,
+				Name:                     "AWSServiceRoleForSupport",
+				CreatedAt:                timePointer(now.Add(-400 * 24 * time.Hour)),
+				AssumeRolePolicyDocument: trustPolicyJSON(map[string]any{"Service": "support.amazonaws.com"}, ""),
+				PermissionPolicies: []IAMPermissionPolicy{{
+					Name:           "AWSSupportServiceRolePolicy",
+					ARN:            "arn:aws:iam::aws:policy/aws-service-role/AWSSupportServiceRolePolicy",
+					AttachmentType: "managed",
+					Document:       `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"support:*","Resource":"*"}}`,
+				}},
+			}
+			bundle, relationships := normalizeRoleForRuleTest(t, role)
+			findings, err := NewRuleSet(WithRuleClock(func() time.Time { return now })).Evaluate(context.Background(), bundle, relationships)
+			if err != nil {
+				t.Fatalf("evaluate failed: %v", err)
+			}
+			if !containsFindingType(findings, domain.FindingOwnerless) || !containsFindingType(findings, domain.FindingStaleIdentity) {
+				t.Fatalf("spoofed service-linked role must fall through to generic rules: %+v", findingTypes(findings))
+			}
+		})
+	}
+}
+
 func TestRuleSetGroupsServiceLinkedRoleAnomalies(t *testing.T) {
 	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
 	role := IAMRole{
@@ -426,6 +461,41 @@ func TestRuleSetEmitsInformationalConnectorTrustReview(t *testing.T) {
 	}
 }
 
+func TestRuleSetRequiresConfiguredConnectorARNAndAccount(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	role := IAMRole{
+		ARN:                      "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+		Name:                     identrailConnectorRoleName,
+		Tags:                     map[string]string{"IdentrailConnectorMode": "read-only"},
+		CreatedAt:                timePointer(now.Add(-400 * 24 * time.Hour)),
+		AssumeRolePolicyDocument: trustPolicyJSON(map[string]any{"AWS": "*"}, ""),
+		PermissionPolicies: []IAMPermissionPolicy{{
+			Name:           "CustomerAdmin",
+			AttachmentType: "inline",
+			Document:       `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:*","Resource":"*"}}`,
+		}},
+	}
+	bundle, relationships := normalizeRoleForRuleTest(t, role)
+	if bundle.Identities[0].IdentityKind != domain.IdentityKindConnector {
+		t.Fatalf("test role must exercise the untrusted connector candidate path: %+v", bundle.Identities[0])
+	}
+	findings, err := NewRuleSet(WithRuleClock(func() time.Time { return now })).Evaluate(context.Background(), bundle, relationships)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	for _, findingType := range []domain.FindingType{
+		domain.FindingOwnerless,
+		domain.FindingStaleIdentity,
+		domain.FindingOverPrivileged,
+		domain.FindingRiskyTrustPolicy,
+		domain.FindingEscalationPath,
+	} {
+		if !containsFindingType(findings, findingType) {
+			t.Fatalf("unconfigured connector candidate must retain %s finding: %+v", findingType, findingTypes(findings))
+		}
+	}
+}
+
 func TestRuleSetGroupsInvalidConnectorRoleSignals(t *testing.T) {
 	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
 	role := IAMRole{
@@ -442,8 +512,8 @@ func TestRuleSetGroupsInvalidConnectorRoleSignals(t *testing.T) {
 	findings, err := NewRuleSet(
 		WithRuleClock(func() time.Time { return now }),
 		WithConnectorRoleExpectation(ConnectorRoleExpectation{
-			RoleARN:          "arn:aws:iam::555555555555:role/IdentrailReadOnly",
-			AccountID:        "555555555555",
+			RoleARN:          "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+			AccountID:        "123456789012",
 			TrustedAccountID: "210987654321",
 			ExternalID:       "expected-external-id",
 		}),
@@ -459,7 +529,7 @@ func TestRuleSetGroupsInvalidConnectorRoleSignals(t *testing.T) {
 		t.Fatalf("expected actionable connector drift, got %+v", finding)
 	}
 	signals, _ := finding.Evidence["contributing_signals"].([]string)
-	for _, expected := range []string{"connector_account_mismatch", "connector_role_mismatch", "external_id_mismatch", "permission_scope_expanded", "unexpected_trust"} {
+	for _, expected := range []string{"external_id_mismatch", "permission_scope_expanded", "unexpected_trust"} {
 		if !containsString(signals, expected) {
 			t.Fatalf("expected signal %q in %+v", expected, signals)
 		}
@@ -520,6 +590,40 @@ func TestRuleSetRequiresExternalIDEqualityOnAssumeRoleBinding(t *testing.T) {
 	}
 }
 
+func TestRuleSetRejectsConnectorTrustAllowNotAction(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	roleARN := "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+	trustDocument := mustJSON(map[string]any{"Version": "2012-10-17", "Statement": []any{
+		map[string]any{
+			"Effect": "Allow", "Action": "sts:AssumeRole",
+			"Principal": map[string]any{"AWS": "arn:aws:iam::210987654321:root"},
+			"Condition": map[string]any{"StringEquals": map[string]any{"sts:ExternalId": "connector-external-id"}},
+		},
+		map[string]any{"Effect": "Allow", "NotAction": "sts:TagSession", "Principal": "*"},
+	}})
+	role := IAMRole{
+		ARN:                      roleARN,
+		Name:                     identrailConnectorRoleName,
+		AssumeRolePolicyDocument: trustDocument,
+		PermissionPolicies: []IAMPermissionPolicy{{
+			Name: "IdentrailReadOnlyCollector", AttachmentType: "inline",
+			Document: `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:ListRoles","Resource":"*"}}`,
+		}},
+	}
+	bundle, relationships := normalizeRoleForRuleTest(t, role)
+	findings, err := NewRuleSet(
+		WithRuleClock(func() time.Time { return now }),
+		WithConnectorRoleExpectation(ConnectorRoleExpectation{RoleARN: roleARN, AccountID: "123456789012", TrustedAccountID: "210987654321", ExternalID: "connector-external-id"}),
+	).Evaluate(context.Background(), bundle, relationships)
+	if err != nil || len(findings) != 1 {
+		t.Fatalf("expected one connector drift finding, findings=%+v err=%v", findings, err)
+	}
+	signals, _ := findings[0].Evidence["contributing_signals"].([]string)
+	if findings[0].Severity != domain.SeverityHigh || !containsString(signals, "unexpected_trust") {
+		t.Fatalf("Allow NotAction trust must be actionable drift: %+v", findings[0])
+	}
+}
+
 func TestRuleSetRejectsConnectorAllowNotAction(t *testing.T) {
 	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
 	roleARN := "arn:aws:iam::123456789012:role/IdentrailReadOnly"
@@ -546,6 +650,40 @@ func TestRuleSetRejectsConnectorAllowNotAction(t *testing.T) {
 	signals, _ := findings[0].Evidence["contributing_signals"].([]string)
 	if findings[0].Severity != domain.SeverityHigh || !containsString(signals, "permission_scope_expanded") {
 		t.Fatalf("Allow NotAction must be actionable permission drift: %+v", findings[0])
+	}
+}
+
+func TestRuleSetRejectsConnectorAllowNotResource(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	roleARN := "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+	role := IAMRole{
+		ARN:                      roleARN,
+		Name:                     identrailConnectorRoleName,
+		AssumeRolePolicyDocument: trustPolicyJSON(map[string]any{"AWS": "arn:aws:iam::210987654321:root"}, "connector-external-id"),
+		PermissionPolicies: []IAMPermissionPolicy{
+			{Name: "IdentrailReadOnlyCollector", AttachmentType: "inline", Document: `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:ListRoles","Resource":"*"}}`},
+			{Name: "AlmostEveryObject", AttachmentType: "inline", Document: `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"s3:GetObject","NotResource":"arn:aws:s3:::public/*"}}`},
+		},
+	}
+	bundle, relationships := normalizeRoleForRuleTest(t, role)
+	policies := permissionPoliciesForIdentity(bundle, bundle.Identities[0].ID)
+	if len(policies) != 2 {
+		t.Fatalf("NotResource policy must survive normalization: %+v", bundle.Policies)
+	}
+	statements, err := parseNormalizedStatements(policies[1].Normalized[statementsKey])
+	if err != nil || len(statements) != 1 || len(parseStringList(statements[0][notResourcesKey])) != 1 {
+		t.Fatalf("NotResource semantics must survive normalization: statements=%+v err=%v", statements, err)
+	}
+	findings, err := NewRuleSet(
+		WithRuleClock(func() time.Time { return now }),
+		WithConnectorRoleExpectation(ConnectorRoleExpectation{RoleARN: roleARN, AccountID: "123456789012", TrustedAccountID: "210987654321", ExternalID: "connector-external-id"}),
+	).Evaluate(context.Background(), bundle, relationships)
+	if err != nil || len(findings) != 1 {
+		t.Fatalf("expected one connector drift finding, findings=%+v err=%v", findings, err)
+	}
+	signals, _ := findings[0].Evidence["contributing_signals"].([]string)
+	if findings[0].Severity != domain.SeverityHigh || !containsString(signals, "permission_scope_expanded") {
+		t.Fatalf("Allow NotResource must be actionable permission drift: %+v", findings[0])
 	}
 }
 

--- a/internal/providers/aws/rules_test.go
+++ b/internal/providers/aws/rules_test.go
@@ -3,6 +3,9 @@ package aws
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
@@ -11,6 +14,7 @@ import (
 
 	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/providers"
+	"gopkg.in/yaml.v3"
 )
 
 func TestRuleSetDetectsAllPrimaryRiskTypes(t *testing.T) {
@@ -462,6 +466,89 @@ func TestRuleSetGroupsInvalidConnectorRoleSignals(t *testing.T) {
 	}
 }
 
+func TestRuleSetRequiresExternalIDEqualityOnAssumeRoleBinding(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	principal := map[string]any{"AWS": "arn:aws:iam::210987654321:root"}
+	tests := []struct {
+		name          string
+		trustDocument string
+	}{
+		{
+			name: "rejects StringNotEquals",
+			trustDocument: mustJSON(map[string]any{"Version": "2012-10-17", "Statement": map[string]any{
+				"Effect": "Allow", "Action": "sts:AssumeRole", "Principal": principal,
+				"Condition": map[string]any{"StringNotEquals": map[string]any{"sts:ExternalId": "connector-external-id"}},
+			}}),
+		},
+		{
+			name: "rejects condition from another statement",
+			trustDocument: mustJSON(map[string]any{"Version": "2012-10-17", "Statement": []any{
+				map[string]any{"Effect": "Allow", "Action": "sts:AssumeRole", "Principal": principal},
+				map[string]any{
+					"Effect": "Allow", "Action": "sts:TagSession", "Principal": principal,
+					"Condition": map[string]any{"StringEquals": map[string]any{"sts:ExternalId": "connector-external-id"}},
+				},
+			}}),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			roleARN := "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+			role := IAMRole{
+				ARN:                      roleARN,
+				Name:                     identrailConnectorRoleName,
+				AssumeRolePolicyDocument: tc.trustDocument,
+				PermissionPolicies: []IAMPermissionPolicy{{
+					Name:           "IdentrailReadOnlyCollector",
+					AttachmentType: "inline",
+					Document:       `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:ListRoles","Resource":"*"}}`,
+				}},
+			}
+			bundle, relationships := normalizeRoleForRuleTest(t, role)
+			findings, err := NewRuleSet(
+				WithRuleClock(func() time.Time { return now }),
+				WithConnectorRoleExpectation(ConnectorRoleExpectation{RoleARN: roleARN, AccountID: "123456789012", TrustedAccountID: "210987654321", ExternalID: "connector-external-id"}),
+			).Evaluate(context.Background(), bundle, relationships)
+			if err != nil || len(findings) != 1 {
+				t.Fatalf("expected one connector drift finding, findings=%+v err=%v", findings, err)
+			}
+			signals, _ := findings[0].Evidence["contributing_signals"].([]string)
+			if findings[0].Severity != domain.SeverityHigh || !containsString(signals, "external_id_mismatch") {
+				t.Fatalf("unsafe external-ID binding must be actionable drift: %+v", findings[0])
+			}
+		})
+	}
+}
+
+func TestRuleSetRejectsConnectorAllowNotAction(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	roleARN := "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+	role := IAMRole{
+		ARN:                      roleARN,
+		Name:                     identrailConnectorRoleName,
+		AssumeRolePolicyDocument: trustPolicyJSON(map[string]any{"AWS": "arn:aws:iam::210987654321:root"}, "connector-external-id"),
+		PermissionPolicies: []IAMPermissionPolicy{
+			{Name: "IdentrailReadOnlyCollector", AttachmentType: "inline", Document: `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:ListRoles","Resource":"*"}}`},
+			{Name: "AlmostEverything", AttachmentType: "inline", Document: `{"Version":"2012-10-17","Statement":{"Effect":"Allow","NotAction":"s3:GetObject","Resource":"*"}}`},
+		},
+	}
+	bundle, relationships := normalizeRoleForRuleTest(t, role)
+	if len(permissionPoliciesForIdentity(bundle, bundle.Identities[0].ID)) != 2 {
+		t.Fatalf("NotAction policy must survive normalization: %+v", bundle.Policies)
+	}
+	findings, err := NewRuleSet(
+		WithRuleClock(func() time.Time { return now }),
+		WithConnectorRoleExpectation(ConnectorRoleExpectation{RoleARN: roleARN, AccountID: "123456789012", TrustedAccountID: "210987654321", ExternalID: "connector-external-id"}),
+	).Evaluate(context.Background(), bundle, relationships)
+	if err != nil || len(findings) != 1 {
+		t.Fatalf("expected one connector drift finding, findings=%+v err=%v", findings, err)
+	}
+	signals, _ := findings[0].Evidence["contributing_signals"].([]string)
+	if findings[0].Severity != domain.SeverityHigh || !containsString(signals, "permission_scope_expanded") {
+		t.Fatalf("Allow NotAction must be actionable permission drift: %+v", findings[0])
+	}
+}
+
 func TestConnectorPermissionScopeRejectsOutOfContractReads(t *testing.T) {
 	policy := domain.Policy{Normalized: map[string]any{
 		statementsKey: []map[string]any{{
@@ -480,6 +567,51 @@ func TestConnectorPermissionScopeRejectsOutOfContractReads(t *testing.T) {
 	}}
 	if connectorPermissionScopeExpanded([]domain.Policy{policy}) {
 		t.Fatal("expected canonical Identrail collector actions to remain valid")
+	}
+}
+
+func TestExpectedConnectorPermissionActionsMatchDeployedTemplate(t *testing.T) {
+	templatePath := filepath.Join("..", "..", "..", "deploy", "connectors", "aws", "identrail-readonly.yaml")
+	body, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("read CloudFormation template: %v", err)
+	}
+	var template map[string]any
+	if err := yaml.Unmarshal(body, &template); err != nil {
+		t.Fatalf("parse CloudFormation template: %v", err)
+	}
+	resources := testYAMLMap(t, template, "Resources")
+	role := testYAMLMap(t, resources, "IdentrailReadOnlyRole")
+	properties := testYAMLMap(t, role, "Properties")
+	policies, ok := properties["Policies"].([]any)
+	if !ok || len(policies) != 1 {
+		t.Fatalf("expected one deployed connector policy, got %#v", properties["Policies"])
+	}
+	policy, ok := policies[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected connector policy map, got %#v", policies[0])
+	}
+	policyDocument := testYAMLMap(t, policy, "PolicyDocument")
+	statements, ok := policyDocument["Statement"].([]any)
+	if !ok {
+		t.Fatalf("expected policy statements, got %#v", policyDocument["Statement"])
+	}
+	deployed := map[string]struct{}{}
+	for _, rawStatement := range statements {
+		statement, ok := rawStatement.(map[string]any)
+		if !ok || !strings.EqualFold(strings.TrimSpace(fmt.Sprint(statement["Effect"])), "Allow") {
+			continue
+		}
+		for _, action := range parseStringList(statement["Action"]) {
+			deployed[strings.ToLower(action)] = struct{}{}
+		}
+	}
+	expected, err := expectedConnectorPermissionActions()
+	if err != nil {
+		t.Fatalf("build expected connector actions: %v", err)
+	}
+	if !reflect.DeepEqual(expected, deployed) {
+		t.Fatalf("connector allowlist drifted from deployed template\nexpected: %+v\ndeployed: %+v", expected, deployed)
 	}
 }
 
@@ -561,6 +693,23 @@ func trustPolicyJSON(principal map[string]any, externalID string) string {
 	}
 	document, _ := json.Marshal(map[string]any{"Version": "2012-10-17", "Statement": statement})
 	return string(document)
+}
+
+func mustJSON(value any) string {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(payload)
+}
+
+func testYAMLMap(t *testing.T, parent map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := parent[key].(map[string]any)
+	if !ok {
+		t.Fatalf("expected %s to be a map, got %#v", key, parent[key])
+	}
+	return value
 }
 
 func timePointer(value time.Time) *time.Time {

--- a/internal/providers/aws/rules_test.go
+++ b/internal/providers/aws/rules_test.go
@@ -462,6 +462,27 @@ func TestRuleSetGroupsInvalidConnectorRoleSignals(t *testing.T) {
 	}
 }
 
+func TestConnectorPermissionScopeRejectsOutOfContractReads(t *testing.T) {
+	policy := domain.Policy{Normalized: map[string]any{
+		statementsKey: []map[string]any{{
+			"effect":    "Allow",
+			"actions":   []string{"iam:ListRoles", "s3:GetObject"},
+			"resources": []string{"*"},
+		}},
+	}}
+	if !connectorPermissionScopeExpanded([]domain.Policy{policy}) {
+		t.Fatal("object-content reads are outside the Identrail collector policy even though they are read-only")
+	}
+	policy.Normalized[statementsKey] = []map[string]any{{
+		"effect":    "Allow",
+		"actions":   []string{"iam:ListRoles", "s3:GetBucketPolicy"},
+		"resources": []string{"*"},
+	}}
+	if connectorPermissionScopeExpanded([]domain.Policy{policy}) {
+		t.Fatal("expected canonical Identrail collector actions to remain valid")
+	}
+}
+
 func TestRuleSetDoesNotTreatAccountRootAsSubordinateIdentity(t *testing.T) {
 	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
 	identity := domain.Identity{

--- a/internal/providers/aws/rules_test.go
+++ b/internal/providers/aws/rules_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -305,6 +306,244 @@ func TestSeveritySortOrder(t *testing.T) {
 	if criticalIndex == -1 || highIndex == -1 || criticalIndex > highIndex {
 		t.Fatalf("expected critical findings before high findings, got order %+v", severities)
 	}
+}
+
+func TestRuleSetSuppressesDefaultNoiseForExpectedServiceLinkedRoles(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name             string
+		roleName         string
+		servicePrincipal string
+	}{
+		{name: "Security Lake", roleName: "AWSServiceRoleForAmazonSecurityLake", servicePrincipal: "securitylake.amazonaws.com"},
+		{name: "Support", roleName: "AWSServiceRoleForSupport", servicePrincipal: "support.amazonaws.com"},
+		{name: "Trusted Advisor", roleName: "AWSServiceRoleForTrustedAdvisor", servicePrincipal: "trustedadvisor.amazonaws.com"},
+		{name: "Organizations", roleName: "AWSServiceRoleForOrganizations", servicePrincipal: "organizations.amazonaws.com"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			role := IAMRole{
+				ARN:                      "arn:aws:iam::123456789012:role/aws-service-role/" + tc.servicePrincipal + "/" + tc.roleName,
+				Name:                     tc.roleName,
+				Path:                     "/aws-service-role/" + tc.servicePrincipal + "/",
+				CreatedAt:                timePointer(now.Add(-400 * 24 * time.Hour)),
+				AssumeRolePolicyDocument: trustPolicyJSON(map[string]any{"Service": tc.servicePrincipal}, ""),
+				PermissionPolicies: []IAMPermissionPolicy{{
+					Name:           tc.roleName + "Policy",
+					ARN:            "arn:aws:iam::aws:policy/aws-service-role/" + tc.roleName + "Policy",
+					AttachmentType: "managed",
+					Document:       `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"organizations:*","Resource":"*"}}`,
+				}},
+			}
+			bundle, relationships := normalizeRoleForRuleTest(t, role)
+			identity := bundle.Identities[0]
+			if identity.IdentityKind != domain.IdentityKindServiceLinked || identity.ManagedBy != domain.IdentityManagedByAWSService || identity.Actionability != domain.FindingActionabilityObserveOnly {
+				t.Fatalf("unexpected service-linked classification: %+v", identity)
+			}
+			findings, err := NewRuleSet(WithRuleClock(func() time.Time { return now })).Evaluate(context.Background(), bundle, relationships)
+			if err != nil {
+				t.Fatalf("evaluate failed: %v", err)
+			}
+			if len(findings) != 0 {
+				t.Fatalf("expected no default findings for expected managed role, got %+v", findingTypes(findings))
+			}
+		})
+	}
+}
+
+func TestRuleSetGroupsServiceLinkedRoleAnomalies(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	role := IAMRole{
+		ARN:                      "arn:aws:iam::123456789012:role/aws-service-role/support.amazonaws.com/AWSServiceRoleForSupport",
+		Name:                     "AWSServiceRoleForSupport",
+		Path:                     "/aws-service-role/support.amazonaws.com/",
+		CreatedAt:                timePointer(now.Add(-400 * 24 * time.Hour)),
+		AssumeRolePolicyDocument: trustPolicyJSON(map[string]any{"AWS": "arn:aws:iam::999999999999:root", "Service": "support.amazonaws.com"}, ""),
+		PermissionPolicies: []IAMPermissionPolicy{{
+			Name:           "CustomerAdmin",
+			AttachmentType: "inline",
+			Document:       `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:*","Resource":"*"}}`,
+		}},
+	}
+	bundle, relationships := normalizeRoleForRuleTest(t, role)
+	findings, err := NewRuleSet(WithRuleClock(func() time.Time { return now })).Evaluate(context.Background(), bundle, relationships)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one correlated managed-role finding, got %d: %+v", len(findings), findingTypes(findings))
+	}
+	finding := findings[0]
+	if finding.Title != "AWS-managed role anomaly: AWSServiceRoleForSupport" || finding.Actionability != domain.FindingActionabilityReview {
+		t.Fatalf("unexpected managed role finding: %+v", finding)
+	}
+	signals, _ := finding.Evidence["contributing_signals"].([]string)
+	for _, expected := range []string{"customer_added_policy", "unexpected_external_trust", "unexpected_permission_reachability", "unexpected_trust"} {
+		if !containsString(signals, expected) {
+			t.Fatalf("expected signal %q in %+v", expected, signals)
+		}
+	}
+}
+
+func TestRuleSetEmitsInformationalConnectorTrustReview(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	roleARN := "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+	role := IAMRole{
+		ARN:                      roleARN,
+		Name:                     identrailConnectorRoleName,
+		CreatedAt:                timePointer(now.Add(-400 * 24 * time.Hour)),
+		AssumeRolePolicyDocument: trustPolicyJSON(map[string]any{"AWS": "arn:aws:iam::210987654321:root"}, "connector-external-id"),
+		PermissionPolicies: []IAMPermissionPolicy{{
+			Name:           "IdentrailReadOnlyCollector",
+			AttachmentType: "inline",
+			Document:       `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":["iam:ListRoles","iam:GetRole"],"Resource":"*"}}`,
+		}},
+	}
+	bundle, relationships := normalizeRoleForRuleTest(t, role)
+	findings, err := NewRuleSet(
+		WithRuleClock(func() time.Time { return now }),
+		WithConnectorRoleExpectation(ConnectorRoleExpectation{RoleARN: roleARN, AccountID: "123456789012", TrustedAccountID: "210987654321", ExternalID: "connector-external-id"}),
+	).Evaluate(context.Background(), bundle, relationships)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one connector review, got %d: %+v", len(findings), findingTypes(findings))
+	}
+	finding := findings[0]
+	if finding.Severity != domain.SeverityInfo || finding.Actionability != domain.FindingActionabilityObserveOnly || finding.Exploitability != domain.FindingExploitabilityNone {
+		t.Fatalf("expected informational observe-only connector finding, got %+v", finding)
+	}
+	if finding.Evidence["external_id_condition_valid"] != true {
+		t.Fatalf("expected external-id validation state without secret value, got %+v", finding.Evidence)
+	}
+	if encoded, err := json.Marshal(finding); err != nil || strings.Contains(string(encoded), "connector-external-id") {
+		t.Fatalf("connector external ID must not be emitted, payload=%s err=%v", encoded, err)
+	}
+}
+
+func TestRuleSetGroupsInvalidConnectorRoleSignals(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	role := IAMRole{
+		ARN:                      "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+		Name:                     identrailConnectorRoleName,
+		AssumeRolePolicyDocument: trustPolicyJSON(map[string]any{"AWS": "arn:aws:iam::999999999999:root"}, "wrong-external-id"),
+		PermissionPolicies: []IAMPermissionPolicy{{
+			Name:           "ExpandedConnectorPolicy",
+			AttachmentType: "inline",
+			Document:       `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:CreatePolicyVersion","Resource":"*"}}`,
+		}},
+	}
+	bundle, relationships := normalizeRoleForRuleTest(t, role)
+	findings, err := NewRuleSet(
+		WithRuleClock(func() time.Time { return now }),
+		WithConnectorRoleExpectation(ConnectorRoleExpectation{
+			RoleARN:          "arn:aws:iam::555555555555:role/IdentrailReadOnly",
+			AccountID:        "555555555555",
+			TrustedAccountID: "210987654321",
+			ExternalID:       "expected-external-id",
+		}),
+	).Evaluate(context.Background(), bundle, relationships)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one correlated connector drift finding, got %d", len(findings))
+	}
+	finding := findings[0]
+	if finding.Severity != domain.SeverityHigh || finding.Actionability != domain.FindingActionabilityActionRequired {
+		t.Fatalf("expected actionable connector drift, got %+v", finding)
+	}
+	signals, _ := finding.Evidence["contributing_signals"].([]string)
+	for _, expected := range []string{"connector_account_mismatch", "connector_role_mismatch", "external_id_mismatch", "permission_scope_expanded", "unexpected_trust"} {
+		if !containsString(signals, expected) {
+			t.Fatalf("expected signal %q in %+v", expected, signals)
+		}
+	}
+}
+
+func TestRuleSetDoesNotTreatAccountRootAsSubordinateIdentity(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	identity := domain.Identity{
+		ID:       identityIDFromARN("arn:aws:iam::123456789012:role/application"),
+		Provider: domain.ProviderAWS,
+		Type:     domain.IdentityTypeRole,
+		Name:     "application",
+		ARN:      "arn:aws:iam::123456789012:role/application",
+	}
+	findings, err := NewRuleSet(WithRuleClock(func() time.Time { return now })).Evaluate(context.Background(), providers.NormalizedBundle{Identities: []domain.Identity{identity}}, []domain.Relationship{{
+		Type:       domain.RelationshipCanAssume,
+		FromNodeID: "aws:principal:arn:aws:iam::123456789012:root",
+		ToNodeID:   identity.ID,
+	}})
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if containsFindingType(findings, domain.FindingRiskyTrustPolicy) {
+		t.Fatalf("same-account root is the account principal, not a subordinate identity: %+v", findings)
+	}
+}
+
+func TestRuleSetAddsNormalizedFindingMetadata(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	identity := domain.Identity{
+		ID:       identityIDFromARN("arn:aws:iam::123456789012:role/ownerless"),
+		Provider: domain.ProviderAWS,
+		Type:     domain.IdentityTypeRole,
+		Name:     "ownerless",
+		ARN:      "arn:aws:iam::123456789012:role/ownerless",
+	}
+	findings, err := NewRuleSet(WithRuleClock(func() time.Time { return now })).Evaluate(context.Background(), providers.NormalizedBundle{Identities: []domain.Identity{identity}}, nil)
+	if err != nil || len(findings) != 1 {
+		t.Fatalf("expected one normalized finding, findings=%+v err=%v", findings, err)
+	}
+	finding := findings[0]
+	if finding.ConfidenceScore == 0 || finding.Actionability == "" || finding.Exploitability == "" || finding.EvidenceCompleteness == "" || finding.Provenance == "" {
+		t.Fatalf("missing normalized top-level fields: %+v", finding)
+	}
+	for _, key := range []string{"account_id", "region", "source", "observed_at", "provenance", "confidence", "identity_kind", "managed_by", "actionability", "exploitability", "evidence_completeness", "evidence_boundary", "contributing_signals"} {
+		if _, ok := finding.Evidence[key]; !ok {
+			t.Fatalf("missing normalized evidence key %q: %+v", key, finding.Evidence)
+		}
+	}
+}
+
+func normalizeRoleForRuleTest(t *testing.T, role IAMRole) (providers.NormalizedBundle, []domain.Relationship) {
+	t.Helper()
+	payload, err := json.Marshal(role)
+	if err != nil {
+		t.Fatalf("marshal role: %v", err)
+	}
+	bundle, err := NewRoleNormalizer().Normalize(context.Background(), []providers.RawAsset{{Kind: "iam_role", SourceID: role.ARN, Payload: payload}})
+	if err != nil {
+		t.Fatalf("normalize role: %v", err)
+	}
+	permissions, err := NewPolicyPermissionResolver().ResolvePermissions(context.Background(), bundle)
+	if err != nil {
+		t.Fatalf("resolve permissions: %v", err)
+	}
+	relationships, err := NewRelationshipBuilder().ResolveRelationships(context.Background(), bundle, permissions)
+	if err != nil {
+		t.Fatalf("resolve relationships: %v", err)
+	}
+	return bundle, relationships
+}
+
+func trustPolicyJSON(principal map[string]any, externalID string) string {
+	statement := map[string]any{
+		"Effect":    "Allow",
+		"Action":    "sts:AssumeRole",
+		"Principal": principal,
+	}
+	if externalID != "" {
+		statement["Condition"] = map[string]any{"StringEquals": map[string]any{"sts:ExternalId": externalID}}
+	}
+	document, _ := json.Marshal(map[string]any{"Version": "2012-10-17", "Statement": statement})
+	return string(document)
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
 }
 
 func containsFindingType(findings []domain.Finding, findingType domain.FindingType) bool {

--- a/internal/providers/aws/sdk_client.go
+++ b/internal/providers/aws/sdk_client.go
@@ -162,7 +162,7 @@ func (a *SDKIAMAPI) collectPermissionPolicies(ctx context.Context, roleName stri
 		if document == "" {
 			continue
 		}
-		policies = append(policies, IAMPermissionPolicy{Name: name, Document: document})
+		policies = append(policies, IAMPermissionPolicy{Name: name, AttachmentType: "inline", Document: document})
 	}
 
 	attached, err := a.listAttachedPolicies(ctx, roleName)
@@ -217,7 +217,7 @@ func (a *SDKIAMAPI) collectPermissionPolicies(ctx context.Context, roleName stri
 		if document == "" {
 			continue
 		}
-		policies = append(policies, IAMPermissionPolicy{Name: policyName, Document: document})
+		policies = append(policies, IAMPermissionPolicy{Name: policyName, ARN: policyARN, AttachmentType: "managed", Document: document})
 	}
 
 	return dedupePermissionPolicies(policies), nil
@@ -285,16 +285,18 @@ func dedupePermissionPolicies(policies []IAMPermissionPolicy) []IAMPermissionPol
 	result := make([]IAMPermissionPolicy, 0, len(policies))
 	for _, policy := range policies {
 		name := strings.TrimSpace(policy.Name)
+		policyARN := strings.TrimSpace(policy.ARN)
+		attachmentType := strings.TrimSpace(policy.AttachmentType)
 		doc := strings.TrimSpace(policy.Document)
 		if name == "" || doc == "" {
 			continue
 		}
-		key := name + "|" + doc
+		key := name + "|" + policyARN + "|" + attachmentType + "|" + doc
 		if _, exists := seen[key]; exists {
 			continue
 		}
 		seen[key] = struct{}{}
-		result = append(result, IAMPermissionPolicy{Name: name, Document: doc})
+		result = append(result, IAMPermissionPolicy{Name: name, ARN: policyARN, AttachmentType: attachmentType, Document: doc})
 	}
 	return result
 }

--- a/internal/providers/aws/sdk_client_test.go
+++ b/internal/providers/aws/sdk_client_test.go
@@ -122,6 +122,12 @@ func TestSDKIAMAPIListRolesHydratesPolicies(t *testing.T) {
 	if len(role.PermissionPolicies) != 2 {
 		t.Fatalf("expected 2 permission policies, got %d", len(role.PermissionPolicies))
 	}
+	if role.PermissionPolicies[0].AttachmentType != "inline" {
+		t.Fatalf("expected inline policy provenance, got %+v", role.PermissionPolicies[0])
+	}
+	if role.PermissionPolicies[1].AttachmentType != "managed" || role.PermissionPolicies[1].ARN != "arn:aws:iam::aws:policy/ReadOnlyAccess" {
+		t.Fatalf("expected managed policy ARN provenance, got %+v", role.PermissionPolicies[1])
+	}
 	if role.Tags["team"] != "payments" {
 		t.Fatalf("unexpected role tags: %+v", role.Tags)
 	}

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -396,6 +396,12 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 			awsprovider.NewSSMParameterMetadataCollector(ssmAPI),
 			awsprovider.NewECRRepositoryMetadataCollector(ecrAPI),
 		)
+		scanner.RiskRuleSet = awsprovider.NewRuleSet(awsprovider.WithConnectorRoleExpectation(awsprovider.ConnectorRoleExpectation{
+			RoleARN:          connection.RoleARN,
+			AccountID:        connection.AccountID,
+			TrustedAccountID: cfg.AWSAccountID,
+			ExternalID:       connection.ExternalID,
+		}))
 		return scanner, nil
 	}
 	svc.AWSCloudTrailLookupEventsFactory = func(ctx context.Context, connection api.AWSConnectionStatus) (api.AWSCloudTrailRuntimeEventIngester, error) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -10,6 +10,10 @@ export type Finding = {
   type: string;
   severity: string;
   confidence_score?: number;
+  actionability?: string;
+  exploitability?: string;
+  evidence_completeness?: string;
+  provenance?: string;
   title: string;
   human_summary: string;
   path?: string[];
@@ -390,6 +394,9 @@ export type Identity = {
   id: string;
   provider: string;
   type: string;
+  identity_kind?: 'standard' | 'service_linked' | 'connector' | string;
+  managed_by?: 'customer' | 'aws_service' | 'identrail_connector' | string;
+  actionability?: 'action_required' | 'review' | 'observe_only' | string;
   name: string;
   arn: string;
   owner_hint: string;

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8681,6 +8681,10 @@ describe('Domain-first app routes', () => {
                 owner: 'AWS scanner',
                 adapter_source: 'iam-policy collector',
                 confidence_score: 0.88,
+                actionability: 'action_required',
+                exploitability: 'plausible',
+                evidence_completeness: 'complete',
+                provenance: 'aws_iam_inventory',
                 first_seen_at: '2026-08-20T20:01:00Z',
                 evidence: { source: 'iam-policy', account_id: '123456789012', region: 'us-east-1' },
                 remediation: 'Reduce the role policy to the required actions.',
@@ -8769,6 +8773,9 @@ describe('Domain-first app routes', () => {
     await waitFor(() => {
       expect(within(findingDrawer).getByText('Reduce the role policy to the required actions.')).toBeInTheDocument();
       expect(within(findingDrawer).getByText('Technical evidence (2 refs)')).toBeInTheDocument();
+      expect(within(findingDrawer).getByText('Action Required')).toBeInTheDocument();
+      expect(within(findingDrawer).getByText('Plausible')).toBeInTheDocument();
+      expect(within(findingDrawer).getByText('Complete')).toBeInTheDocument();
     });
     fireEvent.click(within(findingDrawer).getByRole('button', { name: 'Close detail drawer' }));
     await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Finding details' })).not.toBeInTheDocument());

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -13136,6 +13136,8 @@ type AWSRiskOperationTableRow = AWSInventoryFilterable & {
   source?: string;
   observedAt?: string;
   confidence?: number;
+  actionability?: string;
+  exploitability?: string;
   provenance?: string;
   completeness?: string;
   evidenceBoundary?: string;
@@ -18408,6 +18410,8 @@ function AWSFindingDetailsDrawer({
               <div><dt>Source</dt><dd>{representative.source || 'Unavailable'}</dd></div>
               <div><dt>Completeness</dt><dd>{awsPersistedFindingCompletenessLabel(representative.completeness || 'unknown')}</dd></div>
               {representative.confidence !== undefined ? <div><dt>Confidence</dt><dd>{formatConfidenceScore(representative.confidence)}</dd></div> : null}
+              {representative.actionability ? <div><dt>Actionability</dt><dd>{formatTokenLabel(representative.actionability)}</dd></div> : null}
+              {representative.exploitability ? <div><dt>Exploitability</dt><dd>{formatTokenLabel(representative.exploitability)}</dd></div> : null}
               <div><dt>Observed</dt><dd>{representative.observedAt || 'Unavailable'}</dd></div>
               {representative.evidenceBoundary ? <div><dt>Boundary</dt><dd>{representative.evidenceBoundary}</dd></div> : null}
             </dl>
@@ -18869,6 +18873,8 @@ function awsPersistedFindingRiskOperationRow(
     normalizeValue(persistedScan?.finished_at) ||
     normalizeValue(persistedScan?.started_at);
   const evidenceBoundary = awsPersistedFindingMetadataValue(finding, ['evidence_boundary', 'coverage', 'coverage_state']);
+  const actionability = normalizeValue(finding.actionability) || awsPersistedFindingMetadataValue(finding, ['actionability']);
+  const exploitability = normalizeValue(finding.exploitability) || awsPersistedFindingMetadataValue(finding, ['exploitability']);
   const technicalEvidence = finding.path?.map((value) => normalizeValue(value)).filter(Boolean) ?? [];
   return {
     id: finding.id,
@@ -18887,8 +18893,10 @@ function awsPersistedFindingRiskOperationRow(
     source,
     observedAt,
     confidence: finding.confidence_score,
-    provenance: 'AWS discovery scan',
-    completeness,
+    actionability,
+    exploitability,
+    provenance: normalizeValue(finding.provenance) || 'AWS discovery scan',
+    completeness: normalizeValue(finding.evidence_completeness) || completeness,
     evidenceBoundary,
     technicalEvidence,
     resourceARN: findingScope.resourceARN,
@@ -18912,6 +18920,8 @@ function awsPersistedFindingRiskOperationRow(
       finding.type,
       finding.human_summary,
       finding.remediation,
+      actionability,
+      exploitability,
       findingScope.accountID,
       findingScope.region,
       findingScope.resourceLabel,


### PR DESCRIPTION
Closes #1825

## Summary

- classify AWS service-linked roles and the Identrail connector before generic IAM risk rules run
- suppress default stale, ownerless, and overprivileged noise only for the expected Security Lake, Support, Trusted Advisor, and Organizations role contracts
- retain unexpected trust, customer-added policies, and permission reachability as one correlated managed-role anomaly
- validate the connector role account, trusted account, external-ID condition, and read-only policy scope without emitting the external ID
- carry confidence, exploitability, actionability, evidence completeness, and provenance independently from severity into the API and findings drawer

## Why

The AWS rule engine previously treated every IAM role as customer-controlled. Expected AWS-managed roles and the read-only Identrail connector could therefore appear as generic high-risk findings even when their broad metadata permissions and cross-account trust were intentional.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

The new fields are additive. Unknown service-linked roles keep the existing generic rule behavior, and known roles still emit findings when their trust or policy boundary changes.

## Validation

- go test ./...
- go test ./internal/providers/aws
- npm test --prefix web -- --run src/productShell.test.tsx — 318 tests passed
- npm run build --prefix web — passed; 40 routes prerendered
- make fmt-check
- go vet via the pre-push hook
- git diff --check

The production build reports the existing large-chunk advisory only.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] CHANGELOG.md updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: none
- Areas where used: none
- Human verification performed: reviewed the issue contract and ran the complete Go suite, full product-shell suite, production build, formatting checks, and vet checks listed above

## Related Issues

Closes #1825

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves AWS IAM finding signal for AWS-managed service-linked roles and the Identrail connector. Previously all roles were treated as customer-controlled; now expected managed roles are classified, generic noise is suppressed, and only drift is flagged, while the connector’s exact trust and read-only scope are validated without exposing the external ID.

- Classifies roles in `internal/providers/aws` (adds identity_kind, managed_by, and per-identity actionability). Recognizes service-linked roles only when the ARN matches role/aws-service-role/{service}/{RoleName} and trust is to the expected service principal; suppresses stale/ownerless/overprivileged for these roles; emits one “managed-role anomaly” on unexpected trust, customer-added policies, NotAction/NotResource usage, or permission reachability. Satisfies #1825.
- Hardens connector validation: requires StringEquals on `sts:ExternalId` on the same AssumeRole statement; rejects StringNotEquals and conditions from other statements; validates the exact allowlisted action set and treats Allow NotAction/NotResource as scope expansion; correlates all connector signals into a single finding (info/observe-only when compliant; actionable/high when drift is detected); never includes the external ID in evidence and downgrades evidence completeness when trust or policy data is missing.
- Normalizes evidence and surfaces metadata: permission policies include `policy_arn` and `attachment_type`; trust parsing captures service principals and external‑ID conditions; all AWS findings are decorated with adapter source, confidence state, evidence boundary, and top-level `actionability`, `exploitability`, `evidence_completeness`, and `provenance`. `docs/openapi-v1.yaml`, `internal/db` (persist/hydrate via evidence), and `web` (`web/src/api/client.ts`, finding drawer) model and render these fields.

- Rollout
  - No breaking changes; OpenAPI additions are additive.
  - To enable full connector validation, pass `WithConnectorRoleExpectation` to the AWS `RuleSet` (runtime wiring sets this for hosted connectors).

<sup>Written for commit 08e02e4dc88bd4647c6e66776703698c17f5e6bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

