### PR TITLE
Fix AWS coverage diagnostics and findings console layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Correct AWS service-level coverage diagnostics so permission failures are
+  reported as non-retryable, and keep the findings table and detail drawer
+  usable when the console content area is narrower than the viewport.
 - Redesign the AWS findings queue for prioritization and scan coverage (#1826).
   The summary now exposes open critical/high findings, affected resources,
   historical scan scope, completeness, and named collector failures. Findings

--- a/internal/providers/aws/collector.go
+++ b/internal/providers/aws/collector.go
@@ -269,11 +269,14 @@ func isRetryable(err error) bool {
 	}
 
 	message := strings.ToLower(err.Error())
+	if isAWSTransientFailure(err) {
+		return true
+	}
 	if isAWSNonRetryableFailure(message, err) {
 		return false
 	}
-	if isAWSTransientFailure(err) {
-		return true
+	if isAWSClientHTTPFailure(err) {
+		return false
 	}
 	for _, needle := range []string{
 		"throttl", "rate exceeded", "too many requests", "requestlimitexceeded",
@@ -311,11 +314,6 @@ func isAWSNonRetryableFailure(message string, err error) bool {
 			return true
 		}
 	}
-	var responseErr interface{ HTTPStatusCode() int }
-	if errors.As(err, &responseErr) {
-		status := responseErr.HTTPStatusCode()
-		return status >= 400 && status < 500 && status != 429
-	}
 	return false
 }
 
@@ -337,6 +335,15 @@ func isAWSTransientFailure(err error) bool {
 		return true
 	}
 	return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EPIPE)
+}
+
+func isAWSClientHTTPFailure(err error) bool {
+	var responseErr interface{ HTTPStatusCode() int }
+	if !errors.As(err, &responseErr) {
+		return false
+	}
+	status := responseErr.HTTPStatusCode()
+	return status >= 400 && status < 500 && status != 429
 }
 
 func defaultSleeper(ctx context.Context, delay time.Duration) error {

--- a/internal/providers/aws/collector.go
+++ b/internal/providers/aws/collector.go
@@ -5,10 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
+	"net"
 	"strings"
+	"syscall"
 	"time"
 
+	"github.com/aws/smithy-go"
 	"github.com/identrail/identrail/internal/providers"
 )
 
@@ -265,12 +269,74 @@ func isRetryable(err error) bool {
 	}
 
 	message := strings.ToLower(err.Error())
-	for _, needle := range []string{"throttl", "rate exceeded", "too many requests", "requestlimitexceeded"} {
+	if isAWSNonRetryableFailure(message, err) {
+		return false
+	}
+	if isAWSTransientFailure(err) {
+		return true
+	}
+	for _, needle := range []string{
+		"throttl", "rate exceeded", "too many requests", "requestlimitexceeded",
+		"provisionedthroughputexceeded", "internalerror", "internal failure",
+		"service unavailable", "slowdown", "request timeout", "connection reset",
+		"connection refused", "broken pipe", "temporarily unavailable",
+		"statuscode: 502", "statuscode: 503", "statuscode: 504", "eof",
+	} {
 		if strings.Contains(message, needle) {
 			return true
 		}
 	}
 	return false
+}
+
+// isAWSNonRetryableFailure identifies authentication and authorization
+// failures before broad transient-message checks. These errors require
+// connector configuration or credentials to change; retrying the same request
+// cannot make it succeed.
+func isAWSNonRetryableFailure(message string, err error) bool {
+	for _, needle := range []string{
+		"accessdenied", "access denied", "unauthorizedoperation", "unauthorized operation",
+		"unrecognizedclient", "invalidclienttokenid", "expiredtoken", "signaturedoesnotmatch",
+		"invalid signature", "missingauthenticationtoken", "authentication failed",
+		"not authorized", "permission denied",
+	} {
+		if strings.Contains(message, needle) {
+			return true
+		}
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch strings.ToLower(apiErr.ErrorCode()) {
+		case "accessdenied", "accessdeniedexception", "unauthorizedoperation", "unrecognizedclientexception", "invalidclienttokenid", "expiredtoken", "expiredtokenexception", "signaturedoesnotmatch", "invalidsignatureexception", "missingauthenticationtoken":
+			return true
+		}
+	}
+	var responseErr interface{ HTTPStatusCode() int }
+	if errors.As(err, &responseErr) {
+		status := responseErr.HTTPStatusCode()
+		return status >= 400 && status < 500 && status != 429
+	}
+	return false
+}
+
+func isAWSTransientFailure(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch strings.ToLower(apiErr.ErrorCode()) {
+		case "throttling", "throttlingexception", "requestlimitexceeded", "provisionedthroughputexceededexception", "toomanyrequests", "toomanyrequestsexception", "internalerror", "internalfailure", "serviceunavailable", "serviceunavailableexception", "slowdown", "requesttimeout", "requesttimeoutexception", "priorrequestnotcomplete", "limitexceededexception", "resourcelimitexceeded":
+			return true
+		}
+	}
+	var responseErr interface{ HTTPStatusCode() int }
+	if errors.As(err, &responseErr) {
+		status := responseErr.HTTPStatusCode()
+		return status == 429 || status >= 500
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary()) {
+		return true
+	}
+	return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EPIPE)
 }
 
 func defaultSleeper(ctx context.Context, delay time.Duration) error {

--- a/internal/providers/aws/collector_test.go
+++ b/internal/providers/aws/collector_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/aws/smithy-go"
 )
 
 type fakeIAMClient struct {
@@ -277,13 +281,33 @@ func TestCollectFailsWithoutClient(t *testing.T) {
 }
 
 func TestIsRetryableByMessage(t *testing.T) {
-	if !isRetryable(errors.New("RequestLimitExceeded")) {
-		t.Fatal("expected retryable error")
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "throttle code", err: errors.New("RequestLimitExceeded"), want: true},
+		{name: "throughput code", err: &smithy.GenericAPIError{Code: "ProvisionedThroughputExceededException"}, want: true},
+		{name: "internal service code", err: &smithy.GenericAPIError{Code: "InternalError"}, want: true},
+		{name: "timeout wrapper", err: &url.Error{Op: "GET", URL: "https://example.test", Err: timeoutTestError{}}, want: true},
+		{name: "eof", err: io.EOF, want: true},
+		{name: "access denied code", err: &smithy.GenericAPIError{Code: "AccessDeniedException"}, want: false},
+		{name: "permission message", err: errors.New("permission denied"), want: false},
 	}
-	if isRetryable(errors.New("permission denied")) {
-		t.Fatal("expected non-retryable error")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryable(tt.err); got != tt.want {
+				t.Fatalf("isRetryable(%v)=%t, want %t", tt.err, got, tt.want)
+			}
+		})
 	}
 }
+
+type timeoutTestError struct{}
+
+func (timeoutTestError) Error() string   { return "i/o timeout" }
+func (timeoutTestError) Timeout() bool   { return true }
+func (timeoutTestError) Temporary() bool { return true }
 
 func mustLoadPageFixture(t *testing.T, name string) ListRolesPage {
 	t.Helper()

--- a/internal/providers/aws/collector_test.go
+++ b/internal/providers/aws/collector_test.go
@@ -289,6 +289,8 @@ func TestIsRetryableByMessage(t *testing.T) {
 		{name: "throttle code", err: errors.New("RequestLimitExceeded"), want: true},
 		{name: "throughput code", err: &smithy.GenericAPIError{Code: "ProvisionedThroughputExceededException"}, want: true},
 		{name: "internal service code", err: &smithy.GenericAPIError{Code: "InternalError"}, want: true},
+		{name: "throttle code in client response", err: httpStatusTestError{status: 400, err: &smithy.GenericAPIError{Code: "ThrottlingException"}}, want: true},
+		{name: "unknown client response", err: httpStatusTestError{status: 400, err: errors.New("bad request")}, want: false},
 		{name: "timeout wrapper", err: &url.Error{Op: "GET", URL: "https://example.test", Err: timeoutTestError{}}, want: true},
 		{name: "eof", err: io.EOF, want: true},
 		{name: "access denied code", err: &smithy.GenericAPIError{Code: "AccessDeniedException"}, want: false},
@@ -308,6 +310,15 @@ type timeoutTestError struct{}
 func (timeoutTestError) Error() string   { return "i/o timeout" }
 func (timeoutTestError) Timeout() bool   { return true }
 func (timeoutTestError) Temporary() bool { return true }
+
+type httpStatusTestError struct {
+	status int
+	err    error
+}
+
+func (e httpStatusTestError) Error() string       { return e.err.Error() }
+func (e httpStatusTestError) Unwrap() error       { return e.err }
+func (e httpStatusTestError) HTTPStatusCode() int { return e.status }
 
 func mustLoadPageFixture(t *testing.T, name string) ListRolesPage {
 	t.Helper()

--- a/internal/providers/aws/composite_collector.go
+++ b/internal/providers/aws/composite_collector.go
@@ -186,7 +186,11 @@ func sourceServiceFailureDiagnostic(scope AWSCollectorScope, err error) provider
 		Code:      "service_collection_failed",
 		Message:   appendSourceContextToMessage(scope, err.Error()),
 		SourceID:  compositeSourceID(scope, ""),
-		Retryable: true,
+		// Preserve the underlying AWS error classification. Permission and
+		// authentication failures are configuration problems and retrying them
+		// only creates noisy partial scans; throttles and other transient errors
+		// remain retryable through isRetryable.
+		Retryable: isRetryable(err),
 	}
 }
 

--- a/internal/providers/aws/composite_collector_test.go
+++ b/internal/providers/aws/composite_collector_test.go
@@ -90,7 +90,7 @@ func TestAWSCompositeCollectorNonFatalServiceFailureContinuesAndRecordsDiagnosti
 
 	secondService := &fakeAWSServiceCollector{
 		name: "ecs",
-		err:  errors.New("temporary downstream failure"),
+		err:  errors.New("ThrottlingException: temporary downstream failure"),
 	}
 	composite := NewAWSCompositeCollector(api, "123", "eu-west-1", secondService)
 	assets, sourceErrors, err := composite.CollectWithDiagnostics(context.Background())
@@ -118,8 +118,30 @@ func TestAWSCompositeCollectorNonFatalServiceFailureContinuesAndRecordsDiagnosti
 	if sourceErrors[0].Retryable != true {
 		t.Fatalf("expected retryable diagnostic for service failure")
 	}
-	if sourceErrors[0].Message == "" || sourceErrors[0].Message != "temporary downstream failure [service=ecs account=123 region=eu-west-1]" {
+	if sourceErrors[0].Message == "" || sourceErrors[0].Message != "ThrottlingException: temporary downstream failure [service=ecs account=123 region=eu-west-1]" {
 		t.Fatalf("unexpected diagnostic message %q", sourceErrors[0].Message)
+	}
+}
+
+func TestAWSCompositeCollectorPermissionFailureIsNotRetryable(t *testing.T) {
+	api := &fakeIAMClient{listFn: func(_ context.Context, _ string, _ int32) (ListRolesPage, error) {
+		return ListRolesPage{Roles: []IAMRole{{ARN: "arn:aws:iam::123:role/safe", Name: "safe"}}}, nil
+	}}
+
+	service := &fakeAWSServiceCollector{
+		name: "lambda",
+		err:  errors.New("AccessDeniedException: User is not authorized to perform lambda:ListFunctions"),
+	}
+	composite := NewAWSCompositeCollector(api, "123", "us-east-1", service)
+	_, sourceErrors, err := composite.CollectWithDiagnostics(context.Background())
+	if err != nil {
+		t.Fatalf("expected IAM assets to preserve a non-fatal service failure, got %v", err)
+	}
+	if len(sourceErrors) != 1 {
+		t.Fatalf("expected one service diagnostic, got %d", len(sourceErrors))
+	}
+	if sourceErrors[0].Retryable {
+		t.Fatalf("permission failures must not be marked retryable: %+v", sourceErrors[0])
 	}
 }
 

--- a/web/src/components/app/DomainFoundation.test.tsx
+++ b/web/src/components/app/DomainFoundation.test.tsx
@@ -187,7 +187,9 @@ describe('DomainFoundation', () => {
     expect(within(identityTable).getByText('Deploy role')).toBeInTheDocument();
     expect(identityTable.closest('.idt-domain-table-wrap')).toHaveClass('is-narrow-stack');
     expect(within(identityTable).getByText('Deploy role').closest('td')).toHaveAttribute('data-label', 'Identity');
+    expect(within(identityTable).getByText('Deploy role').closest('td')).toHaveAttribute('data-column', 'name');
     expect(within(identityTable).getByText('High').closest('td')).toHaveAttribute('data-label', 'Risk');
+    expect(within(identityTable).getByRole('columnheader', { name: 'Risk' })).toHaveAttribute('data-column', 'risk');
     expect(screen.getByText('No records yet')).toBeInTheDocument();
     expect(screen.getByRole('alert')).toHaveTextContent('Sync failed');
     expect(screen.getByRole('status')).toHaveTextContent('Loading GitHub repositories');

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -497,7 +497,7 @@ export function DomainDataTable<Row>({
         <thead>
           <tr>
             {columns.map((column) => (
-              <th key={column.key} scope="col" className={column.align === 'right' ? 'is-right' : undefined}>
+              <th key={column.key} scope="col" data-column={column.key} className={column.align === 'right' ? 'is-right' : undefined}>
                 {column.header}
               </th>
             ))}
@@ -507,7 +507,7 @@ export function DomainDataTable<Row>({
           {rows.map((row) => (
             <tr key={getRowKey(row)}>
               {columns.map((column) => (
-                <td key={column.key} data-label={column.header} className={column.align === 'right' ? 'is-right' : undefined}>
+                <td key={column.key} data-column={column.key} data-label={column.header} className={column.align === 'right' ? 'is-right' : undefined}>
                   {column.render(row)}
                 </td>
               ))}

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -9016,6 +9016,7 @@ describe('Domain-first app routes', () => {
     expect(stylesSource).toContain('content: attr(data-label);');
     expect(stylesSource).toContain('overflow-wrap: anywhere;');
     expect(stylesSource).toContain('table-layout: fixed;');
+    expect(stylesSource).toContain('@media (min-width: 1101px)');
     expect(stylesSource).toContain("[data-column='workflow']");
     expect(stylesSource).toContain('.idt-domain-drawer .idt-inline-actions');
     expect(stylesSource).toContain('.idt-domain-drawer .idt-aws-finding-workflow-controls textarea');

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -9015,6 +9015,11 @@ describe('Domain-first app routes', () => {
     expect(stylesSource).toContain('min-width: 0 !important;');
     expect(stylesSource).toContain('content: attr(data-label);');
     expect(stylesSource).toContain('overflow-wrap: anywhere;');
+    expect(stylesSource).toContain('table-layout: fixed;');
+    expect(stylesSource).toContain("[data-column='workflow']");
+    expect(stylesSource).toContain('.idt-domain-drawer .idt-inline-actions');
+    expect(stylesSource).toContain('.idt-domain-drawer .idt-aws-finding-workflow-controls textarea');
+    expect(within(findingsTable).getByRole('columnheader', { name: 'Workflow' })).toHaveAttribute('data-column', 'workflow');
     const [productionRoleFinding] = within(findingsTable).getAllByText('production-role', { exact: true });
     const overprivilegedRow = productionRoleFinding.closest('tr');
     expect(overprivilegedRow).not.toBeNull();

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -25088,37 +25088,39 @@ html[data-theme='light'] .idt-app-shell-screen select {
   table-layout: fixed;
 }
 
-.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='category'] {
-  width: 8%;
-}
+@media (min-width: 1101px) {
+  .idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='category'] {
+    width: 8%;
+  }
 
-.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='title'] {
-  width: 18%;
-}
+  .idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='title'] {
+    width: 18%;
+  }
 
-.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='resource'] {
-  width: 19%;
-}
+  .idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='resource'] {
+    width: 19%;
+  }
 
-.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='why'] {
-  width: 20%;
-}
+  .idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='why'] {
+    width: 20%;
+  }
 
-.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='blast'] {
-  width: 12%;
-}
+  .idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='blast'] {
+    width: 12%;
+  }
 
-.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='evidence'] {
-  width: 13%;
-}
+  .idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='evidence'] {
+    width: 13%;
+  }
 
-.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='workflow'] {
-  width: 10%;
-}
+  .idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='workflow'] {
+    width: 10%;
+  }
 
-.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='title'] > * {
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  .idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='title'] > * {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
 }
 
 .idt-aws-risk-page .idt-domain-table-empty {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -25074,6 +25074,53 @@ html[data-theme='light'] .idt-app-shell-screen select {
   font-size: 0.84rem;
 }
 
+/* Findings are a seven-column operational table. Let the columns share the
+ * available console width instead of allowing long resource names to push
+ * the workflow controls off the viewport. The narrow-stack variant below
+ * still replaces the table with labelled cards on genuinely small screens. */
+.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) {
+  overflow-x: auto;
+}
+
+.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) .idt-domain-data-table {
+  width: 100%;
+  min-width: 0;
+  table-layout: fixed;
+}
+
+.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='category'] {
+  width: 8%;
+}
+
+.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='title'] {
+  width: 18%;
+}
+
+.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='resource'] {
+  width: 19%;
+}
+
+.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='why'] {
+  width: 20%;
+}
+
+.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='blast'] {
+  width: 12%;
+}
+
+.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='evidence'] {
+  width: 13%;
+}
+
+.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='workflow'] {
+  width: 10%;
+}
+
+.idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='title'] > * {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .idt-aws-risk-page .idt-domain-table-empty {
   padding: 0;
 }
@@ -26234,9 +26281,23 @@ button.idt-domain-finding-card:focus-visible {
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
+  overflow-wrap: anywhere;
   overscroll-behavior: contain;
   padding: 1rem;
   color: var(--app-text);
+}
+
+.idt-domain-drawer .idt-inline-actions {
+  margin-top: 0;
+  justify-content: flex-start;
+}
+
+.idt-domain-drawer .idt-aws-finding-workflow-controls textarea {
+  min-height: 5rem;
+}
+
+.idt-domain-drawer .idt-aws-finding-handoff-label textarea {
+  min-height: 8rem;
 }
 
 .idt-domain-drawer footer {
@@ -33676,7 +33737,7 @@ html[data-theme='light'] .idt-danger-modal-typed input {
   font-weight: 800;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 1100px) {
   .idt-aws-finding-summary-heading {
     flex-direction: column;
   }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -25121,6 +25121,13 @@ html[data-theme='light'] .idt-app-shell-screen select {
     overflow-wrap: anywhere;
     word-break: break-word;
   }
+
+  .idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='resource'] .idt-aws-finding-resource-cell,
+  .idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='why'] .idt-aws-finding-why-cell,
+  .idt-aws-risk-page .idt-domain-table-wrap:has(.idt-aws-finding-workflow-cell) [data-column='evidence'] .idt-aws-finding-evidence-cell {
+    min-width: 0;
+    max-width: 100%;
+  }
 }
 
 .idt-aws-risk-page .idt-domain-table-empty {


### PR DESCRIPTION
## Summary

- classify composite AWS service failures from the underlying error instead of marking every failure retryable
- keep permission and authentication failures non-retryable while preserving retry behavior for throttling and other transient failures
- make the AWS findings table fit the available console content area and stack at the real narrow-content breakpoint so workflow actions remain usable
- prevent global console form styles from making finding-drawer controls oversized and add stable table column metadata for responsive styling

## Root cause

The synthetic `service_collection_failed` diagnostic hard-coded `Retryable: true`, so missing permissions from an existing AWS connector role were presented as retryable even though retries cannot repair the role. Separately, long finding/resource content was allowed to determine the seven-column table width, while the drawer inherited oversized global textarea spacing.

The merged read-only policy release updates the policy artifacts for newly deployed or updated connector stacks. Existing AWS roles still need to be updated to that policy version before a subsequent scan can collect the newly wired services.

## Validation

- `go test ./...`
- `npm test -- --run`
- `npm run build`
- pre-commit and pre-push checks

AI assistance disclosure: No
