### PR TITLE
[AWS Findings] Add actionable investigation workflow

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -26218,6 +26218,31 @@ components:
             Optional audit comment. A nonblank verification basis is required
             when `status: resolved`; a suppression reason is required when
             `status: suppressed`.
+      oneOf:
+        - title: Resolution transition
+          properties:
+            status:
+              enum: [resolved]
+            comment:
+              type: string
+              pattern: "\\S"
+          required: [status, comment]
+        - title: Suppression transition
+          properties:
+            status:
+              enum: [suppressed]
+            comment:
+              type: string
+              pattern: "\\S"
+          required: [status, comment]
+        - title: Other status transition
+          properties:
+            status:
+              enum: [open, ack]
+          required: [status]
+        - title: Assignment or audit comment update
+          not:
+            required: [status]
     FindingTriageEvent:
       type: object
       properties:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -26216,33 +26216,10 @@ components:
           type: string
           description: >-
             Optional audit comment. A nonblank verification basis is required
-            when `status: resolved`; a suppression reason is required when
-            `status: suppressed`.
-      oneOf:
-        - title: Resolution transition
-          properties:
-            status:
-              enum: [resolved]
-            comment:
-              type: string
-              pattern: "\\S"
-          required: [status, comment]
-        - title: Suppression transition
-          properties:
-            status:
-              enum: [suppressed]
-            comment:
-              type: string
-              pattern: "\\S"
-          required: [status, comment]
-        - title: Other status transition
-          properties:
-            status:
-              enum: [open, ack]
-          required: [status]
-        - title: Assignment or audit comment update
-          not:
-            required: [status]
+            when the request transitions a finding into `status: resolved`.
+            It is not required when updating metadata on a finding that is
+            already resolved. A suppression reason is required when
+            `status: suppressed` is requested.
     FindingTriageEvent:
       type: object
       properties:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -26214,6 +26214,10 @@ components:
           description: "Optional expiry for suppressed findings. When supplied for `status: suppressed`, it must be in the future; a suppression comment is required as the reason."
         comment:
           type: string
+          description: >-
+            Optional audit comment. A nonblank verification basis is required
+            when `status: resolved`; a suppression reason is required when
+            `status: suppressed`.
     FindingTriageEvent:
       type: object
       properties:

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -3954,9 +3954,8 @@ func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID st
 	if (suppressionRequested || enteringSuppression) && comment == "" {
 		return domain.Finding{}, ErrInvalidFindingTriageRequest
 	}
-	resolutionRequested := request.Status != nil && nextState.Status == domain.FindingLifecycleResolved
 	enteringResolution := currentState.Status != domain.FindingLifecycleResolved && nextState.Status == domain.FindingLifecycleResolved
-	if (resolutionRequested || enteringResolution) && comment == "" {
+	if enteringResolution && comment == "" {
 		return domain.Finding{}, ErrInvalidFindingTriageRequest
 	}
 	if nextState.Status == domain.FindingLifecycleSuppressed && nextState.SuppressionExpiresAt != nil && !nextState.SuppressionExpiresAt.After(now) {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -3954,6 +3954,11 @@ func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID st
 	if (suppressionRequested || enteringSuppression) && comment == "" {
 		return domain.Finding{}, ErrInvalidFindingTriageRequest
 	}
+	resolutionRequested := request.Status != nil && nextState.Status == domain.FindingLifecycleResolved
+	enteringResolution := currentState.Status != domain.FindingLifecycleResolved && nextState.Status == domain.FindingLifecycleResolved
+	if (resolutionRequested || enteringResolution) && comment == "" {
+		return domain.Finding{}, ErrInvalidFindingTriageRequest
+	}
 	if nextState.Status == domain.FindingLifecycleSuppressed && nextState.SuppressionExpiresAt != nil && !nextState.SuppressionExpiresAt.After(now) {
 		return domain.Finding{}, ErrInvalidFindingTriageRequest
 	}

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1187,7 +1187,7 @@ func TestServiceRepoFindingTriageScopesStateToRepoScan(t *testing.T) {
 		defaultScopeContext(),
 		"shared-id",
 		secondScan.ID,
-		FindingTriageRequest{Status: &resolved, Assignee: &secondAssignee},
+		FindingTriageRequest{Status: &resolved, Assignee: &secondAssignee, Comment: "verified in the second scan"},
 		"subject:user-2",
 	); err != nil {
 		t.Fatalf("triage second repo finding: %v", err)
@@ -1638,6 +1638,17 @@ func TestServiceTriageFindingRejectsInvalidRequest(t *testing.T) {
 
 	if _, err := svc.TriageFinding(defaultScopeContext(), "finding-1", scan.ID, FindingTriageRequest{}, "subject:user-1"); !errors.Is(err, ErrInvalidFindingTriageRequest) {
 		t.Fatalf("expected invalid triage request error for empty payload, got %v", err)
+	}
+
+	resolved := string(domain.FindingLifecycleResolved)
+	if _, err := svc.TriageFinding(
+		defaultScopeContext(),
+		"finding-1",
+		scan.ID,
+		FindingTriageRequest{Status: &resolved},
+		"subject:user-1",
+	); !errors.Is(err, ErrInvalidFindingTriageRequest) {
+		t.Fatalf("expected invalid triage request error for resolution without verification basis, got %v", err)
 	}
 
 	suppressed := string(domain.FindingLifecycleSuppressed)

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1725,6 +1725,31 @@ func TestServiceTriageFindingRejectsInvalidRequest(t *testing.T) {
 	); !errors.Is(err, ErrInvalidFindingTriageRequest) {
 		t.Fatalf("expected explicit suppression request without reason to fail, got %v", err)
 	}
+
+	verification := "verified in the follow-up scan"
+	if _, err := svc.TriageFinding(
+		defaultScopeContext(),
+		"finding-1",
+		scan.ID,
+		FindingTriageRequest{Status: &resolved, Comment: verification},
+		"subject:user-1",
+	); err != nil {
+		t.Fatalf("expected resolution with verification basis to pass: %v", err)
+	}
+	resolvedAssignee := "incident-response"
+	updatedResolved, err := svc.TriageFinding(
+		defaultScopeContext(),
+		"finding-1",
+		scan.ID,
+		FindingTriageRequest{Status: &resolved, Assignee: &resolvedAssignee},
+		"subject:user-1",
+	)
+	if err != nil {
+		t.Fatalf("expected resolved finding ownership update without a new basis to pass: %v", err)
+	}
+	if updatedResolved.Triage.Status != domain.FindingLifecycleResolved || updatedResolved.Triage.Assignee != resolvedAssignee {
+		t.Fatalf("expected resolved finding ownership update, got %+v", updatedResolved.Triage)
+	}
 }
 
 func TestServiceExportAndImportFindingBaseline(t *testing.T) {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8448,6 +8448,7 @@ describe('Domain-first app routes', () => {
 
   it('deep-links persisted AWS findings and records guarded workflow changes', async () => {
     const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'getMe').mockResolvedValue({ me: loggedInWithWorkspace });
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
       items: [{
         tenant_id: 'tenant-a',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8573,6 +8573,11 @@ describe('Domain-first app routes', () => {
       expect.anything()
     ));
 
+    const triageCallCountBeforeEmptyResolution = triageFinding.mock.calls.length;
+    fireEvent.click(within(drawer).getByRole('button', { name: 'Mark resolved' }));
+    expect(triageFinding.mock.calls).toHaveLength(triageCallCountBeforeEmptyResolution);
+    expect(within(drawer).getByRole('alert')).toHaveTextContent('Record the verification basis before resolving this finding.');
+
     fireEvent.change(within(drawer).getByLabelText('Resolution verification basis'), { target: { value: 'A follow-up scan confirms only the required actions remain.' } });
     fireEvent.click(within(drawer).getByRole('button', { name: 'Mark resolved' }));
     await waitFor(() => expect(triageFinding).toHaveBeenLastCalledWith(

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -31,6 +31,7 @@ import type {
   AWSUnusedDormantAccessResult,
   CurrentUserContext,
   Finding,
+  FindingTriageEvent,
   GitHubConnectionStatus,
   GitHubOrganizationPosture,
   GitHubRepositoryPosture,
@@ -8445,6 +8446,205 @@ describe('Domain-first app routes', () => {
     );
   });
 
+  it('deep-links persisted AWS findings and records guarded workflow changes', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [{
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: 'production',
+        name: 'Production',
+        slug: 'production',
+        description: 'Production AWS boundary.',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z'
+      }]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
+      scan: {
+        id: 'scan-aws-workflow',
+        project_id: 'production',
+        connector_id: 'aws-connector-1',
+        provider: 'aws',
+        status: 'succeeded',
+        started_at: '2026-08-20T20:00:00Z',
+        finished_at: '2026-08-20T20:03:00Z',
+        asset_count: 1,
+        finding_count: 1
+      }
+    });
+    let persistedFinding: Finding = {
+      id: 'finding-aws-workflow',
+      scan_id: 'scan-aws-workflow',
+      type: 'aws_iam_overprivileged_role',
+      severity: 'high',
+      title: 'Workflow IAM role',
+      human_summary: 'The role grants permissions beyond the observed workload needs.',
+      path: ['arn:aws:iam::123456789012:role/workflow-role', 'iam:GetRole -> iam:ListRoles'],
+      adapter_source: 'iam-policy collector',
+      confidence_score: 0.91,
+      actionability: 'action_required',
+      evidence_completeness: 'complete',
+      provenance: 'aws_iam_inventory',
+      evidence: { account_id: '123456789012', region: 'us-east-1' },
+      remediation: 'Reduce the role policy and verify the effective permissions.',
+      created_at: '2026-08-20T20:03:00Z',
+      lifecycle_status: 'open',
+      triage: { status: 'open' }
+    };
+    vi.spyOn(api.apiClient, 'listFindings').mockImplementation(async () => ({ items: [persistedFinding] }));
+    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({ items: [] });
+    const history: FindingTriageEvent[] = [];
+    const listFindingHistory = vi.spyOn(api.apiClient, 'listFindingHistory').mockImplementation(async () => ({ items: [...history] }));
+    const triageFinding = vi.spyOn(api.apiClient, 'triageFinding').mockImplementation(async (_findingID, payload) => {
+      persistedFinding = {
+        ...persistedFinding,
+        triage: {
+          status: payload.status ?? persistedFinding.triage?.status ?? 'open',
+          assignee: payload.assignee ?? persistedFinding.triage?.assignee,
+          suppression_expires_at: payload.suppression_expires_at,
+          resolved_at: payload.status === 'resolved' ? '2026-08-24T13:00:00Z' : undefined,
+          updated_at: '2026-08-24T13:00:00Z',
+          updated_by: 'subject:security-operator'
+        }
+      };
+      history.unshift({
+        id: `event-${history.length + 1}`,
+        finding_id: persistedFinding.id,
+        action: payload.assignee !== undefined ? 'assigned' : payload.status ?? 'commented',
+        from_status: 'open',
+        to_status: payload.status ?? persistedFinding.triage?.status ?? 'open',
+        assignee: payload.assignee,
+        suppression_expires_at: payload.suppression_expires_at,
+        comment: payload.comment,
+        actor: 'subject:security-operator',
+        created_at: '2026-08-24T13:00:00Z'
+      });
+      return { finding: persistedFinding };
+    });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+    function LocationProbe() {
+      const currentLocation = useLocation();
+      return <output data-testid="aws-finding-location">{currentLocation.search}</output>;
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production&scan_id=scan-aws-workflow&finding_id=finding-aws-workflow']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<><ProductAWSFindingsPage /><LocationProbe /></>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const drawer = await screen.findByRole('dialog', { name: 'Finding details' });
+    expect(within(drawer).getByText('What happened')).toBeInTheDocument();
+    expect(within(drawer).getByText('Blast radius & relationship path')).toBeInTheDocument();
+    expect(within(drawer).getByText('Coverage limitations')).toBeInTheDocument();
+    expect(within(drawer).getByText('Finding history')).toBeInTheDocument();
+    expect(screen.getByTestId('aws-finding-location')).toHaveTextContent('scan_id=scan-aws-workflow');
+    expect(screen.getByTestId('aws-finding-location')).toHaveTextContent('finding_id=finding-aws-workflow');
+
+    fireEvent.change(within(drawer).getByLabelText('Finding owner'), { target: { value: 'Platform Security' } });
+    fireEvent.click(within(drawer).getByRole('button', { name: 'Save owner' }));
+    await waitFor(() => expect(triageFinding).toHaveBeenLastCalledWith(
+      'finding-aws-workflow',
+      { assignee: 'Platform Security' },
+      'scan-aws-workflow',
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    ));
+
+    fireEvent.click(within(drawer).getByRole('button', { name: 'Acknowledge' }));
+    await waitFor(() => expect(triageFinding).toHaveBeenLastCalledWith(
+      'finding-aws-workflow',
+      { status: 'ack' },
+      'scan-aws-workflow',
+      expect.anything()
+    ));
+
+    fireEvent.change(within(drawer).getByLabelText('Suppression reason'), { target: { value: 'Approved exception while policy is reviewed.' } });
+    fireEvent.click(within(drawer).getByRole('button', { name: 'Suppress finding' }));
+    await waitFor(() => expect(triageFinding).toHaveBeenLastCalledWith(
+      'finding-aws-workflow',
+      { status: 'suppressed', comment: 'Approved exception while policy is reviewed.' },
+      'scan-aws-workflow',
+      expect.anything()
+    ));
+
+    fireEvent.change(within(drawer).getByLabelText('Resolution verification basis'), { target: { value: 'A follow-up scan confirms only the required actions remain.' } });
+    fireEvent.click(within(drawer).getByRole('button', { name: 'Mark resolved' }));
+    await waitFor(() => expect(triageFinding).toHaveBeenLastCalledWith(
+      'finding-aws-workflow',
+      { status: 'resolved', comment: 'A follow-up scan confirms only the required actions remain.' },
+      'scan-aws-workflow',
+      expect.anything()
+    ));
+    await waitFor(() => expect(listFindingHistory.mock.calls.length).toBeGreaterThanOrEqual(5));
+    expect(within(drawer).getByText('Finding resolved with a recorded verification basis.')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Severity' }), { target: { value: 'critical' } });
+    expect(await screen.findByText('No findings match these filters')).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Finding details' })).toBeInTheDocument();
+
+    fireEvent.click(within(drawer).getByRole('button', { name: 'Close detail drawer' }));
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Finding details' })).not.toBeInTheDocument());
+    expect(screen.getByTestId('aws-finding-location')).toHaveTextContent('scan_id=scan-aws-workflow');
+    expect(screen.getByTestId('aws-finding-location')).not.toHaveTextContent('finding_id=');
+  });
+
+  it('handles a missing AWS finding deep link without dropping scan scope', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [{
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: 'production',
+        name: 'Production',
+        slug: 'production',
+        description: 'Production AWS boundary.',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z'
+      }]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getScan').mockResolvedValue({
+      scan: {
+        id: 'scan-aws-empty',
+        project_id: 'production',
+        connector_id: 'aws-connector-1',
+        provider: 'aws',
+        status: 'succeeded',
+        started_at: '2026-08-20T20:00:00Z',
+        finished_at: '2026-08-20T20:03:00Z',
+        asset_count: 1,
+        finding_count: 0
+      }
+    });
+    vi.spyOn(api.apiClient, 'listFindings').mockResolvedValue({ items: [] });
+    vi.spyOn(api.apiClient, 'listScanEvents').mockResolvedValue({ items: [] });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+    function LocationProbe() {
+      const currentLocation = useLocation();
+      return <output data-testid="missing-aws-finding-location">{currentLocation.search}</output>;
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production&scan_id=scan-aws-empty&finding_id=missing-finding']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<><ProductAWSFindingsPage /><LocationProbe /></>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Finding reference unavailable')).toBeInTheDocument();
+    expect(screen.getByText(/missing from the selected scan or live scope/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Clear finding reference' }));
+    await waitFor(() => expect(screen.getByTestId('missing-aws-finding-location')).not.toHaveTextContent('finding_id='));
+    expect(screen.getByTestId('missing-aws-finding-location')).toHaveTextContent('scan_id=scan-aws-empty');
+  });
+
   it('shows findings persisted by the completed AWS discovery scan', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
@@ -9084,6 +9284,12 @@ describe('Domain-first app routes', () => {
       'href',
       '/app/tenant-a/workspace-a/aws/coverage?environment=production'
     );
+    const partialFindingRow = screen.getByText('Public bucket from partial scan').closest('tr');
+    expect(partialFindingRow).not.toBeNull();
+    fireEvent.click(within(partialFindingRow as HTMLElement).getByRole('button', { name: 'View details' }));
+    const partialFindingDrawer = await screen.findByRole('dialog', { name: 'Finding details' });
+    expect(within(partialFindingDrawer).getByText(/incomplete or unverified evidence/i)).toBeInTheDocument();
+    expect(within(partialFindingDrawer).getByText(/Lambda Execution Roles · Permission Denied · Retryable/i)).toBeInTheDocument();
     expect(listScanEvents).toHaveBeenNthCalledWith(
       1,
       'scan-aws-partial',
@@ -9311,7 +9517,7 @@ describe('Domain-first app routes', () => {
     }
 
     render(
-      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production&scan_id=scan-aws-complete&severity=high']}>
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production&scan_id=scan-aws-complete&finding_id=finding-aws-complete&severity=high']}>
         <Routes>
           <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<><ProductAWSFindingsPage /><LocationProbe /></>} />
         </Routes>
@@ -9321,6 +9527,7 @@ describe('Domain-first app routes', () => {
     fireEvent.change(await screen.findByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
     await waitFor(() => expect(screen.getByTestId('aws-findings-location')).toHaveTextContent('environment=staging&severity=high'));
     expect(screen.getByTestId('aws-findings-location')).not.toHaveTextContent('scan_id=');
+    expect(screen.getByTestId('aws-findings-location')).not.toHaveTextContent('finding_id=');
   });
 
   it('shows AWS findings load errors separately from an empty result', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8544,6 +8544,7 @@ describe('Domain-first app routes', () => {
     expect(within(drawer).getByText('Blast radius & relationship path')).toBeInTheDocument();
     expect(within(drawer).getByText('Coverage limitations')).toBeInTheDocument();
     expect(within(drawer).getByText('Finding history')).toBeInTheDocument();
+    expect(within(drawer).getByLabelText('Remediation handoff text')).toHaveDisplayValue(/Finding ID: finding-aws-workflow/);
     expect(screen.getByTestId('aws-finding-location')).toHaveTextContent('scan_id=scan-aws-workflow');
     expect(screen.getByTestId('aws-finding-location')).toHaveTextContent('finding_id=finding-aws-workflow');
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18486,6 +18486,7 @@ function AWSFindingDetailsDrawer({
   onClose: () => void;
 }) {
   const relatedRows = row?.relatedRows ?? (row ? [row] : []);
+  const { me: currentUser, loading: currentUserLoading } = useMe();
   const [selectedRelatedRowID, setSelectedRelatedRowID] = useState<string | null>(null);
   const [history, setHistory] = useState<FindingTriageEvent[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
@@ -18503,6 +18504,12 @@ function AWSFindingDetailsDrawer({
   const workflowRequestRef = useRef(0);
   const representative = relatedRows.find((relatedRow) => relatedRow.id === selectedRelatedRowID) ?? relatedRows[0] ?? null;
   const workflowStatus = normalizeFindingStatus(representative?.triageStatus || representative?.status);
+  const canTriage = Boolean(
+    showingPersistedScan &&
+      scope &&
+      currentUser?.workspace_id === scope.workspaceID &&
+      (currentUser.role === 'owner' || currentUser.role === 'admin')
+  );
   const currentAssignee = representative?.owner === 'Unassigned' ? '' : representative?.owner || '';
   const assigneeUnchanged = assigneeDraft.trim() === currentAssignee;
   const evidenceTimestamp = representative?.observedAt ? Date.parse(representative.observedAt) : Number.NaN;
@@ -18513,13 +18520,12 @@ function AWSFindingDetailsDrawer({
     if (!scope || !environmentID || !representative) {
       return undefined;
     }
-    const base = awsRemediationCenterPath(scope, environmentID);
+    // The findings surface is the destination that can load and select this
+    // finding. Keep both identifiers so the persisted scan remains in scope.
+    const base = awsRouteLink(scope, 'findings', environmentID, representative.scanID ? { scanID: representative.scanID } : {});
     const [path, rawQuery = ''] = base.split('?');
     const query = new URLSearchParams(rawQuery);
     query.set('finding_id', representative.findingID || representative.id);
-    if (representative.scanID) {
-      query.set('scan_id', representative.scanID);
-    }
     return `${path}?${query.toString()}`;
   }, [environmentID, representative?.findingID, representative?.id, representative?.scanID, scope?.tenantID, scope?.workspaceID]);
   const remediationHandoff = useMemo(() => {
@@ -18785,7 +18791,9 @@ function AWSFindingDetailsDrawer({
               <div><dt>Status</dt><dd>{showingPersistedScan ? awsPersistedFindingStatusLabel(representative.status) : formatTokenLabel(representative.status)}</dd></div>
               {representative.triageUpdatedAt ? <div><dt>Last updated</dt><dd>{formatDateLabel(representative.triageUpdatedAt)}{representative.triageUpdatedBy ? ` by ${representative.triageUpdatedBy}` : ''}</dd></div> : null}
             </dl>
-            {showingPersistedScan ? (
+            {showingPersistedScan ? currentUserLoading ? (
+              <p>Checking workspace permissions…</p>
+            ) : canTriage ? (
               <div className="idt-aws-finding-workflow-controls">
                 <p>These controls update Identrail investigation state only. They never change AWS resources.</p>
                 {workflowError ? <div className="idt-app-alert idt-app-alert-error" role="alert">{workflowError}</div> : null}
@@ -18808,7 +18816,7 @@ function AWSFindingDetailsDrawer({
                   <button type="submit" className="idt-btn idt-btn-primary" disabled={workflowLoading || workflowStatus === 'resolved'}>Mark resolved</button>
                 </form>
               </div>
-            ) : <p>Persist this live finding in a discovery scan before changing its investigation status. The live evidence remains read-only.</p>}
+            ) : <p>Your workspace role can view this finding but cannot change its investigation state.</p> : <p>Persist this live finding in a discovery scan before changing its investigation status. The live evidence remains read-only.</p>}
           </section>
           <section>
             <h5>Finding history</h5>
@@ -18818,10 +18826,10 @@ function AWSFindingDetailsDrawer({
           </section>
           <section>
             <h5>Remediation handoff</h5>
-            <p>Copy a read-only handoff for an owner or continue in Identrail’s remediation center. No AWS action is performed here.</p>
+            <p>Copy a read-only handoff for an owner or continue in Identrail’s finding workflow. No AWS action is performed here.</p>
             <div className="idt-inline-actions">
               <button type="button" className="idt-btn idt-btn-ghost" onClick={() => void copyText(remediationHandoff, 'handoff')}>{copiedField === 'handoff' ? 'Copied handoff' : 'Copy remediation handoff'}</button>
-              {remediationHandoffLink ? <Link className="idt-btn idt-btn-ghost" to={remediationHandoffLink}>Open remediation center</Link> : null}
+              {remediationHandoffLink ? <Link className="idt-btn idt-btn-ghost" to={remediationHandoffLink}>Open finding workflow</Link> : null}
             </div>
           </section>
           {representative.consoleLink ? (

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18812,7 +18812,7 @@ function AWSFindingDetailsDrawer({
                   <button type="submit" className="idt-btn idt-btn-ghost" disabled={workflowLoading || workflowStatus === 'resolved'}>Suppress finding</button>
                 </form>
                 <form onSubmit={handleResolve}>
-                  <label>Verification basis<textarea aria-label="Resolution verification basis" required value={verificationBasis} onChange={(event) => setVerificationBasis(event.target.value)} rows={3} placeholder="Record the evidence that confirms remediation." /></label>
+                  <label>Verification basis<textarea aria-label="Resolution verification basis" value={verificationBasis} onChange={(event) => setVerificationBasis(event.target.value)} rows={3} placeholder="Record the evidence that confirms remediation." /></label>
                   <button type="submit" className="idt-btn idt-btn-primary" disabled={workflowLoading || workflowStatus === 'resolved'}>Mark resolved</button>
                 </form>
               </div>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18500,6 +18500,7 @@ function AWSFindingDetailsDrawer({
   const [workflowError, setWorkflowError] = useState('');
   const [workflowMessage, setWorkflowMessage] = useState('');
   const [copiedField, setCopiedField] = useState('');
+  const [copyError, setCopyError] = useState('');
   const historyRequestRef = useRef(0);
   const workflowRequestRef = useRef(0);
   const representative = relatedRows.find((relatedRow) => relatedRow.id === selectedRelatedRowID) ?? relatedRows[0] ?? null;
@@ -18560,6 +18561,7 @@ function AWSFindingDetailsDrawer({
     setWorkflowError('');
     setWorkflowMessage('');
     setCopiedField('');
+    setCopyError('');
   }, [open, representative?.findingID, representative?.scanID, scope?.tenantID, scope?.workspaceID]);
 
   useEffect(() => {
@@ -18673,16 +18675,16 @@ function AWSFindingDetailsDrawer({
   };
 
   const copyText = async (text: string, field: string) => {
-    setWorkflowError('');
+    setCopyError('');
     if (!text || typeof navigator === 'undefined' || !navigator.clipboard) {
-      setWorkflowError('Clipboard access is unavailable. Select and copy the text manually.');
+      setCopyError('Clipboard access is unavailable. Select and copy the displayed text manually.');
       return;
     }
     try {
       await navigator.clipboard.writeText(text);
       setCopiedField(field);
     } catch {
-      setWorkflowError('Clipboard access was denied. Select and copy the text manually.');
+      setCopyError('Clipboard access was denied. Select and copy the displayed text manually.');
     }
   };
 
@@ -18830,10 +18832,21 @@ function AWSFindingDetailsDrawer({
           <section>
             <h5>Remediation handoff</h5>
             <p>Copy a read-only handoff for an owner or continue in Identrail’s finding workflow. No AWS action is performed here.</p>
+            {copyError ? <div className="idt-app-alert idt-app-alert-error" role="alert">{copyError}</div> : null}
             <div className="idt-inline-actions">
               <button type="button" className="idt-btn idt-btn-ghost" onClick={() => void copyText(remediationHandoff, 'handoff')}>{copiedField === 'handoff' ? 'Copied handoff' : 'Copy remediation handoff'}</button>
               {remediationHandoffLink ? <Link className="idt-btn idt-btn-ghost" to={remediationHandoffLink}>Open finding workflow</Link> : null}
             </div>
+            <label className="idt-aws-finding-handoff-label">
+              Selectable handoff text
+              <textarea
+                aria-label="Remediation handoff text"
+                readOnly
+                rows={8}
+                value={remediationHandoff}
+                onFocus={(event) => event.currentTarget.select()}
+              />
+            </label>
           </section>
           {representative.consoleLink ? (
             <a className="idt-aws-finding-console-link" href={representative.consoleLink} target="_blank" rel="noreferrer">

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -5544,7 +5544,7 @@ function useAWSInventoryData(): AWSInventoryDataState {
           search: environmentSearch(
             location.search,
             environmentID,
-            location.pathname.endsWith('/aws/findings') ? { omit: ['scan_id'] } : undefined
+            location.pathname.endsWith('/aws/findings') ? { omit: ['scan_id', 'finding_id'] } : undefined
           )
         },
         { replace: false }
@@ -13120,6 +13120,7 @@ const AWS_RISK_OPERATION_FILTERS: AWSRiskOperationFilterConfigMap = {
 type AWSRiskOperationTableRow = AWSInventoryFilterable & {
   id: string;
   title: string;
+  whatHappened?: string;
   category: string;
   maxSeverity?: string;
   evidence: string;
@@ -18464,14 +18465,24 @@ function groupAWSFindingRows(rows: AWSRiskOperationTableRow[]): AWSRiskOperation
 function AWSFindingDetailsDrawer({
   open,
   row,
+  selectedFindingID,
   showingPersistedScan,
   scope,
+  environmentID,
+  coverage,
+  onFindingUpdated,
+  onSelectFinding,
   onClose
 }: {
   open: boolean;
   row: AWSRiskOperationTableRow | null;
+  selectedFindingID: string;
   showingPersistedScan: boolean;
   scope: ProductSession | null;
+  environmentID?: string;
+  coverage: AWSFindingCoverageContext;
+  onFindingUpdated: (finding: ApiFinding) => void;
+  onSelectFinding: (findingID: string) => void;
   onClose: () => void;
 }) {
   const relatedRows = row?.relatedRows ?? (row ? [row] : []);
@@ -18479,21 +18490,79 @@ function AWSFindingDetailsDrawer({
   const [history, setHistory] = useState<FindingTriageEvent[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyUnavailable, setHistoryUnavailable] = useState(false);
+  const [historyReloadToken, setHistoryReloadToken] = useState(0);
+  const [assigneeDraft, setAssigneeDraft] = useState('');
+  const [suppressionReason, setSuppressionReason] = useState('');
+  const [suppressionExpiry, setSuppressionExpiry] = useState('');
+  const [verificationBasis, setVerificationBasis] = useState('');
+  const [workflowLoading, setWorkflowLoading] = useState(false);
+  const [workflowError, setWorkflowError] = useState('');
+  const [workflowMessage, setWorkflowMessage] = useState('');
+  const [copiedField, setCopiedField] = useState('');
+  const historyRequestRef = useRef(0);
+  const workflowRequestRef = useRef(0);
   const representative = relatedRows.find((relatedRow) => relatedRow.id === selectedRelatedRowID) ?? relatedRows[0] ?? null;
+  const workflowStatus = normalizeFindingStatus(representative?.triageStatus || representative?.status);
+  const currentAssignee = representative?.owner === 'Unassigned' ? '' : representative?.owner || '';
+  const assigneeUnchanged = assigneeDraft.trim() === currentAssignee;
+  const evidenceTimestamp = representative?.observedAt ? Date.parse(representative.observedAt) : Number.NaN;
+  const evidenceIsStale = Number.isFinite(evidenceTimestamp) && Date.now() - evidenceTimestamp > 30 * 24 * 60 * 60 * 1000;
+  const evidenceIsIncomplete = normalizeValue(representative?.completeness).toLowerCase() !== 'complete' || coverage.totalCount > 0;
+  const identrailInvestigationLink = representative?.detailLink || (scope && environmentID ? awsRouteLink(scope, 'graph', environmentID) : undefined);
+  const remediationHandoffLink = useMemo(() => {
+    if (!scope || !environmentID || !representative) {
+      return undefined;
+    }
+    const base = awsRemediationCenterPath(scope, environmentID);
+    const [path, rawQuery = ''] = base.split('?');
+    const query = new URLSearchParams(rawQuery);
+    query.set('finding_id', representative.findingID || representative.id);
+    if (representative.scanID) {
+      query.set('scan_id', representative.scanID);
+    }
+    return `${path}?${query.toString()}`;
+  }, [environmentID, representative?.findingID, representative?.id, representative?.scanID, scope?.tenantID, scope?.workspaceID]);
+  const remediationHandoff = useMemo(() => {
+    if (!representative) {
+      return '';
+    }
+    return [
+      `Finding: ${representative.title}`,
+      `Finding ID: ${representative.findingID || representative.id}`,
+      representative.scanID ? `Scan ID: ${representative.scanID}` : '',
+      `Severity: ${representative.category}`,
+      `Affected resource: ${representative.resourceLabel || representative.title}`,
+      `Scope: ${representative.scopeLabel || representative.blastRadius}`,
+      `Why it matters: ${representative.evidence}`,
+      `Recommended action: ${representative.nextAction}`,
+      remediationHandoffLink ? `Identrail handoff: ${remediationHandoffLink}` : ''
+    ].filter(Boolean).join('\n');
+  }, [remediationHandoffLink, representative]);
 
   useEffect(() => {
-    setSelectedRelatedRowID(relatedRows[0]?.id ?? null);
-  }, [open, row?.id]);
+    const selectedRelatedRow = relatedRows.find((relatedRow) => (relatedRow.findingID || relatedRow.id) === selectedFindingID);
+    setSelectedRelatedRowID(selectedRelatedRow?.id ?? relatedRows[0]?.id ?? null);
+  }, [open, row?.id, selectedFindingID]);
 
   useEffect(() => {
-    let active = true;
+    workflowRequestRef.current += 1;
+    setAssigneeDraft(representative?.owner === 'Unassigned' ? '' : representative?.owner || '');
+    setSuppressionReason('');
+    setSuppressionExpiry('');
+    setVerificationBasis('');
+    setWorkflowLoading(false);
+    setWorkflowError('');
+    setWorkflowMessage('');
+    setCopiedField('');
+  }, [open, representative?.findingID, representative?.scanID, scope?.tenantID, scope?.workspaceID]);
+
+  useEffect(() => {
+    const requestID = ++historyRequestRef.current;
     if (!open || !showingPersistedScan || !representative?.findingID || !scope) {
       setHistory([]);
       setHistoryLoading(false);
       setHistoryUnavailable(false);
-      return () => {
-        active = false;
-      };
+      return;
     }
     setHistoryUnavailable(false);
     setHistoryLoading(true);
@@ -18503,21 +18572,110 @@ function AWSFindingDetailsDrawer({
         workspaceID: scope.workspaceID
       })
       .then((response) => {
-        if (active) setHistory(response.items ?? []);
+        if (requestID === historyRequestRef.current) setHistory(response.items ?? []);
       })
       .catch(() => {
-        if (active) {
+        if (requestID === historyRequestRef.current) {
           setHistory([]);
           setHistoryUnavailable(true);
         }
       })
       .finally(() => {
-        if (active) setHistoryLoading(false);
+        if (requestID === historyRequestRef.current) setHistoryLoading(false);
       });
     return () => {
-      active = false;
+      historyRequestRef.current += 1;
     };
-  }, [open, representative?.findingID, representative?.scanID, scope?.tenantID, scope?.workspaceID, showingPersistedScan]);
+  }, [historyReloadToken, open, representative?.findingID, representative?.scanID, scope?.tenantID, scope?.workspaceID, showingPersistedScan]);
+
+  const applyWorkflowUpdate = async (
+    payload: { status?: FindingLifecycleStatus; assignee?: string; suppression_expires_at?: string; comment?: string },
+    successMessage: string
+  ) => {
+    if (!showingPersistedScan || !representative?.findingID || !scope || workflowLoading) {
+      return;
+    }
+    const requestID = ++workflowRequestRef.current;
+    setWorkflowLoading(true);
+    setWorkflowError('');
+    setWorkflowMessage('');
+    try {
+      const response = await apiClient.triageFinding(
+        representative.findingID,
+        payload,
+        representative.scanID,
+        { tenantID: scope.tenantID, workspaceID: scope.workspaceID }
+      );
+      if (requestID !== workflowRequestRef.current) {
+        return;
+      }
+      onFindingUpdated(response.finding);
+      setWorkflowMessage(successMessage);
+      setHistoryReloadToken((current) => current + 1);
+    } catch (requestError) {
+      if (requestID === workflowRequestRef.current) {
+        setWorkflowError(formatAPIError(requestError, 'Unable to update this finding.'));
+      }
+    } finally {
+      if (requestID === workflowRequestRef.current) {
+        setWorkflowLoading(false);
+      }
+    }
+  };
+
+  const handleAssignOwner = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (assigneeUnchanged) {
+      return;
+    }
+    void applyWorkflowUpdate({ assignee: assigneeDraft.trim() }, assigneeDraft.trim() ? 'Finding owner updated.' : 'Finding owner cleared.');
+  };
+
+  const handleSuppress = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const reason = suppressionReason.trim();
+    if (!reason) {
+      setWorkflowError('A suppression reason is required.');
+      return;
+    }
+    let expiry: string | undefined;
+    if (suppressionExpiry) {
+      const parsedExpiry = new Date(suppressionExpiry);
+      if (Number.isNaN(parsedExpiry.getTime())) {
+        setWorkflowError('Enter a valid suppression expiry.');
+        return;
+      }
+      expiry = parsedExpiry.toISOString();
+    }
+    void applyWorkflowUpdate(
+      { status: 'suppressed', comment: reason, ...(expiry ? { suppression_expires_at: expiry } : {}) },
+      'Finding suppressed and the reason was recorded.'
+    );
+  };
+
+  const handleResolve = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const basis = verificationBasis.trim();
+    if (!basis) {
+      setWorkflowError('Record the verification basis before resolving this finding.');
+      return;
+    }
+    void applyWorkflowUpdate({ status: 'resolved', comment: basis }, 'Finding resolved with a recorded verification basis.');
+  };
+
+  const copyText = async (text: string, field: string) => {
+    setWorkflowError('');
+    if (!text || typeof navigator === 'undefined' || !navigator.clipboard) {
+      setWorkflowError('Clipboard access is unavailable. Select and copy the text manually.');
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedField(field);
+    } catch {
+      setWorkflowError('Clipboard access was denied. Select and copy the text manually.');
+    }
+  };
 
   return (
     <DomainDetailDrawer open={open} title="Finding details" eyebrow="AWS risk" onClose={onClose} resizable expandable>
@@ -18531,6 +18689,10 @@ function AWSFindingDetailsDrawer({
             </div>
           </div>
           <section>
+            <h5>What happened</h5>
+            <p>{representative.whatHappened || representative.title}</p>
+          </section>
+          <section>
             <h5>Why it matters</h5>
             <p>{representative.evidence}</p>
           </section>
@@ -18540,9 +18702,14 @@ function AWSFindingDetailsDrawer({
               <div><dt>Resource</dt><dd>{representative.resourceLabel || representative.title}</dd></div>
               <div><dt>Type</dt><dd>{representative.resourceType || 'AWS resource'}</dd></div>
               {representative.identity ? <div><dt>Identity</dt><dd>{representative.identity}</dd></div> : null}
-              <div><dt>Scope</dt><dd>{representative.scopeLabel || representative.blastRadius}</dd></div>
-              {representative.resourceARN ? <div><dt>ARN</dt><dd><code>{representative.resourceARN}</code></dd></div> : null}
+              <div><dt>Account</dt><dd>{representative.accountID || 'Unavailable'}</dd></div>
+              <div><dt>Region</dt><dd>{representative.region || (representative.resourceType?.startsWith('IAM') ? 'Global' : 'Unavailable')}</dd></div>
             </dl>
+            {identrailInvestigationLink ? <Link to={identrailInvestigationLink}>Investigate in Identrail</Link> : <p>No specific Identrail resource route is available for this reference.</p>}
+          </section>
+          <section>
+            <h5>Blast radius &amp; relationship path</h5>
+            <p>{representative.blastRadius || 'No relationship path was returned for this finding.'}</p>
           </section>
           <section>
             <h5>Recommended action</h5>
@@ -18559,7 +18726,10 @@ function AWSFindingDetailsDrawer({
                       className="idt-aws-finding-related-button"
                       aria-label={`View details for ${relatedRow.title}`}
                       aria-pressed={relatedRow.id === representative.id}
-                      onClick={() => setSelectedRelatedRowID(relatedRow.id)}
+                      onClick={() => {
+                        setSelectedRelatedRowID(relatedRow.id);
+                        onSelectFinding(relatedRow.findingID || relatedRow.id);
+                      }}
                     >
                       <strong>{relatedRow.title}</strong>
                       <span>{relatedRow.category} · {formatTokenLabel(relatedRow.status)}</span>
@@ -18575,32 +18745,84 @@ function AWSFindingDetailsDrawer({
               <div><dt>Finding ID</dt><dd><code>{representative.findingID || representative.id}</code></dd></div>
               <div><dt>Scan ID</dt><dd><code>{representative.scanID || 'Unavailable'}</code></dd></div>
               <div><dt>Source</dt><dd>{representative.source || 'Unavailable'}</dd></div>
+              <div><dt>Provenance</dt><dd>{representative.provenance || 'Unavailable'}</dd></div>
               <div><dt>Completeness</dt><dd>{awsPersistedFindingCompletenessLabel(representative.completeness || 'unknown')}</dd></div>
               {representative.confidence !== undefined ? <div><dt>Confidence</dt><dd>{formatConfidenceScore(representative.confidence)}</dd></div> : null}
               {representative.actionability ? <div><dt>Actionability</dt><dd>{formatTokenLabel(representative.actionability)}</dd></div> : null}
               {representative.exploitability ? <div><dt>Exploitability</dt><dd>{formatTokenLabel(representative.exploitability)}</dd></div> : null}
               <div><dt>Observed</dt><dd>{representative.observedAt || 'Unavailable'}</dd></div>
               {representative.evidenceBoundary ? <div><dt>Boundary</dt><dd>{representative.evidenceBoundary}</dd></div> : null}
+              <div><dt>Freshness</dt><dd>{evidenceIsStale ? 'Stale — refresh discovery before relying on this evidence.' : representative.observedAt ? 'Current within the last 30 days' : 'Unknown'}</dd></div>
             </dl>
             <details className="idt-aws-finding-technical-evidence">
               <summary>Technical evidence ({representative.technicalEvidence?.length ?? 0} refs)</summary>
               {representative.technicalEvidence?.length ? (
-                <ul>{representative.technicalEvidence.map((ref, index) => <li key={`${ref}-${index}`}><code>{ref}</code></li>)}</ul>
+                <>
+                  <button type="button" className="idt-aws-finding-copy-button" onClick={() => void copyText(representative.technicalEvidence?.join('\n') ?? '', 'evidence')}>
+                    {copiedField === 'evidence' ? 'Copied technical evidence' : 'Copy technical evidence'}
+                  </button>
+                  <ul>{representative.technicalEvidence.map((ref, index) => <li key={`${ref}-${index}`}><code>{ref}</code></li>)}</ul>
+                </>
               ) : (
                 <p>No raw path or evidence references were returned.</p>
               )}
             </details>
           </section>
+          <section className={evidenceIsIncomplete ? 'idt-aws-finding-coverage-warning' : undefined}>
+            <h5>Coverage limitations</h5>
+            {evidenceIsIncomplete ? (
+              <>
+                <p>This finding comes from incomplete or unverified evidence. Treat the result as directional until coverage is refreshed.</p>
+                {coverage.issues.length > 0 ? <ul>{coverage.issues.map((issue, index) => <li key={`${issue.collector}-${issue.sourceID || issue.code || index}`}>{formatTokenLabel(issue.collector)}{issue.code ? ` · ${formatTokenLabel(issue.code)}` : ''}{issue.retryable ? ' · Retryable' : ''}</li>)}</ul> : null}
+              </>
+            ) : <p>No coverage gaps were reported for the evidence used by this finding.</p>}
+            {showingPersistedScan ? <p>This is persisted scan evidence. Its original scan scope is preserved even if the current connector or filters have changed.</p> : null}
+          </section>
           <section>
-            <h5>Ownership &amp; resolution</h5>
+            <h5>Investigation workflow</h5>
             <dl>
               <div><dt>Owner</dt><dd>{representative.owner || 'Unassigned'}</dd></div>
               <div><dt>Status</dt><dd>{showingPersistedScan ? awsPersistedFindingStatusLabel(representative.status) : formatTokenLabel(representative.status)}</dd></div>
               {representative.triageUpdatedAt ? <div><dt>Last updated</dt><dd>{formatDateLabel(representative.triageUpdatedAt)}{representative.triageUpdatedBy ? ` by ${representative.triageUpdatedBy}` : ''}</dd></div> : null}
             </dl>
-            {historyLoading ? <p>Loading resolution history…</p> : historyUnavailable ? <p>Resolution history is unavailable for this finding.</p> : history.length > 0 ? (
-              <ol className="idt-aws-finding-history">{history.map((event) => <li key={event.id}><strong>{formatTokenLabel(event.from_status)} → {formatTokenLabel(event.to_status)}</strong><span>{formatDateLabel(event.created_at)}{event.actor ? ` · ${event.actor}` : ''}</span>{event.comment ? <p>{event.comment}</p> : null}</li>)}</ol>
-            ) : <p>No recorded triage changes.</p>}
+            {showingPersistedScan ? (
+              <div className="idt-aws-finding-workflow-controls">
+                <p>These controls update Identrail investigation state only. They never change AWS resources.</p>
+                {workflowError ? <div className="idt-app-alert idt-app-alert-error" role="alert">{workflowError}</div> : null}
+                {workflowMessage ? <div className="idt-app-alert idt-app-alert-success" role="status">{workflowMessage}</div> : null}
+                <form onSubmit={handleAssignOwner}>
+                  <label>Owner<input aria-label="Finding owner" value={assigneeDraft} onChange={(event) => setAssigneeDraft(event.target.value)} placeholder="Team or person" /></label>
+                  <button type="submit" className="idt-btn idt-btn-ghost" disabled={workflowLoading || assigneeUnchanged}>Save owner</button>
+                </form>
+                <div className="idt-inline-actions">
+                  <button type="button" className="idt-btn idt-btn-ghost" disabled={workflowLoading || workflowStatus === 'ack' || workflowStatus === 'resolved'} onClick={() => void applyWorkflowUpdate({ status: 'ack' }, 'Finding acknowledged.')}>Acknowledge</button>
+                  {workflowStatus !== 'open' ? <button type="button" className="idt-btn idt-btn-ghost" disabled={workflowLoading} onClick={() => void applyWorkflowUpdate({ status: 'open', comment: 'Reopened for further investigation.' }, 'Finding reopened.')}>Reopen</button> : null}
+                </div>
+                <form onSubmit={handleSuppress}>
+                  <label>Suppression reason<textarea aria-label="Suppression reason" required value={suppressionReason} onChange={(event) => setSuppressionReason(event.target.value)} rows={3} /></label>
+                  <label>Optional expiry<input aria-label="Suppression expiry" type="datetime-local" value={suppressionExpiry} onChange={(event) => setSuppressionExpiry(event.target.value)} /></label>
+                  <button type="submit" className="idt-btn idt-btn-ghost" disabled={workflowLoading || workflowStatus === 'resolved'}>Suppress finding</button>
+                </form>
+                <form onSubmit={handleResolve}>
+                  <label>Verification basis<textarea aria-label="Resolution verification basis" required value={verificationBasis} onChange={(event) => setVerificationBasis(event.target.value)} rows={3} placeholder="Record the evidence that confirms remediation." /></label>
+                  <button type="submit" className="idt-btn idt-btn-primary" disabled={workflowLoading || workflowStatus === 'resolved'}>Mark resolved</button>
+                </form>
+              </div>
+            ) : <p>Persist this live finding in a discovery scan before changing its investigation status. The live evidence remains read-only.</p>}
+          </section>
+          <section>
+            <h5>Finding history</h5>
+            {historyLoading ? <p>Loading finding history…</p> : historyUnavailable ? <p>Finding history is unavailable for this finding.</p> : history.length > 0 ? (
+              <ol className="idt-aws-finding-history">{history.map((event) => <li key={event.id}><strong>{formatTokenLabel(event.action)}</strong><span>{formatTokenLabel(event.from_status)} → {formatTokenLabel(event.to_status)} · {formatDateLabel(event.created_at)}{event.actor ? ` · ${event.actor}` : ''}</span>{event.assignee ? <p>Owner: {event.assignee}</p> : null}{event.comment ? <p>{event.comment}</p> : null}</li>)}</ol>
+            ) : <p>{showingPersistedScan ? 'No recorded triage changes.' : 'History becomes available after the finding is persisted.'}</p>}
+          </section>
+          <section>
+            <h5>Remediation handoff</h5>
+            <p>Copy a read-only handoff for an owner or continue in Identrail’s remediation center. No AWS action is performed here.</p>
+            <div className="idt-inline-actions">
+              <button type="button" className="idt-btn idt-btn-ghost" onClick={() => void copyText(remediationHandoff, 'handoff')}>{copiedField === 'handoff' ? 'Copied handoff' : 'Copy remediation handoff'}</button>
+              {remediationHandoffLink ? <Link className="idt-btn idt-btn-ghost" to={remediationHandoffLink}>Open remediation center</Link> : null}
+            </div>
           </section>
           {representative.consoleLink ? (
             <a className="idt-aws-finding-console-link" href={representative.consoleLink} target="_blank" rel="noreferrer">
@@ -18630,6 +18852,7 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
   return {
     id: finding.finding_id,
     title: awsSecretPermissionEquivalenceLabel(finding),
+    whatHappened: finding.rationale || evidence,
     category: formatTokenLabel(finding.severity),
     evidence,
     identity,
@@ -18654,9 +18877,10 @@ function awsSecretPermissionEquivalenceRiskOperationRow(
     identityKey: awsSecretPermissionEquivalenceIdentityKey(finding),
     triageStatus: finding.status,
     technicalEvidence: [
+      finding.secret_arn,
       ...finding.evidence.map((evidence) => evidence.evidence_ref),
       ...finding.impacted_path.map((step) => step.node_id)
-    ].filter(Boolean),
+    ].filter((value): value is string => Boolean(value)),
     filters: {
       severity: finding.severity || 'unknown',
       account: connection?.account_id && connection.account_id === finding.account_id ? 'connected' : 'unknown',
@@ -19088,10 +19312,14 @@ function awsPersistedFindingRiskOperationRow(
   const evidenceBoundary = awsPersistedFindingMetadataValue(finding, ['evidence_boundary', 'coverage', 'coverage_state']);
   const actionability = normalizeValue(finding.actionability) || awsPersistedFindingMetadataValue(finding, ['actionability']);
   const exploitability = normalizeValue(finding.exploitability) || awsPersistedFindingMetadataValue(finding, ['exploitability']);
-  const technicalEvidence = finding.path?.map((value) => normalizeValue(value)).filter(Boolean) ?? [];
+  const technicalEvidence = Array.from(new Set([
+    findingScope.resourceARN,
+    ...(finding.path ?? []).map((value) => normalizeValue(value))
+  ].filter((value): value is string => Boolean(value))));
   return {
     id: finding.id,
     title: finding.title || formatTokenLabel(finding.type),
+    whatHappened: finding.human_summary || evidence,
     category: formatTokenLabel(finding.severity),
     evidence,
     owner: finding.triage?.assignee || (finding.owner && finding.owner !== source ? finding.owner : undefined) || 'Unassigned',
@@ -19172,6 +19400,7 @@ function AWSFindingsContent({
   loading,
   error,
   onRetry,
+  onPersistedFindingUpdate,
   filters,
   onFiltersChange
 }: {
@@ -19188,9 +19417,12 @@ function AWSFindingsContent({
   loading: boolean;
   error: string;
   onRetry: () => void;
+  onPersistedFindingUpdate: (finding: ApiFinding) => void;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
+  const location = useLocation();
+  const navigate = useNavigate();
   const showingPersistedScan = Boolean(persistedScanID);
   const persistedCompleteness = persistedScanPartial ? 'partial' : persistedScanCoverageUnknown ? 'unknown' : 'complete';
   const findingCompleteness = showingPersistedScan
@@ -19202,17 +19434,30 @@ function AWSFindingsContent({
   const rows = showingPersistedScan
     ? persistedFindings?.map((finding) => awsPersistedFindingRiskOperationRow(finding, persistedScan, persistedCompleteness)) ?? []
     : findings?.findings.map((finding) => awsSecretPermissionEquivalenceRiskOperationRow(finding, findings, scope, environmentID, connection)) ?? [];
+  const groupedRows = groupAWSFindingRows(rows);
   const filteredRows = filterAWSInventoryRows(rows, filters);
   const displayedRows = groupAWSFindingRows(filteredRows).sort(
     (left, right) => awsFindingSeverityRank(awsFindingDisplaySeverity(right)) - awsFindingSeverityRank(awsFindingDisplaySeverity(left)) || left.title.localeCompare(right.title) || left.id.localeCompare(right.id)
   );
-  const [selectedRowID, setSelectedRowID] = useState<string | null>(null);
-  const selectedRow = displayedRows.find((row) => row.id === selectedRowID) ?? null;
+  const selectedFindingID = useMemo(() => normalizeValue(new URLSearchParams(location.search).get('finding_id')), [location.search]);
+  const selectedRow = groupedRows.find((row) =>
+    (row.findingID || row.id) === selectedFindingID || row.relatedRows?.some((relatedRow) => (relatedRow.findingID || relatedRow.id) === selectedFindingID)
+  ) ?? null;
+  const setSelectedFindingID = (findingID: string) => {
+    const query = new URLSearchParams(location.search);
+    if (findingID) {
+      query.set('finding_id', findingID);
+    } else {
+      query.delete('finding_id');
+    }
+    navigate({ pathname: location.pathname, search: query.size > 0 ? `?${query.toString()}` : '' }, { replace: true });
+  };
   const persistedScanReadyToLoad = Boolean(scope && environmentID);
   const liveFindingsReadyToLoad = Boolean(scope && environmentID && connection?.connected);
   const isLoading = loading || (showingPersistedScan && persistedScanReadyToLoad && !persistedFindings && !error) || (!showingPersistedScan && liveFindingsReadyToLoad && !findings && !error);
   const coveragePath = scope && environmentID ? awsRouteLink(scope, 'coverage', environmentID) : undefined;
   const showSummary = !error && !isLoading && (showingPersistedScan ? Boolean(persistedScan) : Boolean(findings));
+  const missingSelectedFinding = Boolean(selectedFindingID && !selectedRow && !isLoading && !error);
 
   return (
     <>
@@ -19250,6 +19495,13 @@ function AWSFindingsContent({
         onChange={onFiltersChange}
         configs={awsFindingFilterConfigs(rows, showingPersistedScan)}
       />
+      {missingSelectedFinding ? (
+        <DomainErrorState
+          title="Finding reference unavailable"
+          body="This finding is missing from the selected scan or live scope. It may be stale, deleted, or outside the current environment."
+          retryAction={{ label: 'Clear finding reference', onClick: () => setSelectedFindingID('') }}
+        />
+      ) : null}
       {error ? (
         <DomainErrorState
           title="Couldn't load AWS findings"
@@ -19308,7 +19560,7 @@ function AWSFindingsContent({
               render: (row) => (
                 <div className="idt-aws-finding-workflow-cell">
                   <AWSFindingStatusBadge status={row.status} showingPersistedScan={showingPersistedScan} />
-                  <button type="button" className="idt-aws-finding-view-details" onClick={() => setSelectedRowID(row.id)}>View details</button>
+                  <button type="button" className="idt-aws-finding-view-details" onClick={() => setSelectedFindingID(row.relatedRows?.[0]?.findingID || row.findingID || row.id)}>View details</button>
                 </div>
               )
             }
@@ -19318,9 +19570,14 @@ function AWSFindingsContent({
       <AWSFindingDetailsDrawer
         open={Boolean(selectedRow)}
         row={selectedRow}
+        selectedFindingID={selectedFindingID}
         showingPersistedScan={showingPersistedScan}
         scope={scope}
-        onClose={() => setSelectedRowID(null)}
+        environmentID={environmentID}
+        coverage={findingCoverage}
+        onFindingUpdated={onPersistedFindingUpdate}
+        onSelectFinding={setSelectedFindingID}
+        onClose={() => setSelectedFindingID('')}
       />
     </>
   );
@@ -22006,6 +22263,11 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={persistedScanID ? persistedFindingsLoading : secretPermissionEquivalenceLoading}
             error={persistedScanID ? persistedFindingsError : secretPermissionEquivalenceError}
             onRetry={persistedScanID ? loadPersistedAWSFindings : loadSecretPermissionEquivalence}
+            onPersistedFindingUpdate={(updatedFinding) => {
+              setPersistedFindings((current) => current?.map((finding) =>
+                finding.id === updatedFinding.id && finding.scan_id === updatedFinding.scan_id ? updatedFinding : finding
+              ) ?? current);
+            }}
             filters={activeFilters}
             onFiltersChange={onFiltersChange}
           />

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -18612,10 +18612,13 @@ function AWSFindingDetailsDrawer({
         representative.scanID,
         { tenantID: scope.tenantID, workspaceID: scope.workspaceID }
       );
+      // The server mutation is durable even if the drawer was closed or the
+      // operator selected another related finding while it was in flight.
+      // Update the parent cache before ignoring stale drawer-local UI work.
+      onFindingUpdated(response.finding);
       if (requestID !== workflowRequestRef.current) {
         return;
       }
-      onFindingUpdated(response.finding);
       setWorkflowMessage(successMessage);
       setHistoryReloadToken((current) => current + 1);
     } catch (requestError) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -33818,6 +33818,22 @@ html[data-theme='light'] .idt-danger-modal-typed input {
   line-height: 1.5;
 }
 
+.idt-aws-finding-coverage-warning {
+  border: 1px solid rgba(245, 158, 11, 0.45);
+  border-radius: 0.45rem;
+  padding: 0.7rem;
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.idt-aws-finding-coverage-warning ul {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.78rem;
+}
+
 .idt-aws-finding-detail dl {
   display: grid;
   gap: 0.55rem;
@@ -33892,6 +33908,52 @@ html[data-theme='light'] .idt-danger-modal-typed input {
   color: var(--idt-text-muted, #aeb8c9);
 }
 
+.idt-aws-finding-workflow-controls {
+  display: grid;
+  gap: 0.75rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.22);
+  padding-top: 0.75rem;
+}
+
+.idt-aws-finding-workflow-controls > p {
+  margin: 0;
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.idt-aws-finding-workflow-controls form {
+  display: grid;
+  gap: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 0.45rem;
+  padding: 0.65rem;
+}
+
+.idt-aws-finding-workflow-controls label {
+  display: grid;
+  gap: 0.3rem;
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.idt-aws-finding-workflow-controls input,
+.idt-aws-finding-workflow-controls textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 0.35rem;
+  padding: 0.5rem 0.55rem;
+  color: inherit;
+  background: rgba(4, 8, 18, 0.36);
+  font: inherit;
+}
+
+.idt-aws-finding-workflow-controls textarea {
+  resize: vertical;
+}
+
 .idt-aws-finding-console-link {
   display: inline-flex;
   align-items: center;
@@ -33923,6 +33985,22 @@ html[data-theme='light'] .idt-danger-modal-typed input {
   cursor: pointer;
   color: var(--idt-text-muted, #aeb8c9);
   font-weight: 600;
+}
+
+.idt-aws-finding-copy-button {
+  margin-top: 0.55rem;
+  border: 1px solid rgba(174, 161, 255, 0.45);
+  border-radius: 0.35rem;
+  padding: 0.35rem 0.5rem;
+  color: inherit;
+  background: rgba(111, 89, 255, 0.12);
+  cursor: pointer;
+}
+
+.idt-aws-finding-copy-button:hover,
+.idt-aws-finding-copy-button:focus-visible {
+  border-color: rgba(174, 161, 255, 0.8);
+  background: rgba(111, 89, 255, 0.2);
 }
 
 .idt-aws-finding-technical-evidence dl {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -34003,6 +34003,28 @@ html[data-theme='light'] .idt-danger-modal-typed input {
   background: rgba(111, 89, 255, 0.2);
 }
 
+.idt-aws-finding-handoff-label {
+  display: grid;
+  gap: 0.3rem;
+  margin-top: 0.75rem;
+  color: var(--idt-text-muted, #aeb8c9);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.idt-aws-finding-handoff-label textarea {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 0.35rem;
+  padding: 0.5rem 0.55rem;
+  color: inherit;
+  background: rgba(4, 8, 18, 0.36);
+  font: inherit;
+  line-height: 1.45;
+}
+
 .idt-aws-finding-technical-evidence dl {
   display: grid;
   gap: 0.25rem;


### PR DESCRIPTION
Closes #1827

## Summary

- preserve finding and scan selection in stable drawer URLs, including missing, filtered, historical, and cross-environment states
- complete the investigation view with explicit event, scope, relationship, provenance, freshness, coverage, technical evidence, and remediation handoff sections
- wire persisted findings to assignment, acknowledgement, suppression, reopening, and verified resolution with audit-history refresh and stale-request guards
- require a recorded verification basis before the API accepts a resolved transition

## Why

AWS finding rows already had the queue and drawer foundations from the preceding issues, but operators could not deep-link an investigation or persist workflow decisions from that drawer. Resolution also lacked a server-side verification-basis guard.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed: moderate, limited to finding workflow state and AWS finding presentation

## Validation

- `go test ./...`
- `npx vitest run src/productShell.test.tsx src/api/client.test.ts` (407 tests)
- `npm run build` from `web`
- desktop and 390x844 browser QA on a mocked persisted partial-scan finding; no error overlay or horizontal overflow

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes (inline workflow and coverage guidance)
- [ ] `CHANGELOG.md` updated when relevant (not required for this scoped product change)
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: Full automated validation and browser QA completed

## Related Issues

- Closes #1827

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deep-linkable AWS finding investigation drawer with a persisted, permission-gated workflow and a required verification basis to resolve. Previously triage didn’t persist and resolution didn’t require verification; now triage updates are saved, history loads, URLs track selection, and the API rejects resolution without a nonblank comment.

- Keeps stable URLs with `scan_id` and `finding_id`; environment changes clear both; a missing `finding_id` shows a non-destructive warning and preserves scan scope; selecting related findings updates the URL.
- Completes the investigation view: What happened; Blast radius & relationship path with Identrail investigation link; Coverage limitations (freshness and coverage gaps); Technical evidence with copy; Finding history; and Remediation handoff with copy and Identrail link. No AWS changes are performed.
- Persists workflow with workspace permission gating: owners/admins can assign owner, acknowledge, suppress with reason and optional expiry, reopen, and resolve with a required verification basis. Live findings remain read-only. Preserves server updates if selection changes mid-request, ignores stale drawer responses, refreshes history, updates in-memory state, and keeps status badges consistent.
- Documents and validates server-side rules in `docs/openapi-v1.yaml` and enforces them in the service and tests: a comment is required when transitioning to `resolved`, not when updating metadata on an already resolved finding; suppression requires a reason and a future expiry when set.

**Required actions**
- Clients resolving a finding must include a non-empty `comment` describing the verification basis; otherwise the server rejects the request.
- Clients suppressing a finding must include a non-empty `comment`; if provided, `suppression_expires_at` must be in the future.
- Clients may update metadata (for example, `assignee`) on an already resolved finding without providing a new comment.

<sup>Written for commit f55fd5e354902b467c9ab5ecc4604872f42e5b38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

