### PR TITLE
[AWS Findings] Redesign findings queue for prioritization and coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Redesign the AWS findings queue for prioritization and scan coverage (#1826).
+  The summary now exposes open critical/high findings, affected resources,
+  historical scan scope, completeness, and named collector failures. Findings
+  use focused triage columns, retain real historical account and region filters,
+  and stack into labeled rows on narrow screens instead of overflowing.
 - Improve AWS IAM finding signal quality for AWS-managed service-linked roles
   and the Identrail connector role (#1825). Expected Security Lake, Support,
   Trusted Advisor, and Organizations roles no longer emit generic stale,

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -79,6 +79,28 @@ describe('apiClient', () => {
     expect(url).toContain('/v1/scans?sort_by=started_at&sort_order=desc');
   });
 
+  it('passes the scan event cursor for paging', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [], next_cursor: 'cursor-3' })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.listScanEvents(
+      'scan-1',
+      undefined,
+      500,
+      { tenantID: 'tenant-a', workspaceID: 'workspace-a' },
+      'cursor-2'
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/scans/scan-1/events?limit=500&cursor=cursor-2&sort_by=created_at&sort_order=desc');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace-a');
+  });
+
   it('builds AWS graph explorer URL with filters', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -10826,11 +10826,12 @@ export const apiClient = {
       auth
     );
   },
-  listScanEvents(scanID: string, level?: string, limit = 50, auth?: RequestAuthContext) {
-    return request<{ items: ScanEvent[] }>(
+  listScanEvents(scanID: string, level?: string, limit = 50, auth?: RequestAuthContext, cursor?: string) {
+    return request<{ items: ScanEvent[]; next_cursor?: string }>(
       `/v1/scans/${encodeURIComponent(scanID)}/events${buildQuery({
         level,
         limit,
+        cursor,
         sort_by: 'created_at',
         sort_order: 'desc'
       })}`,

--- a/web/src/components/app/DomainFoundation.test.tsx
+++ b/web/src/components/app/DomainFoundation.test.tsx
@@ -156,6 +156,7 @@ describe('DomainFoundation', () => {
         </DomainFilterBar>
         <DomainDataTable
           label="Identity inventory"
+          stackOnNarrow
           columns={[
             { key: 'name', header: 'Identity', render: (row: { id: string; name: string }) => row.name },
             { key: 'risk', header: 'Risk', align: 'right', render: () => 'High' }
@@ -182,7 +183,11 @@ describe('DomainFoundation', () => {
     expect(screen.getByRole('heading', { name: 'GitHub posture' })).toBeInTheDocument();
     expect(screen.getByText('Webhook delivery is current.')).toBeInTheDocument();
     expect(screen.getByRole('search', { name: 'Filter domain data' })).toBeInTheDocument();
-    expect(within(screen.getByRole('table', { name: 'Identity inventory' })).getByText('Deploy role')).toBeInTheDocument();
+    const identityTable = screen.getByRole('table', { name: 'Identity inventory' });
+    expect(within(identityTable).getByText('Deploy role')).toBeInTheDocument();
+    expect(identityTable.closest('.idt-domain-table-wrap')).toHaveClass('is-narrow-stack');
+    expect(within(identityTable).getByText('Deploy role').closest('td')).toHaveAttribute('data-label', 'Identity');
+    expect(within(identityTable).getByText('High').closest('td')).toHaveAttribute('data-label', 'Risk');
     expect(screen.getByText('No records yet')).toBeInTheDocument();
     expect(screen.getByRole('alert')).toHaveTextContent('Sync failed');
     expect(screen.getByRole('status')).toHaveTextContent('Loading GitHub repositories');

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -481,16 +481,18 @@ export function DomainDataTable<Row>({
   columns,
   rows,
   getRowKey,
-  emptyState
+  emptyState,
+  stackOnNarrow = false
 }: {
   label: string;
   columns: DomainDataTableColumn<Row>[];
   rows: Row[];
   getRowKey: (row: Row) => string;
   emptyState?: ReactNode;
+  stackOnNarrow?: boolean;
 }) {
   return (
-    <div className="idt-domain-table-wrap">
+    <div className={classNames(['idt-domain-table-wrap', stackOnNarrow ? 'is-narrow-stack' : undefined])}>
       <table className="idt-domain-data-table" aria-label={label}>
         <thead>
           <tr>
@@ -505,7 +507,7 @@ export function DomainDataTable<Row>({
           {rows.map((row) => (
             <tr key={getRowKey(row)}>
               {columns.map((column) => (
-                <td key={column.key} className={column.align === 'right' ? 'is-right' : undefined}>
+                <td key={column.key} data-label={column.header} className={column.align === 'right' ? 'is-right' : undefined}>
                   {column.render(row)}
                 </td>
               ))}

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8162,9 +8162,15 @@ describe('Domain-first app routes', () => {
     );
     const liveFindingRow = within(findingsTable).getByRole('link', { name: /openai\/api-key/i }).closest('tr');
     expect(liveFindingRow).not.toBeNull();
-    expect(within(liveFindingRow as HTMLElement).getByText(/Case Triage · openai\/api-key · Secret · Account 123456789012 · Region us-east-1/)).toBeInTheDocument();
-    expect(within(findingsTable).getByText(/Case Triage · anthropic\/api-key · Secret · Account 123456789012 · Region eu-west-1/)).toBeInTheDocument();
-    fireEvent.click(within(liveFindingRow as HTMLElement).getByRole('button', { name: 'View details' }));
+    expect(liveFindingRow).toHaveTextContent('openai/api-key');
+    expect(liveFindingRow).toHaveTextContent('Secret · Case Triage');
+    expect(liveFindingRow).toHaveTextContent('Secret');
+    expect(liveFindingRow).toHaveTextContent('Account 123456789012 · Region us-east-1');
+    expect(within(findingsTable).getByText('Account 123456789012 · Region eu-west-1')).toBeInTheDocument();
+    const liveDetailsButton = within(liveFindingRow as HTMLElement).getByRole('button', { name: 'View details' });
+    liveDetailsButton.focus();
+    expect(liveDetailsButton).toHaveFocus();
+    fireEvent.click(liveDetailsButton);
     const liveFindingDrawer = await screen.findByRole('dialog', { name: 'Finding details' });
     expect(within(liveFindingDrawer).getByText('Case Triage', { exact: true })).toBeInTheDocument();
     fireEvent.click(within(liveFindingDrawer).getByRole('button', { name: 'Close detail drawer' }));
@@ -8743,15 +8749,29 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByText('AWS findings')).toBeInTheDocument();
     expect(screen.getByText(/source completeness could not be verified/i)).toBeInTheDocument();
     const prioritySummary = await screen.findByRole('region', { name: 'Finding priority summary' });
-    expect(within(prioritySummary).getByText('Unknown')).toBeInTheDocument();
-    expect(within(prioritySummary).getByText('20 risk signals · 18 affected resources')).toBeInTheDocument();
+    expect(within(prioritySummary).getByText('Completeness').closest('div')).toHaveTextContent('Unknown');
+    expect(within(prioritySummary).getByText('20 findings · 1 critical/high open · 18 affected resources')).toBeInTheDocument();
+    expect(within(prioritySummary).getByText(/Scan scan-aws-complete/)).toBeInTheDocument();
+    expect(within(prioritySummary).getByText('Account 123456789012 · 2 regions + Global')).toBeInTheDocument();
+    expect(within(prioritySummary).getByRole('link', { name: 'View coverage details' })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/coverage?environment=production'
+    );
     const findingsTable = await screen.findByRole('table', { name: 'AWS findings' });
-    expect(within(findingsTable).getByText('production-role', { exact: true })).toBeInTheDocument();
-    const overprivilegedRow = within(findingsTable).getByText('production-role', { exact: true }).closest('tr');
+    expect(findingsTable.closest('.idt-domain-table-wrap')).toHaveClass('is-narrow-stack');
+    expect(stylesSource).toContain('.idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table {');
+    expect(stylesSource).toContain('min-width: 0 !important;');
+    expect(stylesSource).toContain('content: attr(data-label);');
+    const [productionRoleFinding] = within(findingsTable).getAllByText('production-role', { exact: true });
+    const overprivilegedRow = productionRoleFinding.closest('tr');
     expect(overprivilegedRow).not.toBeNull();
-    expect(within(overprivilegedRow as HTMLElement).getByText('production-role · IAM role · Account 123456789012 · Global')).toBeInTheDocument();
-    expect(within(overprivilegedRow as HTMLElement).getByText('2 related risks detected for this identity.')).toBeInTheDocument();
-    expect(within(overprivilegedRow as HTMLElement).getByText('Source: iam-policy collector · Confidence: 82% · Completeness: Unknown')).toBeInTheDocument();
+    expect(overprivilegedRow).toHaveTextContent('production-role');
+    expect(overprivilegedRow).toHaveTextContent('IAM role');
+    expect(overprivilegedRow).toHaveTextContent('Account 123456789012 · Global');
+    expect(overprivilegedRow).toHaveTextContent('1 affected resource');
+    expect(overprivilegedRow).toHaveTextContent('2 related risks');
+    expect(overprivilegedRow).toHaveTextContent('iam-policy collector');
+    expect(overprivilegedRow).toHaveTextContent('Confidence: 82% · Completeness: Unknown');
     expect(within(overprivilegedRow as HTMLElement).queryByText('Technical evidence (2 refs)')).not.toBeInTheDocument();
     expect(within(overprivilegedRow as HTMLElement).queryByText('scan-aws-complete')).not.toBeInTheDocument();
     fireEvent.click(within(overprivilegedRow as HTMLElement).getByRole('button', { name: 'View details' }));
@@ -8788,11 +8808,12 @@ describe('Domain-first app routes', () => {
     expect(within(findingsTable).getByText('Blocked')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Suppressed')).toBeInTheDocument();
     expect(within(findingsTable).queryByText(/Region unknown/i)).not.toBeInTheDocument();
-    expect(within(findingsTable).getByText('shared-function · Lambda function · Account 123456789012 · Region us-east-1')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('shared-function · Lambda function · Account 123456789012 · Region eu-west-1')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('shared-function-colon · Lambda function · Account 123456789012 · Region us-east-1')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('payments · Lambda function · Account 123456789012 · Region us-east-1')).toBeInTheDocument();
-    expect(within(findingsTable).getByText('database-password-abc123 · Secrets Manager secret · Account 123456789012 · Region us-east-1')).toBeInTheDocument();
+    expect(within(findingsTable).getAllByText('shared-function')).toHaveLength(2);
+    expect(within(findingsTable).getAllByText('Lambda function').length).toBeGreaterThanOrEqual(4);
+    expect(within(findingsTable).getByText('Account 123456789012 · Region eu-west-1')).toBeInTheDocument();
+    expect(within(findingsTable).getByText('shared-function-colon')).toBeInTheDocument();
+    expect(within(findingsTable).getAllByText('payments')).toHaveLength(2);
+    expect(within(findingsTable).getByText('database-password-abc123')).toBeInTheDocument();
     expect(within(findingsTable).getByText('Production database secret', { exact: true })).toBeInTheDocument();
     expect(within(findingsTable).getByText('Staging database secret', { exact: true })).toBeInTheDocument();
 
@@ -8844,7 +8865,14 @@ describe('Domain-first app routes', () => {
         }
       ]
     });
-    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: { ...disconnectedAWS, connector_id: 'aws-connector-new' } });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({
+      connection: {
+        ...disconnectedAWS,
+        connector_id: 'aws-connector-new',
+        account_id: '123456789012',
+        region: 'us-east-1'
+      }
+    });
     vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
       scan: {
         id: 'scan-aws-history',
@@ -8887,11 +8915,117 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByText('AWS findings')).toBeInTheDocument();
     expect(await screen.findByText('Historical IAM finding')).toBeInTheDocument();
+    const prioritySummary = await screen.findByRole('region', { name: 'Finding priority summary' });
+    expect(within(prioritySummary).getByText('Account 999999999999 · Global')).toBeInTheDocument();
+    expect(within(prioritySummary).queryByText(/123456789012/)).not.toBeInTheDocument();
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Account' }), { target: { value: 'unknown' } });
+    const accountFilter = screen.getByRole('combobox', { name: 'Account' });
+    const regionFilter = screen.getByRole('combobox', { name: 'Region' });
+    expect(within(accountFilter).getByRole('option', { name: '999999999999' })).toHaveValue('999999999999');
+    expect(within(accountFilter).queryByRole('option', { name: '123456789012' })).not.toBeInTheDocument();
+    expect(within(regionFilter).getByRole('option', { name: 'Global resources' })).toHaveValue('global');
+    expect(within(regionFilter).queryByRole('option', { name: 'us-east-1' })).not.toBeInTheDocument();
+    fireEvent.change(accountFilter, { target: { value: '999999999999' } });
     expect(await screen.findByText('Historical IAM finding')).toBeInTheDocument();
-    fireEvent.change(screen.getByRole('combobox', { name: 'Account' }), { target: { value: 'connected' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Severity' }), { target: { value: 'critical' } });
     expect(await screen.findByText('No findings match these filters')).toBeInTheDocument();
+  });
+
+  it('names unavailable collectors and links partial findings to coverage details', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
+      scan: {
+        id: 'scan-aws-partial',
+        project_id: 'production',
+        connector_id: 'aws-connector-1',
+        provider: 'aws',
+        status: 'partial',
+        started_at: '2026-08-20T20:00:00Z',
+        finished_at: '2026-08-20T20:03:00Z',
+        asset_count: 1,
+        finding_count: 1
+      }
+    });
+    vi.spyOn(api.apiClient, 'listFindings').mockResolvedValue({
+      items: [
+        {
+          id: 'finding-aws-partial',
+          scan_id: 'scan-aws-partial',
+          type: 'aws_s3_public_bucket',
+          severity: 'high',
+          title: 'Public bucket from partial scan',
+          human_summary: 'The bucket policy allows public access.',
+          remediation: 'Restrict the bucket policy.',
+          path: ['arn:aws:s3:::partial-scan-bucket'],
+          evidence: { account_id: '123456789012', region: 'us-east-1' },
+          created_at: '2026-08-20T20:03:00Z',
+          lifecycle_status: 'open'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({
+      items: [
+        {
+          id: 'event-aws-partial',
+          scan_id: 'scan-aws-partial',
+          level: 'warning',
+          message: 'Discovery completed with partial sources.',
+          metadata: {
+            state: 'partial',
+            source_error_count: 2,
+            source_errors: [
+              {
+                collector: 'lambda_execution_roles',
+                source_id: '123456789012/us-west-2/lambda',
+                code: 'permission_denied',
+                retryable: true
+              },
+              {
+                collector: 'cloudtrail_activity',
+                code: 'source_unavailable',
+                retryable: false
+              }
+            ]
+          },
+          created_at: '2026-08-20T20:03:00Z'
+        }
+      ]
+    });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production&scan_id=scan-aws-partial']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Public bucket from partial scan')).toBeInTheDocument();
+    const prioritySummary = await screen.findByRole('region', { name: 'Finding priority summary' });
+    expect(within(prioritySummary).getByText('2 unavailable or degraded')).toBeInTheDocument();
+    expect(within(prioritySummary).getByText(/Lambda Execution Roles · 123456789012\/us-west-2\/lambda · Permission Denied · retryable/)).toBeInTheDocument();
+    expect(within(prioritySummary).getByText(/Cloudtrail Activity · Source Unavailable/)).toBeInTheDocument();
+    expect(within(prioritySummary).getByRole('link', { name: 'View coverage details' })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/coverage?environment=production'
+    );
   });
 
   it('rejects persisted AWS findings until the scan reaches a terminal result', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8110,6 +8110,13 @@ describe('Domain-first app routes', () => {
       finding_id: 'aws-secret-permission-equivalence:findings-route-actionable',
       status: 'action_required'
     };
+    const sameIdentityDifferentSecretFinding = {
+      ...equivalenceFinding,
+      finding_id: 'aws-secret-permission-equivalence:findings-route-second-secret',
+      secret_node_id: 'aws:resource:secret:github-api-key',
+      secret_label: 'github/api-key',
+      provider: 'github'
+    };
     const sameNameDifferentIdentityFinding = {
       ...equivalenceFinding,
       finding_id: 'aws-secret-permission-equivalence:findings-route-different-identity',
@@ -8122,7 +8129,12 @@ describe('Domain-first app routes', () => {
     const getSecretPermissionEquivalence = vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockResolvedValue({
       findings: {
         status: 'ready',
-        findings: [equivalenceFinding, actionableEquivalenceFinding, sameNameDifferentIdentityFinding],
+        findings: [
+          equivalenceFinding,
+          actionableEquivalenceFinding,
+          sameIdentityDifferentSecretFinding,
+          sameNameDifferentIdentityFinding
+        ],
         summary: {
           external_provider_key_count: 0,
           aws_managed_secret_count: 0,
@@ -8166,7 +8178,14 @@ describe('Domain-first app routes', () => {
     expect(liveFindingRow).toHaveTextContent('Secret · Case Triage');
     expect(liveFindingRow).toHaveTextContent('Secret');
     expect(liveFindingRow).toHaveTextContent('Account 123456789012 · Region us-east-1');
+    expect(liveFindingRow).toHaveTextContent('2 affected resources');
+    expect(liveFindingRow).toHaveTextContent('3 related risks');
     expect(within(findingsTable).getByText('Account 123456789012 · Region eu-west-1')).toBeInTheDocument();
+    expect(
+      within(screen.getByRole('region', { name: 'Finding priority summary' })).getByText(
+        '4 findings · 1 critical/high open · 3 affected resources'
+      )
+    ).toBeInTheDocument();
     const liveDetailsButton = within(liveFindingRow as HTMLElement).getByRole('button', { name: 'View details' });
     liveDetailsButton.focus();
     expect(liveDetailsButton).toHaveFocus();
@@ -8187,29 +8206,28 @@ describe('Domain-first app routes', () => {
       )
     );
 
-    getSecretPermissionEquivalence.mockResolvedValue({
-      findings: {
-        status: 'degraded',
-        findings: [equivalenceFinding],
-        summary: {
-          external_provider_key_count: 0,
-          aws_managed_secret_count: 0,
-          runtime_observed_count: 0,
-          kms_backed_count: 0
-        },
-        caveats: [],
-        failure_reasons: [],
-        remediation_hints: [],
-        coverage_gaps: [
-          {
-            capability: 'secrets_manager_runtime',
-            status: 'partial',
-            reason: 'Runtime delivery evidence is unavailable.'
-          }
-        ],
-        diagnostics: []
-      } as any
-    });
+    const degradedEquivalenceResult = {
+      status: 'degraded',
+      findings: [{ ...equivalenceFinding, region: '' }],
+      summary: {
+        external_provider_key_count: 0,
+        aws_managed_secret_count: 0,
+        runtime_observed_count: 0,
+        kms_backed_count: 0
+      },
+      caveats: [],
+      failure_reasons: [],
+      remediation_hints: [],
+      coverage_gaps: [
+        {
+          capability: 'secrets_manager_runtime',
+          status: 'partial',
+          reason: 'Runtime delivery evidence is unavailable.'
+        }
+      ],
+      diagnostics: []
+    } as any;
+    getSecretPermissionEquivalence.mockResolvedValue({ findings: degradedEquivalenceResult });
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Findings search' }), { target: { value: 'openai' } });
     await waitFor(() =>
@@ -8223,7 +8241,15 @@ describe('Domain-first app routes', () => {
     await waitFor(() =>
       expect(within(screen.getByRole('table', { name: 'AWS findings' })).getByText(/Completeness: Partial/i)).toBeInTheDocument()
     );
+    const degradedSummary = screen.getByRole('region', { name: 'Finding priority summary' });
+    expect(within(degradedSummary).getByText('Completeness').closest('div')).toHaveTextContent('Partial');
+    expect(within(degradedSummary).getByText('Source health').closest('div')).toHaveTextContent('1 unavailable or degraded');
+    expect(within(degradedSummary).getByText('Account 123456789012 · Region unavailable')).toBeInTheDocument();
+    expect(within(degradedSummary).getByText('Secrets Manager Runtime · Partial')).toBeInTheDocument();
 
+    getSecretPermissionEquivalence.mockResolvedValue({
+      findings: { ...degradedEquivalenceResult, findings: [equivalenceFinding] }
+    });
     fireEvent.change(screen.getByRole('textbox', { name: 'Findings search' }), { target: { value: '' } });
     await waitFor(() =>
       expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
@@ -8750,7 +8776,7 @@ describe('Domain-first app routes', () => {
     expect(screen.getByText(/source completeness could not be verified/i)).toBeInTheDocument();
     const prioritySummary = await screen.findByRole('region', { name: 'Finding priority summary' });
     expect(within(prioritySummary).getByText('Completeness').closest('div')).toHaveTextContent('Unknown');
-    expect(within(prioritySummary).getByText('20 findings · 1 critical/high open · 18 affected resources')).toBeInTheDocument();
+    expect(within(prioritySummary).getByText('20 findings · 0 critical/high open · 18 affected resources')).toBeInTheDocument();
     expect(within(prioritySummary).getByText(/Scan scan-aws-complete/)).toBeInTheDocument();
     expect(within(prioritySummary).getByText('Account 123456789012 · 2 regions + Global')).toBeInTheDocument();
     expect(within(prioritySummary).getByRole('link', { name: 'View coverage details' })).toHaveAttribute(
@@ -8762,6 +8788,7 @@ describe('Domain-first app routes', () => {
     expect(stylesSource).toContain('.idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table {');
     expect(stylesSource).toContain('min-width: 0 !important;');
     expect(stylesSource).toContain('content: attr(data-label);');
+    expect(stylesSource).toContain('overflow-wrap: anywhere;');
     const [productionRoleFinding] = within(findingsTable).getAllByText('production-role', { exact: true });
     const overprivilegedRow = productionRoleFinding.closest('tr');
     expect(overprivilegedRow).not.toBeNull();
@@ -8978,7 +9005,19 @@ describe('Domain-first app routes', () => {
         }
       ]
     });
-    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({
+    const listScanEvents = vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValueOnce({
+      items: [
+        {
+          id: 'event-aws-complete',
+          scan_id: 'scan-aws-partial',
+          level: 'info',
+          message: 'Discovery findings persisted.',
+          metadata: { state: 'complete' },
+          created_at: '2026-08-20T20:03:01Z'
+        }
+      ],
+      next_cursor: 'aws-events-page-2'
+    }).mockResolvedValueOnce({
       items: [
         {
           id: 'event-aws-partial',
@@ -9025,6 +9064,22 @@ describe('Domain-first app routes', () => {
     expect(within(prioritySummary).getByRole('link', { name: 'View coverage details' })).toHaveAttribute(
       'href',
       '/app/tenant-a/workspace-a/aws/coverage?environment=production'
+    );
+    expect(listScanEvents).toHaveBeenNthCalledWith(
+      1,
+      'scan-aws-partial',
+      undefined,
+      500,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' }),
+      undefined
+    );
+    expect(listScanEvents).toHaveBeenNthCalledWith(
+      2,
+      'scan-aws-partial',
+      undefined,
+      500,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' }),
+      'aws-events-page-2'
     );
   });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8407,7 +8407,15 @@ describe('Domain-first app routes', () => {
         caveats: [],
         remediation_hints: [],
         coverage_gaps: [],
-        diagnostics: []
+        diagnostics: [
+          {
+            collector: 'secret_permission_inventory',
+            source_id: 'production/live',
+            code: 'live_inventory_unavailable',
+            message: 'Live inventory is unavailable.',
+            retryable: true
+          }
+        ]
       } as any
     });
 
@@ -8424,6 +8432,17 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByText('Live AWS findings are not available yet')).toBeInTheDocument();
     expect(screen.getByText('live secret-permission inventory is unavailable')).toBeInTheDocument();
     expect(screen.queryByText('No AWS findings')).not.toBeInTheDocument();
+    const prioritySummary = screen.getByRole('region', { name: 'Finding priority summary' });
+    expect(within(prioritySummary).getByText('0 findings · 0 critical/high open · 0 affected resources')).toBeInTheDocument();
+    expect(within(prioritySummary).getByText('Completeness').closest('div')).toHaveTextContent('Partial');
+    expect(within(prioritySummary).getByText('Source health').closest('div')).toHaveTextContent('1 unavailable or degraded');
+    expect(
+      within(prioritySummary).getByText(/Secret Permission Inventory · production\/live · Live Inventory Unavailable · retryable/)
+    ).toBeInTheDocument();
+    expect(within(prioritySummary).getByRole('link', { name: 'View coverage details' })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/coverage?environment=production'
+    );
   });
 
   it('shows findings persisted by the completed AWS discovery scan', async () => {
@@ -9220,6 +9239,14 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByText('No findings in this AWS scan')).toBeInTheDocument();
     expect(screen.getByText('Evidence incomplete')).toBeInTheDocument();
     expect(screen.getByText(/sources that were available/i)).toBeInTheDocument();
+    const prioritySummary = screen.getByRole('region', { name: 'Finding priority summary' });
+    expect(within(prioritySummary).getByText('Completeness').closest('div')).toHaveTextContent('Partial');
+    expect(within(prioritySummary).getByText('Source health').closest('div')).toHaveTextContent('Degraded');
+    expect(within(prioritySummary).getByText(/Collector details were not retained for this partial result/)).toBeInTheDocument();
+    expect(within(prioritySummary).getByRole('link', { name: 'View coverage details' })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/coverage?environment=production'
+    );
   });
 
   it('clears a completed scan context when switching AWS findings environments', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18318,6 +18318,9 @@ function AWSFindingSeveritySummary({
     : 'Live collector view';
   const scopeLabel = awsFindingQueueScopeLabel(rows, connection, showingPersistedScan);
   const completenessLabel = awsPersistedFindingCompletenessLabel(completeness);
+  const sourceHealthLabel = coverage.totalCount > 0
+    ? `${coverage.totalCount} unavailable or degraded`
+    : completeness === 'unknown' ? 'Unknown' : completeness === 'partial' ? 'Degraded' : 'Available';
   return (
     <section className="idt-aws-finding-summary" aria-label="Finding priority summary">
       <div className="idt-aws-finding-summary-heading">
@@ -18339,7 +18342,7 @@ function AWSFindingSeveritySummary({
         <div><dt>Scan</dt><dd>{scanLabel}</dd></div>
         <div><dt>Scope</dt><dd>{scopeLabel}</dd></div>
         <div><dt>Completeness</dt><dd>{completenessLabel}</dd></div>
-        <div><dt>Source health</dt><dd>{coverage.totalCount > 0 ? `${coverage.totalCount} unavailable or degraded` : completeness === 'unknown' ? 'Unknown' : 'Available'}</dd></div>
+        <div><dt>Source health</dt><dd>{sourceHealthLabel}</dd></div>
       </dl>
       {coverage.totalCount > 0 ? (
         <div className="idt-aws-finding-coverage-warning" role="status">
@@ -18361,6 +18364,12 @@ function AWSFindingSeveritySummary({
           <strong>Coverage could not be verified</strong>
           <p>Scan source events are unavailable, so this result must not be treated as complete.</p>
           <Link to={coveragePath}>View coverage details</Link>
+        </div>
+      ) : completeness === 'partial' ? (
+        <div className="idt-aws-finding-coverage-warning" role="status">
+          <strong>Coverage needs attention</strong>
+          <p>Collector details were not retained for this partial result, so it must not be treated as complete.</p>
+          {coveragePath ? <Link to={coveragePath}>View coverage details</Link> : null}
         </div>
       ) : null}
     </section>
@@ -19203,7 +19212,7 @@ function AWSFindingsContent({
   const liveFindingsReadyToLoad = Boolean(scope && environmentID && connection?.connected);
   const isLoading = loading || (showingPersistedScan && persistedScanReadyToLoad && !persistedFindings && !error) || (!showingPersistedScan && liveFindingsReadyToLoad && !findings && !error);
   const coveragePath = scope && environmentID ? awsRouteLink(scope, 'coverage', environmentID) : undefined;
-  const showSummary = !error && !isLoading && (rows.length > 0 || Boolean(showingPersistedScan && persistedScan));
+  const showSummary = !error && !isLoading && (showingPersistedScan ? Boolean(persistedScan) : Boolean(findings));
 
   return (
     <>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -13155,14 +13155,28 @@ type AWSRiskOperationTableRow = AWSInventoryFilterable & {
   relatedRows?: AWSRiskOperationTableRow[];
 };
 
+type AWSFindingCoverageIssue = {
+  collector: string;
+  sourceID?: string;
+  code?: string;
+  retryable: boolean;
+};
+
+type AWSFindingCoverageContext = {
+  totalCount: number;
+  issues: AWSFindingCoverageIssue[];
+};
+
 function AWSRiskOperationFilterSet({
   routeID,
   filters,
-  onChange
+  onChange,
+  configs
 }: {
   routeID: AWSRiskOperationRouteID;
   filters: AWSInventoryFilterState;
   onChange: (nextFilters: AWSInventoryFilterState) => void;
+  configs?: AWSInventoryFilterConfig[];
 }) {
   const searchPlaceholder: Record<AWSRiskOperationRouteID, string> = {
     runtime: 'Search events',
@@ -13189,7 +13203,7 @@ function AWSRiskOperationFilterSet({
 
   return (
     <DomainFilterBar label={`${AWS_RISK_OPERATION_PAGE_COPY[routeID].title} filters`}>
-      {AWS_RISK_OPERATION_FILTERS[routeID].map((filter) => (
+      {(configs ?? AWS_RISK_OPERATION_FILTERS[routeID]).map((filter) => (
         <label key={filter.label}>
           {filter.label}
           <select value={filters[filter.id] ?? 'all'} onChange={(event) => onFilterChange(filter.id, event.target.value)}>
@@ -18136,14 +18150,33 @@ function AWSGraphEvidenceDrawer({ refs }: { refs: string[] }) {
 
 function AWSFindingEvidenceCell({ row }: { row: AWSRiskOperationTableRow }) {
   const metadata = [
-    row.source ? `Source: ${row.source}` : undefined,
     row.confidence !== undefined ? `Confidence: ${formatConfidenceScore(row.confidence)}` : undefined,
     row.completeness ? `Completeness: ${awsPersistedFindingCompletenessLabel(row.completeness)}` : undefined
   ].filter(Boolean);
   return (
     <div className="idt-aws-finding-evidence-cell">
-      <span>{row.evidence}</span>
+      <span>{row.source || 'AWS scanner'}</span>
       {metadata.length > 0 ? <small>{metadata.join(' · ')}</small> : null}
+    </div>
+  );
+}
+
+function AWSFindingAffectedResourceCell({ row }: { row: AWSRiskOperationTableRow }) {
+  return (
+    <div className="idt-aws-finding-resource-cell">
+      <strong>{row.resourceLabel || row.identity || row.title}</strong>
+      <small>{[row.resourceType, row.identity && row.identity !== row.resourceLabel ? row.identity : undefined].filter(Boolean).join(' · ') || 'AWS resource'}</small>
+      <small>{row.scopeLabel || row.blastRadius}</small>
+    </div>
+  );
+}
+
+function AWSFindingBlastRadiusCell({ row }: { row: AWSRiskOperationTableRow }) {
+  const relatedRiskCount = row.relatedRows?.length ?? 1;
+  return (
+    <div className="idt-aws-finding-blast-cell">
+      <strong>1 affected resource</strong>
+      <small>{relatedRiskCount} related risk{relatedRiskCount === 1 ? '' : 's'}</small>
     </div>
   );
 }
@@ -18180,7 +18213,91 @@ function awsFindingDistinctResourceCount(rows: AWSRiskOperationTableRow[]): numb
   return new Set(rows.map(awsFindingResourceKey)).size;
 }
 
-function AWSFindingSeveritySummary({ rows, resourceCount }: { rows: AWSRiskOperationTableRow[]; resourceCount: number }) {
+function awsFindingQueueScopeLabel(
+  rows: AWSRiskOperationTableRow[],
+  connection: AWSConnectionStatus | null,
+  showingPersistedScan: boolean
+): string {
+  const accounts = [...new Set(rows.map((row) => normalizeValue(row.accountID)).filter(Boolean))];
+  const scopes = [...new Set(rows.flatMap((row) => {
+    const region = normalizeValue(row.region);
+    if (region) return [region];
+    return normalizeValue(row.scopeLabel).toLowerCase().includes('global') ? ['Global'] : [];
+  }))];
+  if (!showingPersistedScan) {
+    const currentAccount = normalizeValue(connection?.account_id);
+    const currentRegion = normalizeValue(connection?.region);
+    if (accounts.length === 0 && currentAccount) accounts.push(currentAccount);
+    if (scopes.length === 0 && currentRegion) scopes.push(currentRegion);
+  }
+  const accountLabel = accounts.length === 0 ? 'Account unavailable' : accounts.length === 1 ? `Account ${accounts[0]}` : `${accounts.length} accounts`;
+  const includesGlobal = scopes.includes('Global');
+  const regions = scopes.filter((scope) => scope !== 'Global');
+  const regionLabel = regions.length === 0
+    ? includesGlobal ? 'Global' : 'Region unavailable'
+    : `${regions.length === 1 ? regions[0] : `${regions.length} regions`}${includesGlobal ? ' + Global' : ''}`;
+  return `${accountLabel} · ${regionLabel}`;
+}
+
+function awsFindingFilterConfigs(
+  rows: AWSRiskOperationTableRow[],
+  showingPersistedScan: boolean
+): AWSInventoryFilterConfig[] | undefined {
+  if (!showingPersistedScan) {
+    return undefined;
+  }
+  const accounts = [...new Set(rows.map((row) => normalizeValue(row.accountID)).filter(Boolean))].sort();
+  const regions = [...new Set(rows.map((row) => normalizeValue(row.region)).filter(Boolean))].sort();
+  const hasGlobalResources = rows.some((row) => normalizeValue(row.scopeLabel).toLowerCase().includes('global'));
+  const hasUnknownAccount = rows.some((row) => !normalizeValue(row.accountID));
+  const hasUnknownRegion = rows.some(
+    (row) => !normalizeValue(row.region) && !normalizeValue(row.scopeLabel).toLowerCase().includes('global')
+  );
+  return AWS_RISK_OPERATION_FILTERS.findings.map((filter) => {
+    if (filter.id === 'account') {
+      return {
+        ...filter,
+        options: [
+          { label: 'All scan accounts', value: 'all' },
+          ...accounts.map((account) => ({ label: account, value: account })),
+          ...(hasUnknownAccount ? [{ label: 'Account unavailable', value: 'unknown' }] : [])
+        ]
+      };
+    }
+    if (filter.id === 'region') {
+      return {
+        ...filter,
+        options: [
+          { label: 'All scan regions', value: 'all' },
+          ...regions.map((region) => ({ label: region, value: region })),
+          ...(hasGlobalResources ? [{ label: 'Global resources', value: 'global' }] : []),
+          ...(hasUnknownRegion ? [{ label: 'Region unavailable', value: 'unknown' }] : [])
+        ]
+      };
+    }
+    return filter;
+  });
+}
+
+function AWSFindingSeveritySummary({
+  rows,
+  resourceCount,
+  persistedScan,
+  showingPersistedScan,
+  completeness,
+  coverage,
+  coveragePath,
+  connection
+}: {
+  rows: AWSRiskOperationTableRow[];
+  resourceCount: number;
+  persistedScan: ScanRecord | null;
+  showingPersistedScan: boolean;
+  completeness: string;
+  coverage: AWSFindingCoverageContext;
+  coveragePath?: string;
+  connection: AWSConnectionStatus | null;
+}) {
   const counts = ['critical', 'high', 'medium', 'low', 'unknown'].map((severity) => ({
     severity,
     count: rows.filter((row) => {
@@ -18188,12 +18305,22 @@ function AWSFindingSeveritySummary({ rows, resourceCount }: { rows: AWSRiskOpera
       return normalized === severity || (severity === 'unknown' && !['critical', 'high', 'medium', 'low'].includes(normalized));
     }).length
   }));
+  const criticalHighOpen = groupAWSFindingRows(rows).filter((row) => {
+    const severity = normalizeValue(awsFindingDisplaySeverity(row)).toLowerCase();
+    return (severity === 'critical' || severity === 'high') && normalizeValue(row.status).toLowerCase() === 'open';
+  }).length;
+  const scanTimestamp = normalizeValue(persistedScan?.finished_at) || normalizeValue(persistedScan?.started_at);
+  const scanLabel = showingPersistedScan
+    ? `${scanTimestamp ? formatDateLabel(scanTimestamp) : 'Time unavailable'} · Scan ${normalizeValue(persistedScan?.id) || 'unavailable'}`
+    : 'Live collector view';
+  const scopeLabel = awsFindingQueueScopeLabel(rows, connection, showingPersistedScan);
+  const completenessLabel = awsPersistedFindingCompletenessLabel(completeness);
   return (
     <section className="idt-aws-finding-summary" aria-label="Finding priority summary">
       <div className="idt-aws-finding-summary-heading">
         <div>
           <p className="idt-app-kicker">Priority overview</p>
-          <strong>{rows.length} risk signals · {resourceCount} affected resources</strong>
+          <strong>{rows.length} findings · {criticalHighOpen} critical/high open · {resourceCount} affected resources</strong>
         </div>
         <span className="idt-aws-finding-summary-note">Sorted by severity</span>
       </div>
@@ -18205,6 +18332,34 @@ function AWSFindingSeveritySummary({ rows, resourceCount }: { rows: AWSRiskOpera
           </div>
         ))}
       </div>
+      <dl className="idt-aws-finding-scope-summary">
+        <div><dt>Scan</dt><dd>{scanLabel}</dd></div>
+        <div><dt>Scope</dt><dd>{scopeLabel}</dd></div>
+        <div><dt>Completeness</dt><dd>{completenessLabel}</dd></div>
+        <div><dt>Source health</dt><dd>{coverage.totalCount > 0 ? `${coverage.totalCount} unavailable or degraded` : completeness === 'unknown' ? 'Unknown' : 'Available'}</dd></div>
+      </dl>
+      {coverage.totalCount > 0 ? (
+        <div className="idt-aws-finding-coverage-warning" role="status">
+          <strong>Coverage needs attention</strong>
+          {coverage.issues.length > 0 ? (
+            <ul>
+              {coverage.issues.map((issue) => (
+                <li key={`${issue.collector}:${issue.sourceID ?? ''}:${issue.code ?? ''}`}>
+                  {formatTokenLabel(issue.collector)}{issue.sourceID ? ` · ${issue.sourceID}` : ''}{issue.code ? ` · ${formatTokenLabel(issue.code)}` : ''}{issue.retryable ? ' · retryable' : ''}
+                </li>
+              ))}
+            </ul>
+          ) : <p>Collector details were not retained for this scan.</p>}
+          {coverage.totalCount > coverage.issues.length ? <p>{coverage.totalCount - coverage.issues.length} additional source issue{coverage.totalCount - coverage.issues.length === 1 ? '' : 's'} were not included in the event sample.</p> : null}
+          {coveragePath ? <Link to={coveragePath}>View coverage details</Link> : null}
+        </div>
+      ) : completeness === 'unknown' && coveragePath ? (
+        <div className="idt-aws-finding-coverage-warning" role="status">
+          <strong>Coverage could not be verified</strong>
+          <p>Scan source events are unavailable, so this result must not be treated as complete.</p>
+          <Link to={coveragePath}>View coverage details</Link>
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -18857,7 +19012,6 @@ function awsPersistedFindingScope(finding: ApiFinding): AWSPersistedFindingScope
 
 function awsPersistedFindingRiskOperationRow(
   finding: ApiFinding,
-  connection: AWSConnectionStatus | null,
   persistedScan: ScanRecord | null,
   completeness: string
 ): AWSRiskOperationTableRow {
@@ -18910,8 +19064,8 @@ function awsPersistedFindingRiskOperationRow(
     triageUpdatedBy: finding.triage?.updated_by,
     filters: {
       severity: normalizeValue(finding.severity).toLowerCase() || 'unknown',
-      account: findingScope.accountID && findingScope.accountID === connection?.account_id ? 'connected' : 'unknown',
-      region: findingScope.global ? 'global' : findingScope.region && findingScope.region === connection?.region ? 'current' : findingScope.region ? 'other' : 'unknown',
+      account: findingScope.accountID || 'unknown',
+      region: findingScope.global ? 'global' : findingScope.region || 'unknown',
       evidence: Object.keys(finding.evidence ?? {}).length > 0 ? 'inventory-backed' : 'unavailable',
       status
     },
@@ -18951,6 +19105,7 @@ function AWSFindingsContent({
   persistedScan,
   persistedScanPartial,
   persistedScanCoverageUnknown,
+  persistedScanCoverage,
   persistedScanID,
   scope,
   environmentID,
@@ -18966,6 +19121,7 @@ function AWSFindingsContent({
   persistedScan: ScanRecord | null;
   persistedScanPartial: boolean;
   persistedScanCoverageUnknown: boolean;
+  persistedScanCoverage: AWSFindingCoverageContext;
   persistedScanID?: string;
   scope: ProductSession | null;
   environmentID?: string;
@@ -18979,7 +19135,7 @@ function AWSFindingsContent({
   const showingPersistedScan = Boolean(persistedScanID);
   const persistedCompleteness = persistedScanPartial ? 'partial' : persistedScanCoverageUnknown ? 'unknown' : 'complete';
   const rows = showingPersistedScan
-    ? persistedFindings?.map((finding) => awsPersistedFindingRiskOperationRow(finding, connection, persistedScan, persistedCompleteness)) ?? []
+    ? persistedFindings?.map((finding) => awsPersistedFindingRiskOperationRow(finding, persistedScan, persistedCompleteness)) ?? []
     : findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, findings, scope, environmentID, connection)) ?? [];
   const filteredRows = filterAWSInventoryRows(rows, filters);
   const displayedRows = groupAWSFindingRows(filteredRows).sort(
@@ -18990,6 +19146,8 @@ function AWSFindingsContent({
   const persistedScanReadyToLoad = Boolean(scope && environmentID);
   const liveFindingsReadyToLoad = Boolean(scope && environmentID && connection?.connected);
   const isLoading = loading || (showingPersistedScan && persistedScanReadyToLoad && !persistedFindings && !error) || (!showingPersistedScan && liveFindingsReadyToLoad && !findings && !error);
+  const coveragePath = scope && environmentID ? awsRouteLink(scope, 'coverage', environmentID) : undefined;
+  const showSummary = !error && !isLoading && (rows.length > 0 || Boolean(showingPersistedScan && persistedScan));
 
   return (
     <>
@@ -19009,8 +19167,24 @@ function AWSFindingsContent({
           </p>
         </DomainStatusPanel>
       ) : null}
-      {displayedRows.length > 0 ? <AWSFindingSeveritySummary rows={filteredRows} resourceCount={awsFindingDistinctResourceCount(filteredRows)} /> : null}
-      <AWSRiskOperationFilterSet routeID="findings" filters={filters} onChange={onFiltersChange} />
+      {showSummary ? (
+        <AWSFindingSeveritySummary
+          rows={rows}
+          resourceCount={awsFindingDistinctResourceCount(rows)}
+          persistedScan={persistedScan}
+          showingPersistedScan={showingPersistedScan}
+          completeness={persistedCompleteness}
+          coverage={persistedScanCoverage}
+          coveragePath={coveragePath}
+          connection={connection}
+        />
+      ) : null}
+      <AWSRiskOperationFilterSet
+        routeID="findings"
+        filters={filters}
+        onChange={onFiltersChange}
+        configs={awsFindingFilterConfigs(rows, showingPersistedScan)}
+      />
       {error ? (
         <DomainErrorState
           title="Couldn't load AWS findings"
@@ -19026,6 +19200,7 @@ function AWSFindingsContent({
       ) : (
         <DomainDataTable
           label="AWS findings"
+          stackOnNarrow
           rows={displayedRows}
           getRowKey={(row) => row.id}
           emptyState={
@@ -19056,12 +19231,22 @@ function AWSFindingsContent({
             />
           }
           columns={[
-            { key: 'title', header: 'Finding', render: (row) => row.detailLink ? <Link to={row.detailLink}>{row.title}</Link> : <strong>{row.title}</strong> },
             { key: 'category', header: 'Severity', render: (row) => <AWSFindingSeverityBadge severity={awsFindingDisplaySeverity(row)} /> },
-            { key: 'evidence', header: 'Evidence', render: (row) => <AWSFindingEvidenceCell row={row} /> },
-            { key: 'blast', header: 'Blast radius', render: (row) => row.blastRadius },
-            { key: 'status', header: 'Status', render: (row) => <AWSFindingStatusBadge status={row.status} showingPersistedScan={showingPersistedScan} /> },
-            { key: 'action', header: 'Action', render: (row) => <button type="button" className="idt-aws-finding-view-details" onClick={() => setSelectedRowID(row.id)}>View details</button> }
+            { key: 'title', header: 'Finding', render: (row) => row.detailLink ? <Link to={row.detailLink}>{row.title}</Link> : <strong>{row.title}</strong> },
+            { key: 'resource', header: 'Affected resource', render: (row) => <AWSFindingAffectedResourceCell row={row} /> },
+            { key: 'why', header: 'Why it matters', render: (row) => <span className="idt-aws-finding-why-cell">{row.evidence}</span> },
+            { key: 'blast', header: 'Blast radius', render: (row) => <AWSFindingBlastRadiusCell row={row} /> },
+            { key: 'evidence', header: 'Confidence / evidence', render: (row) => <AWSFindingEvidenceCell row={row} /> },
+            {
+              key: 'workflow',
+              header: 'Workflow',
+              render: (row) => (
+                <div className="idt-aws-finding-workflow-cell">
+                  <AWSFindingStatusBadge status={row.status} showingPersistedScan={showingPersistedScan} />
+                  <button type="button" className="idt-aws-finding-view-details" onClick={() => setSelectedRowID(row.id)}>View details</button>
+                </div>
+              )
+            }
           ]}
         />
       )}
@@ -19427,6 +19612,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [persistedScan, setPersistedScan] = useState<ScanRecord | null>(null);
   const [persistedScanPartial, setPersistedScanPartial] = useState(false);
   const [persistedScanCoverageUnknown, setPersistedScanCoverageUnknown] = useState(false);
+  const [persistedScanCoverage, setPersistedScanCoverage] = useState<AWSFindingCoverageContext>({
+    totalCount: 0,
+    issues: []
+  });
   const [persistedFindingsLoading, setPersistedFindingsLoading] = useState(false);
   const [persistedFindingsError, setPersistedFindingsError] = useState('');
   const persistedFindingsRequestRef = useRef(0);
@@ -19437,7 +19626,7 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
 
   useEffect(() => {
     setActiveFilters({ ...AWS_RISK_OPERATION_FILTER_DEFAULTS[routeID] });
-  }, [routeID]);
+  }, [persistedScanID, routeID, selectedEnvironmentID]);
 
   const showSecretPermissionEquivalence = routeID === 'runtime';
   const shouldLoadSecretPermissionEquivalence = routeID === 'runtime' || (routeID === 'findings' && !persistedScanID);
@@ -21302,6 +21491,7 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     setPersistedScan(null);
     setPersistedScanPartial(false);
     setPersistedScanCoverageUnknown(false);
+    setPersistedScanCoverage({ totalCount: 0, issues: [] });
     setPersistedFindingsError('');
     if (routeID !== 'findings' || !persistedScanID || !scope || !selectedEnvironmentID) {
       setPersistedFindingsLoading(false);
@@ -21338,9 +21528,13 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       ) {
         throw new Error('The requested AWS scan does not belong to this environment.');
       }
+      const coverage = awsDiscoveryFindingCoverage(eventsResponse.items);
       setPersistedScan(scan);
       setPersistedFindings(findingsResponse);
-      setPersistedScanPartial(scanStatus === 'partial' || awsDiscoveryHasPartialResults(eventsResponse.items));
+      setPersistedScanCoverage(coverage);
+      setPersistedScanPartial(
+        scanStatus === 'partial' || coverage.totalCount > 0 || awsDiscoveryHasPartialResults(eventsResponse.items)
+      );
       setPersistedScanCoverageUnknown(!eventsResponse.available);
     } catch (requestError) {
       if (requestID !== persistedFindingsRequestRef.current) {
@@ -21739,6 +21933,7 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             persistedScan={persistedScan}
             persistedScanPartial={persistedScanPartial}
             persistedScanCoverageUnknown={persistedScanCoverageUnknown}
+            persistedScanCoverage={persistedScanCoverage}
             persistedScanID={persistedScanID}
             scope={scope}
             environmentID={selectedEnvironmentID}
@@ -21845,6 +22040,44 @@ function awsDiscoveryHasPartialResults(events: ScanEvent[]): boolean {
     const message = normalizeValue(event.message).toLowerCase();
     return message.includes('partial source') || normalizeValue(event.metadata?.state).toLowerCase() === 'partial';
   });
+}
+
+function awsDiscoveryFindingCoverage(events: ScanEvent[]): AWSFindingCoverageContext {
+  const issues: AWSFindingCoverageIssue[] = [];
+  const seenIssues = new Set<string>();
+  let totalCount = 0;
+
+  for (const event of events) {
+    const declaredCount = Number(event.metadata?.source_error_count);
+    if (Number.isFinite(declaredCount) && declaredCount > totalCount) {
+      totalCount = Math.floor(declaredCount);
+    }
+    const sourceErrors = event.metadata?.source_errors;
+    if (!Array.isArray(sourceErrors)) {
+      continue;
+    }
+    for (const sourceError of sourceErrors) {
+      if (!sourceError || typeof sourceError !== 'object' || Array.isArray(sourceError)) {
+        continue;
+      }
+      const error = sourceError as Record<string, unknown>;
+      const collector = normalizeValue(error.collector) || 'Unknown collector';
+      const sourceID = normalizeValue(error.source_id) || undefined;
+      const code = normalizeValue(error.code) || undefined;
+      const retryable = error.retryable === true;
+      const issueKey = `${collector}\u0000${sourceID ?? ''}\u0000${code ?? ''}`;
+      if (seenIssues.has(issueKey)) {
+        continue;
+      }
+      seenIssues.add(issueKey);
+      issues.push({ collector, sourceID, code, retryable });
+    }
+  }
+
+  return {
+    totalCount: Math.max(totalCount, issues.length),
+    issues: issues.slice(0, 8)
+  };
 }
 
 function awsDiscoveryPhase(scan: ScanRecord | null, events: ScanEvent[]): AWSDiscoveryPhase {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18172,10 +18172,12 @@ function AWSFindingAffectedResourceCell({ row }: { row: AWSRiskOperationTableRow
 }
 
 function AWSFindingBlastRadiusCell({ row }: { row: AWSRiskOperationTableRow }) {
-  const relatedRiskCount = row.relatedRows?.length ?? 1;
+  const relatedRows = row.relatedRows ?? [row];
+  const relatedRiskCount = relatedRows.length;
+  const affectedResourceCount = awsFindingDistinctResourceCount(relatedRows);
   return (
     <div className="idt-aws-finding-blast-cell">
-      <strong>1 affected resource</strong>
+      <strong>{affectedResourceCount} affected resource{affectedResourceCount === 1 ? '' : 's'}</strong>
       <small>{relatedRiskCount} related risk{relatedRiskCount === 1 ? '' : 's'}</small>
     </div>
   );
@@ -18225,10 +18227,11 @@ function awsFindingQueueScopeLabel(
     return normalizeValue(row.scopeLabel).toLowerCase().includes('global') ? ['Global'] : [];
   }))];
   if (!showingPersistedScan) {
+    const hasFindingAccount = accounts.length > 0;
     const currentAccount = normalizeValue(connection?.account_id);
     const currentRegion = normalizeValue(connection?.region);
     if (accounts.length === 0 && currentAccount) accounts.push(currentAccount);
-    if (scopes.length === 0 && currentRegion) scopes.push(currentRegion);
+    if (scopes.length === 0 && !hasFindingAccount && currentRegion) scopes.push(currentRegion);
   }
   const accountLabel = accounts.length === 0 ? 'Account unavailable' : accounts.length === 1 ? `Account ${accounts[0]}` : `${accounts.length} accounts`;
   const includesGlobal = scopes.includes('Global');
@@ -18305,9 +18308,9 @@ function AWSFindingSeveritySummary({
       return normalized === severity || (severity === 'unknown' && !['critical', 'high', 'medium', 'low'].includes(normalized));
     }).length
   }));
-  const criticalHighOpen = groupAWSFindingRows(rows).filter((row) => {
-    const severity = normalizeValue(awsFindingDisplaySeverity(row)).toLowerCase();
-    return (severity === 'critical' || severity === 'high') && normalizeValue(row.status).toLowerCase() === 'open';
+  const criticalHighOpen = rows.filter((row) => {
+    const severity = normalizeValue(row.category).toLowerCase();
+    return (severity === 'critical' || severity === 'high') && normalizeValue(row.filters.status).toLowerCase() === 'open';
   }).length;
   const scanTimestamp = normalizeValue(persistedScan?.finished_at) || normalizeValue(persistedScan?.started_at);
   const scanLabel = showingPersistedScan
@@ -18666,6 +18669,31 @@ function awsSecretPermissionEquivalenceCompleteness(result: AWSSecretPermissionE
   return 'complete';
 }
 
+function awsSecretPermissionEquivalenceCoverage(
+  result: AWSSecretPermissionEquivalenceResult | null
+): AWSFindingCoverageContext {
+  if (!result || result.status === 'ready') {
+    return { totalCount: 0, issues: [] };
+  }
+  const diagnosticIssues = result.diagnostics.map((diagnostic) => ({
+    collector: diagnostic.collector || 'Unknown collector',
+    sourceID: diagnostic.source_id,
+    code: diagnostic.code,
+    retryable: diagnostic.retryable
+  }));
+  const issues = diagnosticIssues.length > 0
+    ? diagnosticIssues
+    : result.coverage_gaps.map((gap) => ({
+        collector: gap.capability || 'Unknown capability',
+        code: gap.status,
+        retryable: false
+      }));
+  return {
+    totalCount: Math.max(issues.length, 1),
+    issues: issues.slice(0, 8)
+  };
+}
+
 function awsPersistedFindingStage(finding: ApiFinding): AWSCapabilityStage {
   const severity = normalizeValue(finding.severity).toLowerCase();
   if (severity === 'critical') {
@@ -18709,6 +18737,7 @@ function awsPersistedFindingStatusLabel(status: string): string {
 }
 
 const AWS_PERSISTED_FINDINGS_PAGE_LIMIT = 500;
+const AWS_SCAN_EVENTS_PAGE_LIMIT = 500;
 
 async function listAllAWSScanFindings(scanID: string, auth: RequestAuthContext): Promise<ApiFinding[]> {
   const findings: ApiFinding[] = [];
@@ -18732,6 +18761,27 @@ async function listAllAWSScanFindings(scanID: string, auth: RequestAuthContext):
     }
     if (seenCursors.has(nextCursor)) {
       throw new Error('AWS findings pagination returned a repeated cursor.');
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+}
+
+async function listAllAWSScanEvents(scanID: string, auth: RequestAuthContext): Promise<ScanEvent[]> {
+  const events: ScanEvent[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  while (true) {
+    const response = await apiClient.listScanEvents(scanID, undefined, AWS_SCAN_EVENTS_PAGE_LIMIT, auth, cursor);
+    events.push(...response.items);
+
+    const nextCursor = normalizeValue(response.next_cursor);
+    if (!nextCursor) {
+      return events;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error('AWS scan event pagination returned a repeated cursor.');
     }
     seenCursors.add(nextCursor);
     cursor = nextCursor;
@@ -19134,6 +19184,12 @@ function AWSFindingsContent({
 }) {
   const showingPersistedScan = Boolean(persistedScanID);
   const persistedCompleteness = persistedScanPartial ? 'partial' : persistedScanCoverageUnknown ? 'unknown' : 'complete';
+  const findingCompleteness = showingPersistedScan
+    ? persistedCompleteness
+    : findings ? awsSecretPermissionEquivalenceCompleteness(findings) : 'unknown';
+  const findingCoverage = showingPersistedScan
+    ? persistedScanCoverage
+    : awsSecretPermissionEquivalenceCoverage(findings);
   const rows = showingPersistedScan
     ? persistedFindings?.map((finding) => awsPersistedFindingRiskOperationRow(finding, persistedScan, persistedCompleteness)) ?? []
     : findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, findings, scope, environmentID, connection)) ?? [];
@@ -19173,8 +19229,8 @@ function AWSFindingsContent({
           resourceCount={awsFindingDistinctResourceCount(rows)}
           persistedScan={persistedScan}
           showingPersistedScan={showingPersistedScan}
-          completeness={persistedCompleteness}
-          coverage={persistedScanCoverage}
+          completeness={findingCompleteness}
+          coverage={findingCoverage}
           coveragePath={coveragePath}
           connection={connection}
         />
@@ -21503,8 +21559,8 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       const [scanResponse, findingsResponse, eventsResponse] = await Promise.all([
         apiClient.getScan(persistedScanID, auth),
         listAllAWSScanFindings(persistedScanID, auth),
-        apiClient.listScanEvents(persistedScanID, undefined, 100, auth)
-          .then((response) => ({ items: response.items, available: true }))
+        listAllAWSScanEvents(persistedScanID, auth)
+          .then((items) => ({ items, available: true }))
           .catch(() => ({ items: [], available: false }))
       ]);
       if (requestID !== persistedFindingsRequestRef.current) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -33751,6 +33751,12 @@ html[data-theme='light'] .idt-danger-modal-typed input {
     border-bottom: 0;
   }
 
+  .idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table td > * {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
   .idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table td::before {
     content: attr(data-label);
     color: var(--idt-text-muted, #aeb8c9);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -33447,6 +33447,39 @@ html[data-theme='light'] .idt-danger-modal-typed input {
   min-width: 12rem;
 }
 
+.idt-aws-finding-resource-cell,
+.idt-aws-finding-blast-cell,
+.idt-aws-finding-workflow-cell {
+  display: grid;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.idt-aws-finding-resource-cell {
+  min-width: 12rem;
+}
+
+.idt-aws-finding-resource-cell > strong,
+.idt-aws-finding-resource-cell > small,
+.idt-aws-finding-blast-cell > small {
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-finding-resource-cell > small,
+.idt-aws-finding-blast-cell > small {
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.idt-aws-finding-why-cell {
+  min-width: 13rem;
+  margin: 0;
+  color: var(--idt-text-muted, #c1c9d7);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
 .idt-aws-finding-evidence-cell > small {
   color: var(--idt-text-muted, #aeb8c9);
   font-size: 0.72rem;
@@ -33574,6 +33607,75 @@ html[data-theme='light'] .idt-danger-modal-typed input {
   font-size: 0.9rem;
 }
 
+.idt-aws-finding-scope-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+  border: 1px solid rgba(154, 164, 190, 0.2);
+  border-radius: 0.35rem;
+  background: rgba(4, 8, 18, 0.24);
+}
+
+.idt-aws-finding-scope-summary > div {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+  border-right: 1px solid rgba(154, 164, 190, 0.2);
+  padding: 0.65rem;
+}
+
+.idt-aws-finding-scope-summary > div:last-child {
+  border-right: 0;
+}
+
+.idt-aws-finding-scope-summary dt {
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.idt-aws-finding-scope-summary dd {
+  margin: 0;
+  color: var(--app-text);
+  font-size: 0.78rem;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-finding-coverage-warning {
+  display: grid;
+  gap: 0.45rem;
+  border: 1px solid rgba(251, 171, 64, 0.48);
+  border-radius: 0.4rem;
+  padding: 0.7rem 0.8rem;
+  background: rgba(234, 139, 20, 0.1);
+  color: var(--idt-text-muted, #d6deea);
+  font-size: 0.78rem;
+}
+
+.idt-aws-finding-coverage-warning strong {
+  color: #ffd18d;
+}
+
+.idt-aws-finding-coverage-warning p,
+.idt-aws-finding-coverage-warning ul {
+  margin: 0;
+}
+
+.idt-aws-finding-coverage-warning ul {
+  display: grid;
+  gap: 0.25rem;
+  padding-left: 1.1rem;
+}
+
+.idt-aws-finding-coverage-warning a {
+  width: fit-content;
+  color: #c9c0ff;
+  font-weight: 800;
+}
+
 @media (max-width: 720px) {
   .idt-aws-finding-summary-heading {
     flex-direction: column;
@@ -33585,6 +33687,83 @@ html[data-theme='light'] .idt-danger-modal-typed input {
 
   .idt-aws-finding-severity-summary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .idt-aws-finding-scope-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-aws-finding-scope-summary > div {
+    border-right: 0;
+    border-bottom: 1px solid rgba(154, 164, 190, 0.2);
+  }
+
+  .idt-aws-finding-scope-summary > div:last-child {
+    border-bottom: 0;
+  }
+
+  .idt-domain-table-wrap.is-narrow-stack {
+    overflow-x: visible;
+  }
+
+  .idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table {
+    display: block;
+    min-width: 0 !important;
+  }
+
+  .idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table tbody {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table tr {
+    display: grid;
+    border-bottom: 1px solid var(--app-border-soft);
+  }
+
+  .idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table tr:last-child {
+    border-bottom: 0;
+  }
+
+  .idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table td,
+  .idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table td.is-right {
+    display: grid;
+    grid-template-columns: minmax(7rem, 0.4fr) minmax(0, 1fr);
+    gap: 0.65rem;
+    align-items: start;
+    width: 100%;
+    min-width: 0;
+    border-bottom: 1px solid rgba(154, 164, 190, 0.12);
+    text-align: left;
+  }
+
+  .idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table td:last-child {
+    border-bottom: 0;
+  }
+
+  .idt-domain-table-wrap.is-narrow-stack .idt-domain-data-table td::before {
+    content: attr(data-label);
+    color: var(--idt-text-muted, #aeb8c9);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .idt-domain-table-wrap.is-narrow-stack .idt-aws-finding-resource-cell,
+  .idt-domain-table-wrap.is-narrow-stack .idt-aws-finding-evidence-cell,
+  .idt-domain-table-wrap.is-narrow-stack .idt-aws-finding-why-cell {
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

- complete the remaining #1826 queue gaps without duplicating the normalized evidence, grouping, lifecycle states, or details drawer already delivered by #1829 and #1830
- add scan-wide priority, historical scope, completeness, and named collector health context with an actionable coverage link
- split the queue into focused triage columns and stack them into labeled rows at narrow widths
- preserve actual historical account and region filter values instead of classifying them against the current connector

## Why

The findings experience already had the normalized evidence and detail workflow from the earlier detour, but it still lacked the scan context, collector limitations, historical filter boundaries, and narrow-screen layout required to make it an effective triage queue.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Risk: low to moderate, limited to the AWS findings presentation and reusable opt-in narrow table behavior.

## Validation

```bash
npm test -- --run src/components/app/DomainFoundation.test.tsx src/productShell.test.tsx
# 341 passed

npm run build
# TypeScript, Vite production build, and 40-route prerender passed

make fmt-check
git diff --check
# passed
```

Push hooks also passed merge-conflict, YAML, whitespace, gofmt, go vet, token hygiene, and Vercel artifact checks.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: focused tests, production build, formatting checks, and exact diff review

## Related Issues

Closes #1826

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns the AWS findings queue to surface scan priority, scope, and coverage, and to work on narrow screens. Previously the queue lacked context and overflowed; now it shows scan-wide priority, scope, completeness, and source health and stacks into labeled rows on small viewports.

- Priority summary: shows total findings, critical/high open count, affected resources, scan id/time, scope (accounts/regions + Global), completeness, and named collector health (with retryability and codes); links to coverage details and handles scans that report partial coverage without per-collector details. Addresses #1826.
- Table structure: focuses triage into severity, finding, affected resource, why it matters, blast radius, confidence/evidence, and workflow (status + View details).
- Historical filters: when viewing a persisted scan, Account and Region lists reflect only values present in that scan (plus Global/Unavailable). We no longer map to the currently connected account/region.
- Coverage detection: pages scan events via cursor to count and name unavailable/degraded collectors, respects declared source_error_count, marks partial results even when only totals are available, and shows a coverage-unknown banner when events are unavailable.
- Narrow layout: `DomainDataTable` adds an opt-in `stackOnNarrow` mode that stacks rows with data-labels on small screens; applied to AWS findings. Migration: pass `stackOnNarrow` to tables that should stack on narrow screens.
- API: `apiClient.listScanEvents` now accepts an optional `cursor` and returns `next_cursor` for pagination. Migration: consumers that read scan events must iterate using `next_cursor` to process all events.

<sup>Written for commit 5033504fff42a1b7eeb39e034a76f894585cb211. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

