### PR TITLE
Accept AWS service-only trust policies

### DIFF
--- a/internal/providers/aws/normalizer_test.go
+++ b/internal/providers/aws/normalizer_test.go
@@ -67,6 +67,42 @@ func TestRoleNormalizerDecodesURLTrustPolicy(t *testing.T) {
 	}
 }
 
+func TestRoleNormalizerAcceptsServiceOnlyTrustPolicy(t *testing.T) {
+	role := IAMRole{
+		ARN:                      "arn:aws:iam::123456789012:role/aws-service-role/access-analyzer.amazonaws.com/AWSServiceRoleForAccessAnalyzer",
+		Name:                     "AWSServiceRoleForAccessAnalyzer",
+		AssumeRolePolicyDocument: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"access-analyzer.amazonaws.com"},"Action":"sts:AssumeRole"}]}`,
+	}
+	payload, err := json.Marshal(role)
+	if err != nil {
+		t.Fatalf("marshal service-linked role: %v", err)
+	}
+
+	bundle, err := NewRoleNormalizer().Normalize(context.Background(), []providers.RawAsset{{
+		Kind:     "iam_role",
+		SourceID: role.ARN,
+		Payload:  payload,
+	}})
+	if err != nil {
+		t.Fatalf("normalize service-linked role: %v", err)
+	}
+	if err := providers.ValidateNormalizedBundle(bundle); err != nil {
+		t.Fatalf("service-only trust policy should satisfy the normalized contract: %v", err)
+	}
+
+	if len(bundle.Policies) != 1 {
+		t.Fatalf("expected one trust policy, got %d", len(bundle.Policies))
+	}
+	policy := bundle.Policies[0]
+	if principals := parseStringList(policy.Normalized[principalsKey]); len(principals) != 0 {
+		t.Fatalf("service principal should not be treated as an IAM principal: %v", principals)
+	}
+	servicePrincipals := parseStringList(policy.Normalized[servicePrincipalsKey])
+	if len(servicePrincipals) != 1 || servicePrincipals[0] != "access-analyzer.amazonaws.com" {
+		t.Fatalf("unexpected service principals: %v", servicePrincipals)
+	}
+}
+
 func TestRoleNormalizerSkipsUnsupportedAndDeduplicates(t *testing.T) {
 	normalizer := NewRoleNormalizer()
 	asset := loadRawRoleAssetFixture(t, "role_with_policies.json")

--- a/internal/providers/contracts.go
+++ b/internal/providers/contracts.go
@@ -298,9 +298,21 @@ func validateStatement(statement map[string]any) error {
 func extractStringSlice(raw any) []string {
 	switch values := raw.(type) {
 	case []string:
-		copied := append([]string(nil), values...)
-		slices.Sort(copied)
-		return slices.Compact(copied)
+		result := make([]string, 0, len(values))
+		seen := map[string]struct{}{}
+		for _, value := range values {
+			normalized := strings.TrimSpace(value)
+			if normalized == "" {
+				continue
+			}
+			if _, exists := seen[normalized]; exists {
+				continue
+			}
+			seen[normalized] = struct{}{}
+			result = append(result, normalized)
+		}
+		slices.Sort(result)
+		return result
 	case []any:
 		result := make([]string, 0, len(values))
 		seen := map[string]struct{}{}

--- a/internal/providers/contracts.go
+++ b/internal/providers/contracts.go
@@ -271,7 +271,8 @@ func validatePolicyNormalized(normalized map[string]any, identityIDs map[string]
 		}
 	case "trust":
 		principals := extractStringSlice(normalized["principals"])
-		if len(principals) == 0 {
+		servicePrincipals := extractStringSlice(normalized["service_principals"])
+		if len(principals) == 0 && len(servicePrincipals) == 0 {
 			return fmt.Errorf("missing trust principals")
 		}
 	}

--- a/internal/providers/contracts_validation_test.go
+++ b/internal/providers/contracts_validation_test.go
@@ -262,6 +262,24 @@ func TestValidateNormalizedBundleDuplicateAndSchemaFailures(t *testing.T) {
 			needle: "missing trust principals",
 		},
 		{
+			name: "trust service principals blank",
+			bundle: NormalizedBundle{
+				Identities: []domain.Identity{baseIdentity},
+				Policies: []domain.Policy{{
+					ID:       "p1",
+					Provider: domain.ProviderAWS,
+					Name:     "trust",
+					RawRef:   "raw",
+					Normalized: map[string]any{
+						"policy_type":        "trust",
+						"identity_id":        "id-1",
+						"service_principals": []string{"", "  "},
+					},
+				}},
+			},
+			needle: "missing trust principals",
+		},
+		{
 			name: "permission statement shape",
 			bundle: NormalizedBundle{
 				Identities: []domain.Identity{baseIdentity},


### PR DESCRIPTION
## Summary

- accept normalized AWS trust policies that contain service principals without IAM principals
- preserve service principals separately so they do not create dangling IAM graph edges
- add a regression test covering the AWSServiceRoleForAccessAnalyzer-shaped role through normalization and contract validation

## Why

AWS service-linked roles use `Principal.Service` rather than `Principal.AWS`. The managed-role signal update began preserving those principals as `service_principals`, but the normalized contract still required `principals`, causing discovery to fail with `missing trust principals`.

## Validation

- `go test ./internal/...`
- pre-commit hooks, including `go vet`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts AWS trust policies that contain only service principals and validates them without requiring IAM principals. Previously we rejected these as “missing trust principals,” breaking discovery for service‑linked roles; now we accept them and keep service principals separate to avoid dangling IAM edges, while rejecting blank/whitespace principals.

- Validation: a `trust` policy is valid if either `principals` or `service_principals` contains at least one non-blank value; blank/whitespace values are ignored.
- Normalization: keep service principals only in `service_principals`; do not add them to `principals`.
- Tests: add normalizer coverage for `AWSServiceRoleForAccessAnalyzer` and a validation case where blank `service_principals` still fail with “missing trust principals.”
- No migrations or config changes; discovery of service‑linked roles should now succeed.

<sup>Written for commit 82d08e4f715f54015efed8343f790c7b870b3a4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

