### PR TITLE
[AWS] Block scans on incomplete connector permission scope

### DIFF
--- a/internal/api/aws_baseline.go
+++ b/internal/api/aws_baseline.go
@@ -174,47 +174,56 @@ func (s *Service) GetAWSPlatformBaseline(ctx context.Context, workspaceID string
 	}, nil
 }
 
-func (s *Service) ensureAWSPlatformBaselineReadyForScan(ctx context.Context, provider string, source db.ScanSource) error {
+func (s *Service) ensureAWSPlatformBaselineReadyForScan(ctx context.Context, provider string, source db.ScanSource) (db.ScanSource, error) {
 	if strings.ToLower(strings.TrimSpace(provider)) != string(domain.ConnectorTypeAWS) {
-		return nil
+		return source.Normalize(), nil
 	}
 	source = source.Normalize()
 	if source.ProjectID == "" {
-		return nil
+		return source, nil
 	}
-	if err := s.refreshAWSConnectionForScan(ctx, source); err != nil {
-		return err
+	var err error
+	source, err = s.refreshAWSConnectionForScan(ctx, source)
+	if err != nil {
+		return source, err
 	}
 	result, err := s.VerifyAWSPlatformBaseline(ctx, "", source.ProjectID, AWSPlatformBaselineRequest{ConnectorID: source.ConnectorID})
 	if err != nil {
-		return err
+		return source, err
 	}
 	if !result.RequiredChecksPassed {
-		return AWSPlatformBaselineNotReadyError{Result: result}
+		return source, AWSPlatformBaselineNotReadyError{Result: result}
 	}
-	return nil
+	return source, nil
 }
 
 // refreshAWSConnectionForScan revalidates the selected AWS connector immediately
-// before a new scan is queued. Connector health is persisted state, so relying
-// on an old successful validation would allow a role-policy change to produce a
-// partial scan while the UI still reports the connector as healthy.
-func (s *Service) refreshAWSConnectionForScan(ctx context.Context, source db.ScanSource) error {
-	if s.AWSConnectorValidator == nil || s.awsBaselineSourceMode() == "fixture" {
-		return nil
-	}
+// before a new scan is queued or started. Connector health is persisted state,
+// so relying on an old successful validation would allow a role-policy change to
+// produce a partial scan while the UI still reports the connector as healthy.
+func (s *Service) refreshAWSConnectionForScan(ctx context.Context, source db.ScanSource) (db.ScanSource, error) {
 	source = source.Normalize()
+	if s.AWSConnectorValidator == nil || s.awsBaselineSourceMode() == "fixture" {
+		return source, nil
+	}
 	project, _, err := s.requireScopedProject(ctx, "", source.ProjectID)
 	if err != nil {
-		return err
+		return source, err
 	}
 	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, source.ConnectorID)
 	if err != nil {
-		return err
+		return source, err
 	}
 	if !hasConnection || strings.TrimSpace(connection.RoleARN) == "" || connection.Disabled || connection.Status == domain.ConnectorStatusDisconnected {
-		return nil
+		if hasConnection && source.ConnectorID == "" {
+			source.ConnectorID = connection.ConnectorID
+		}
+		return source, nil
 	}
+	// Bind the scan to the exact connector selected for this validation. Without
+	// this, a failed validation can make the selector silently fall through to a
+	// different connector whose persisted health is stale.
+	source.ConnectorID = connection.ConnectorID
 	_, err = s.ValidateAWSConnector(ctx, connection.ConnectorID, AWSConnectorValidateRequest{
 		WorkspaceID: project.WorkspaceID,
 		ProjectID:   project.ProjectID,
@@ -222,7 +231,7 @@ func (s *Service) refreshAWSConnectionForScan(ctx context.Context, source db.Sca
 		ExternalID:  connection.ExternalID,
 		Region:      connection.Region,
 	})
-	return err
+	return source, err
 }
 
 func (s *Service) awsBaselineConnection(ctx context.Context, project db.TenancyProject, connectorID string) (AWSConnectionStatus, bool, error) {

--- a/internal/api/aws_baseline.go
+++ b/internal/api/aws_baseline.go
@@ -182,6 +182,9 @@ func (s *Service) ensureAWSPlatformBaselineReadyForScan(ctx context.Context, pro
 	if source.ProjectID == "" {
 		return nil
 	}
+	if err := s.refreshAWSConnectionForScan(ctx, source); err != nil {
+		return err
+	}
 	result, err := s.VerifyAWSPlatformBaseline(ctx, "", source.ProjectID, AWSPlatformBaselineRequest{ConnectorID: source.ConnectorID})
 	if err != nil {
 		return err
@@ -190,6 +193,36 @@ func (s *Service) ensureAWSPlatformBaselineReadyForScan(ctx context.Context, pro
 		return AWSPlatformBaselineNotReadyError{Result: result}
 	}
 	return nil
+}
+
+// refreshAWSConnectionForScan revalidates the selected AWS connector immediately
+// before a new scan is queued. Connector health is persisted state, so relying
+// on an old successful validation would allow a role-policy change to produce a
+// partial scan while the UI still reports the connector as healthy.
+func (s *Service) refreshAWSConnectionForScan(ctx context.Context, source db.ScanSource) error {
+	if s.AWSConnectorValidator == nil || s.awsBaselineSourceMode() == "fixture" {
+		return nil
+	}
+	source = source.Normalize()
+	project, _, err := s.requireScopedProject(ctx, "", source.ProjectID)
+	if err != nil {
+		return err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, source.ConnectorID)
+	if err != nil {
+		return err
+	}
+	if !hasConnection || strings.TrimSpace(connection.RoleARN) == "" || connection.Disabled || connection.Status == domain.ConnectorStatusDisconnected {
+		return nil
+	}
+	_, err = s.ValidateAWSConnector(ctx, connection.ConnectorID, AWSConnectorValidateRequest{
+		WorkspaceID: project.WorkspaceID,
+		ProjectID:   project.ProjectID,
+		RoleARN:     connection.RoleARN,
+		ExternalID:  connection.ExternalID,
+		Region:      connection.Region,
+	})
+	return err
 }
 
 func (s *Service) awsBaselineConnection(ctx context.Context, project db.TenancyProject, connectorID string) (AWSConnectionStatus, bool, error) {

--- a/internal/api/aws_baseline_test.go
+++ b/internal/api/aws_baseline_test.go
@@ -475,8 +475,13 @@ func TestScheduledAWSScanRevalidatesSelectedConnectorInItsScope(t *testing.T) {
 	workerCtx := defaultScopeContext()
 	selectedCtx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
 	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, workerCtx, "project-a")
 	seedDefaultProject(t, store, selectedCtx, "project-b")
-	seedAWSConnectorForScanTest(t, store, selectedCtx, "project-b", "aws-tenant-b", domain.ConnectorStatusActive, "healthy", now)
+	// Connector IDs are project-scoped, so the same ID can exist in both
+	// scopes. Keep the default-scope row newer but degraded to ensure the
+	// selector's full row, rather than only its ID, is preserved.
+	seedAWSConnectorForScanTest(t, store, workerCtx, "project-a", "aws-shared", domain.ConnectorStatusActive, "error", now.Add(time.Hour))
+	seedAWSConnectorForScanTest(t, store, selectedCtx, "project-b", "aws-shared", domain.ConnectorStatusActive, "healthy", now)
 
 	validator := &scopeRecordingAWSConnectorValidator{result: AWSConnectionValidationResult{
 		AccountID: "123456789012",
@@ -491,7 +496,7 @@ func TestScheduledAWSScanRevalidatesSelectedConnectorInItsScope(t *testing.T) {
 	var factoryScope db.Scope
 	svc.AWSScannerFactory = func(ctx context.Context, connection AWSConnectionStatus) (ScannerRunner, error) {
 		factoryScope = db.ScopeFromContext(ctx)
-		if connection.ConnectorID != "aws-tenant-b" {
+		if connection.ConnectorID != "aws-shared" {
 			t.Fatalf("expected selected connector, got %q", connection.ConnectorID)
 		}
 		return fakeScanner{result: app.ScanResult{Assets: 1}}, nil

--- a/internal/api/aws_baseline_test.go
+++ b/internal/api/aws_baseline_test.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -269,6 +271,120 @@ func TestVerifyAWSPlatformBaselineExplainsUnhealthyConnectorAndFullQueue(t *test
 	queueCheck := requireAWSBaselineCheck(t, result.Checks, "worker_queue_availability")
 	if queueCheck.Status != db.AWSPlatformBaselineCheckFailed || queueCheck.FailureReason != "worker queue is full" {
 		t.Fatalf("expected full queue check, got %+v", queueCheck)
+	}
+}
+
+func TestEnqueueAWSScanRevalidatesConnectorPermissionScope(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	stored, err := store.GetTenancyConnector(ctx, "default", "project-a", "aws-prod")
+	if err != nil {
+		t.Fatalf("load connector: %v", err)
+	}
+	stored.State.Metadata["external_id"] = "test-external-id"
+	if err := store.UpsertTenancyConnector(ctx, stored.Connector, stored.State); err != nil {
+		t.Fatalf("persist connector external id: %v", err)
+	}
+
+	validator := &fakeAWSConnectorValidator{result: AWSConnectionValidationResult{
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		PermissionChecks: []AWSConnectionPermissionCheck{
+			{Name: "sts:AssumeRole", Passed: true, Message: "Role assumption succeeded."},
+			{Name: "aws:ReadOnlyCollectorScope", Passed: false, Message: "The connector role is missing required read-only collector actions.", Remediation: "Attach the current read-only collector policy."},
+		},
+	}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSConnectorValidator = validator
+
+	_, err = svc.EnqueueScan(ctx, ScanRequest{ProjectID: "project-a", ConnectorID: "aws-prod"})
+	var notReady AWSPlatformBaselineNotReadyError
+	if !errors.As(err, &notReady) {
+		t.Fatalf("expected permission preflight to block scan, got %v", err)
+	}
+	if validator.calls != 1 {
+		t.Fatalf("expected one live connector validation, got %d", validator.calls)
+	}
+	check := requireAWSBaselineCheck(t, notReady.Result.Checks, "aws_connector_health")
+	if check.Status != db.AWSPlatformBaselineCheckPermissionDenied || !strings.Contains(check.FailureReason, "missing required") {
+		t.Fatalf("expected permission-scope failure in baseline, got %+v", check)
+	}
+}
+
+type sequenceAWSConnectorValidator struct {
+	results []AWSConnectionValidationResult
+	calls   int
+}
+
+func (v *sequenceAWSConnectorValidator) ValidateAWSConnection(_ context.Context, _ AWSConnectionValidationRequest) (AWSConnectionValidationResult, error) {
+	index := v.calls
+	v.calls++
+	if index >= len(v.results) {
+		index = len(v.results) - 1
+	}
+	return v.results[index], nil
+}
+
+func TestAWSWorkerRevalidatesConnectorBeforeStartingQueuedScan(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 8, 26, 11, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	stored, err := store.GetTenancyConnector(ctx, "default", "project-a", "aws-prod")
+	if err != nil {
+		t.Fatalf("load connector: %v", err)
+	}
+	stored.State.Metadata["external_id"] = "test-external-id"
+	if err := store.UpsertTenancyConnector(ctx, stored.Connector, stored.State); err != nil {
+		t.Fatalf("persist connector external id: %v", err)
+	}
+
+	healthy := AWSConnectionValidationResult{
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		PermissionChecks: []AWSConnectionPermissionCheck{
+			{Name: "sts:AssumeRole", Passed: true, Message: "Role assumption succeeded."},
+			{Name: "aws:ReadOnlyCollectorScope", Passed: true, Message: "The connector role grants every required read-only collector action."},
+		},
+	}
+	degraded := AWSConnectionValidationResult{
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		PermissionChecks: []AWSConnectionPermissionCheck{
+			{Name: "sts:AssumeRole", Passed: true, Message: "Role assumption succeeded."},
+			{Name: "aws:ReadOnlyCollectorScope", Passed: false, Message: "The connector role is missing required read-only collector actions."},
+		},
+	}
+	validator := &sequenceAWSConnectorValidator{results: []AWSConnectionValidationResult{healthy, degraded}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSConnectorValidator = validator
+	factoryCalled := false
+	svc.AWSScannerFactory = func(_ context.Context, _ AWSConnectionStatus) (ScannerRunner, error) {
+		factoryCalled = true
+		return fakeScanner{result: app.ScanResult{Assets: 1}}, nil
+	}
+
+	record, err := svc.EnqueueScan(ctx, ScanRequest{ProjectID: "project-a", ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("enqueue scan: %v", err)
+	}
+	if validator.calls != 1 {
+		t.Fatalf("expected enqueue validation, got %d calls", validator.calls)
+	}
+	if _, err := svc.scannerForScan(ctx, record); err == nil || !strings.Contains(err.Error(), "not active") {
+		t.Fatalf("expected worker validation to reject stale connector health, got %v", err)
+	}
+	if validator.calls != 2 {
+		t.Fatalf("expected worker validation, got %d calls", validator.calls)
+	}
+	if factoryCalled {
+		t.Fatal("expected AWS scanner factory not to run after permission drift")
 	}
 }
 

--- a/internal/api/aws_baseline_test.go
+++ b/internal/api/aws_baseline_test.go
@@ -315,6 +315,40 @@ func TestEnqueueAWSScanRevalidatesConnectorPermissionScope(t *testing.T) {
 	}
 }
 
+func TestEnqueueAWSScanBindsSelectedConnectorBeforeBaselineCheck(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 8, 26, 10, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	// The most recently updated connector is selected for an unbound scan.
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-first", domain.ConnectorStatusActive, "healthy", now.Add(time.Hour))
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-second", domain.ConnectorStatusActive, "healthy", now)
+
+	validator := &sequenceAWSConnectorValidator{results: []AWSConnectionValidationResult{{
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		PermissionChecks: []AWSConnectionPermissionCheck{
+			{Name: "sts:AssumeRole", Passed: true, Message: "Role assumption succeeded."},
+			{Name: "aws:ReadOnlyCollectorScope", Passed: false, Message: "The connector role is missing required read-only collector actions."},
+		},
+	}}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSConnectorValidator = validator
+
+	_, err := svc.EnqueueScan(ctx, ScanRequest{ProjectID: "project-a"})
+	var notReady AWSPlatformBaselineNotReadyError
+	if !errors.As(err, &notReady) {
+		t.Fatalf("expected selected connector validation to block scan, got %v", err)
+	}
+	if validator.calls != 1 {
+		t.Fatalf("expected one validation of the selected connector, got %d", validator.calls)
+	}
+	if notReady.Result.ConnectorID != "aws-first" {
+		t.Fatalf("expected baseline to remain bound to selected connector, got %q", notReady.Result.ConnectorID)
+	}
+}
+
 type sequenceAWSConnectorValidator struct {
 	results []AWSConnectionValidationResult
 	calls   int
@@ -526,7 +560,7 @@ func TestEnsureAWSPlatformBaselineBlocksMissingConnector(t *testing.T) {
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }
 
-	err := svc.ensureAWSPlatformBaselineReadyForScan(ctx, "aws", db.ScanSource{ProjectID: "project-a"})
+	_, err := svc.ensureAWSPlatformBaselineReadyForScan(ctx, "aws", db.ScanSource{ProjectID: "project-a"})
 	var notReady AWSPlatformBaselineNotReadyError
 	if !errorsAsAWSBaseline(err, &notReady) {
 		t.Fatalf("expected baseline not ready error, got %v", err)
@@ -551,7 +585,7 @@ func TestEnsureAWSPlatformBaselineAllowsFixtureModeWithoutConnector(t *testing.T
 	svc.AWSBaselineSourceMode = "fixture"
 	svc.AWSBaselineFixturePaths = []string{fixtureDir}
 
-	if err := svc.ensureAWSPlatformBaselineReadyForScan(ctx, "aws", db.ScanSource{ProjectID: "project-a"}); err != nil {
+	if _, err := svc.ensureAWSPlatformBaselineReadyForScan(ctx, "aws", db.ScanSource{ProjectID: "project-a"}); err != nil {
 		t.Fatalf("expected fixture baseline to allow scan without connector: %v", err)
 	}
 	result, err := store.GetAWSPlatformBaselineResult(ctx, db.AWSPlatformBaselineFilter{

--- a/internal/api/aws_baseline_test.go
+++ b/internal/api/aws_baseline_test.go
@@ -422,6 +422,42 @@ func TestAWSWorkerRevalidatesConnectorBeforeStartingQueuedScan(t *testing.T) {
 	}
 }
 
+func TestScheduledAWSScanRevalidatesSelectedConnectorBeforeStarting(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 8, 26, 11, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	validator := &sequenceAWSConnectorValidator{results: []AWSConnectionValidationResult{{
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		PermissionChecks: []AWSConnectionPermissionCheck{
+			{Name: "sts:AssumeRole", Passed: true, Message: "Role assumption succeeded."},
+			{Name: "aws:ReadOnlyCollectorScope", Passed: false, Message: "The connector role is missing required read-only collector actions."},
+		},
+	}}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSConnectorValidator = validator
+	factoryCalled := false
+	svc.AWSScannerFactory = func(_ context.Context, _ AWSConnectionStatus) (ScannerRunner, error) {
+		factoryCalled = true
+		return fakeScanner{result: app.ScanResult{Assets: 1}}, nil
+	}
+
+	_, err := svc.RunScan(ctx)
+	if err == nil || !strings.Contains(err.Error(), "not active") {
+		t.Fatalf("expected scheduled scan to fail closed after connector drift, got %v", err)
+	}
+	if validator.calls != 1 {
+		t.Fatalf("expected one scheduled-scan connector validation, got %d", validator.calls)
+	}
+	if factoryCalled {
+		t.Fatal("expected scanner factory not to run after scheduled connector validation failed")
+	}
+}
+
 func TestVerifyAWSPlatformBaselineQueueCheckIsSourceScoped(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/aws_baseline_test.go
+++ b/internal/api/aws_baseline_test.go
@@ -363,6 +363,18 @@ func (v *sequenceAWSConnectorValidator) ValidateAWSConnection(_ context.Context,
 	return v.results[index], nil
 }
 
+type scopeRecordingAWSConnectorValidator struct {
+	result AWSConnectionValidationResult
+	seen   db.Scope
+	calls  int
+}
+
+func (v *scopeRecordingAWSConnectorValidator) ValidateAWSConnection(ctx context.Context, _ AWSConnectionValidationRequest) (AWSConnectionValidationResult, error) {
+	v.calls++
+	v.seen = db.ScopeFromContext(ctx)
+	return v.result, nil
+}
+
 func TestAWSWorkerRevalidatesConnectorBeforeStartingQueuedScan(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()
@@ -455,6 +467,45 @@ func TestScheduledAWSScanRevalidatesSelectedConnectorBeforeStarting(t *testing.T
 	}
 	if factoryCalled {
 		t.Fatal("expected scanner factory not to run after scheduled connector validation failed")
+	}
+}
+
+func TestScheduledAWSScanRevalidatesSelectedConnectorInItsScope(t *testing.T) {
+	store := db.NewMemoryStore()
+	workerCtx := defaultScopeContext()
+	selectedCtx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, selectedCtx, "project-b")
+	seedAWSConnectorForScanTest(t, store, selectedCtx, "project-b", "aws-tenant-b", domain.ConnectorStatusActive, "healthy", now)
+
+	validator := &scopeRecordingAWSConnectorValidator{result: AWSConnectionValidationResult{
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		PermissionChecks: []AWSConnectionPermissionCheck{{
+			Name: "sts:AssumeRole", Passed: true, Message: "Role assumption succeeded.",
+		}},
+	}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSConnectorValidator = validator
+	var factoryScope db.Scope
+	svc.AWSScannerFactory = func(ctx context.Context, connection AWSConnectionStatus) (ScannerRunner, error) {
+		factoryScope = db.ScopeFromContext(ctx)
+		if connection.ConnectorID != "aws-tenant-b" {
+			t.Fatalf("expected selected connector, got %q", connection.ConnectorID)
+		}
+		return fakeScanner{result: app.ScanResult{Assets: 1}}, nil
+	}
+
+	if _, err := svc.scannerForScan(workerCtx, db.ScanRecord{Provider: "aws"}); err != nil {
+		t.Fatalf("build scheduled scanner: %v", err)
+	}
+	wantScope := db.Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"}
+	if validator.calls != 1 || validator.seen != wantScope {
+		t.Fatalf("expected connector validation in selected scope, calls=%d scope=%+v", validator.calls, validator.seen)
+	}
+	if factoryScope != wantScope {
+		t.Fatalf("expected scanner factory in selected scope, got %+v", factoryScope)
 	}
 }
 

--- a/internal/api/aws_baseline_test.go
+++ b/internal/api/aws_baseline_test.go
@@ -423,7 +423,7 @@ func TestAWSWorkerRevalidatesConnectorBeforeStartingQueuedScan(t *testing.T) {
 	if validator.calls != 1 {
 		t.Fatalf("expected enqueue validation, got %d calls", validator.calls)
 	}
-	if _, err := svc.scannerForScan(ctx, record); err == nil || !strings.Contains(err.Error(), "not active") {
+	if _, _, err := svc.scannerForScan(ctx, record); err == nil || !strings.Contains(err.Error(), "not active") {
 		t.Fatalf("expected worker validation to reject stale connector health, got %v", err)
 	}
 	if validator.calls != 2 {
@@ -468,6 +468,13 @@ func TestScheduledAWSScanRevalidatesSelectedConnectorBeforeStarting(t *testing.T
 	if factoryCalled {
 		t.Fatal("expected scanner factory not to run after scheduled connector validation failed")
 	}
+	scans, err := store.ListScans(ctx, 10)
+	if err != nil {
+		t.Fatalf("list failed scheduled scan: %v", err)
+	}
+	if len(scans) != 1 || scans[0].ProjectID != "project-a" || scans[0].ConnectorID != "aws-prod" {
+		t.Fatalf("expected failed scheduled scan to retain selected source for replay, got %+v", scans)
+	}
 }
 
 func TestScheduledAWSScanRevalidatesSelectedConnectorInItsScope(t *testing.T) {
@@ -502,8 +509,9 @@ func TestScheduledAWSScanRevalidatesSelectedConnectorInItsScope(t *testing.T) {
 		return fakeScanner{result: app.ScanResult{Assets: 1}}, nil
 	}
 
-	if _, err := svc.scannerForScan(workerCtx, db.ScanRecord{Provider: "aws"}); err != nil {
-		t.Fatalf("build scheduled scanner: %v", err)
+	result, err := svc.RunScan(workerCtx)
+	if err != nil {
+		t.Fatalf("run scheduled scan: %v", err)
 	}
 	wantScope := db.Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"}
 	if validator.calls != 1 || validator.seen != wantScope {
@@ -511,6 +519,16 @@ func TestScheduledAWSScanRevalidatesSelectedConnectorInItsScope(t *testing.T) {
 	}
 	if factoryScope != wantScope {
 		t.Fatalf("expected scanner factory in selected scope, got %+v", factoryScope)
+	}
+	if result.Scan.ProjectID != "project-b" || result.Scan.ConnectorID != "aws-shared" || result.Scan.TenantID != wantScope.TenantID || result.Scan.WorkspaceID != wantScope.WorkspaceID {
+		t.Fatalf("expected scheduled scan to persist selected source and scope, got %+v", result.Scan)
+	}
+	persisted, err := store.GetScan(selectedCtx, result.Scan.ID)
+	if err != nil {
+		t.Fatalf("load persisted selected scan: %v", err)
+	}
+	if persisted.ProjectID != "project-b" || persisted.ConnectorID != "aws-shared" || persisted.TenantID != wantScope.TenantID || persisted.WorkspaceID != wantScope.WorkspaceID {
+		t.Fatalf("expected persisted scan source and scope, got %+v", persisted)
 	}
 }
 

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -1071,6 +1071,16 @@ func (s *Service) resumeAWSConnectorStart(
 	if storedTemplateChecksum != "" {
 		storedTemplateURL = firstNonEmptyAWSValue(awsMetadataString(stored.State.Metadata, "template_url"), templateURL)
 	}
+	storedTemplateVersion := awsMetadataString(stored.State.Metadata, "template_version")
+	configuredTemplateChecksum := normalizeAWSConnectorTemplateChecksum(s.AWSCloudFormationTemplateSHA)
+	if storedTemplateVersion != awsConnectorTemplateVersion ||
+		(configuredTemplateChecksum != "" && storedTemplateChecksum != "" && storedTemplateChecksum != configuredTemplateChecksum) {
+		// A repair/relaunch must use the currently published template. Reusing a
+		// legacy URL would simply recreate the same incomplete policy and leave
+		// the connector stuck in a partial-coverage loop.
+		storedTemplateURL = templateURL
+		templateChecksum = configuredTemplateChecksum
+	}
 	if generatedExternalID {
 		if rotatedAt.IsZero() {
 			rotatedAt = s.Now().UTC()

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -1124,6 +1124,7 @@ func (s *Service) resumeAWSConnectorStart(
 		TemplateURL:             storedTemplateURL,
 		Region:                  region,
 		StackName:               stackName,
+		StackID:                 attempt.StackID,
 		IdentrailAccountID:      accountID,
 		RoleName:                roleName,
 		RegistrationProviderARN: registrationProviderARN,

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -1306,6 +1306,7 @@ func awsConnectorLaunchMetadata(metadata map[string]any) map[string]any {
 		"stack_set_name",
 		"template_url",
 		"template_checksum",
+		"template_version",
 		"launch_url",
 		"policy_hash",
 		"target_summary",

--- a/internal/api/aws_registration.go
+++ b/internal/api/aws_registration.go
@@ -22,15 +22,17 @@ import (
 )
 
 const (
-	awsConnectorTemplateVersion       = "2.2.0"
-	awsLegacyConnectorTemplateVersion = "2.1.0"
-	awsRegistrationTokenPurpose       = "aws-connector-registration-v1"
-	awsRegistrationAttemptLifetime    = 2 * time.Hour
+	awsConnectorTemplateVersion         = "2.2.0"
+	awsOriginalConnectorTemplateVersion = "2.0.0"
+	awsLegacyConnectorTemplateVersion   = "2.1.0"
+	awsRegistrationTokenPurpose         = "aws-connector-registration-v1"
+	awsRegistrationAttemptLifetime      = 2 * time.Hour
 )
 
 var awsConnectorTemplateVersionOrder = map[string]int{
-	awsLegacyConnectorTemplateVersion: 1,
-	awsConnectorTemplateVersion:       2,
+	awsOriginalConnectorTemplateVersion: 1,
+	awsLegacyConnectorTemplateVersion:   2,
+	awsConnectorTemplateVersion:         3,
 }
 
 var (
@@ -200,6 +202,22 @@ func (s *Service) activeOrNewAWSConnectorOnboardingAttempt(
 	} else if !errors.Is(err, db.ErrNotFound) {
 		return db.AWSConnectorOnboardingAttempt{}, "", err
 	}
+	// Connected and needs-fix attempts are intentionally excluded from the
+	// active-attempt query, but a completed CloudFormation stack must be resumed
+	// with that same bound attempt. Creating a fresh attempt would produce a
+	// Create URL for a stack that already exists, while an Update would then be
+	// rejected as an unbound lifecycle transition.
+	latest, latestErr := store.GetLatestAWSConnectorOnboardingAttempt(ctx, stored.Connector.WorkspaceID, stored.Connector.ProjectID, stored.Connector.ConnectorID)
+	if latestErr == nil && awsOnboardingAttemptCanResumeBoundStack(latest, providerTopicARN, region) {
+		token, tokenErr := s.awsRegistrationToken(latest)
+		if tokenErr != nil {
+			return db.AWSConnectorOnboardingAttempt{}, "", tokenErr
+		}
+		return latest, token, nil
+	}
+	if latestErr != nil && !errors.Is(latestErr, db.ErrNotFound) {
+		return db.AWSConnectorOnboardingAttempt{}, "", latestErr
+	}
 	created, token, createErr := s.createAWSConnectorOnboardingAttempt(ctx, stored, providerTopicARN, templateChecksum, region, now)
 	if createErr == nil || !errors.Is(createErr, db.ErrConflict) {
 		return created, token, createErr
@@ -213,6 +231,17 @@ func (s *Service) activeOrNewAWSConnectorOnboardingAttempt(
 		return db.AWSConnectorOnboardingAttempt{}, "", tokenErr
 	}
 	return active, activeToken, nil
+}
+
+func awsOnboardingAttemptCanResumeBoundStack(attempt db.AWSConnectorOnboardingAttempt, providerTopicARN string, region string) bool {
+	if attempt.Status != db.AWSConnectorOnboardingAttemptConnected && attempt.Status != db.AWSConnectorOnboardingAttemptNeedsFix {
+		return false
+	}
+	return attempt.StackID != "" &&
+		attempt.BootstrapRequestID != "" &&
+		attempt.RegisterRequestID != "" &&
+		attempt.ProviderTopicARN == strings.TrimSpace(providerTopicARN) &&
+		attempt.DeploymentRegion == strings.ToLower(strings.TrimSpace(region))
 }
 
 func (s *Service) awsRegistrationToken(attempt db.AWSConnectorOnboardingAttempt) (string, error) {

--- a/internal/api/aws_registration.go
+++ b/internal/api/aws_registration.go
@@ -457,7 +457,7 @@ func (s *Service) processAWSRegistrationRole(ctx context.Context, store db.AWSCo
 	// has a different request ID and is allowed to validate the replacement.
 	if callbackAlreadyDelivered &&
 		(attempt.Status == db.AWSConnectorOnboardingAttemptConnected || attempt.Status == db.AWSConnectorOnboardingAttemptNeedsFix) {
-		return nil
+		return s.reconcileAWSConnectorFromOnboardingAttempt(ctx, attempt)
 	}
 	status, validationErr := s.ValidateAWSConnector(ctx, attempt.ConnectorID, AWSConnectorValidateRequest{
 		WorkspaceID: attempt.WorkspaceID,
@@ -492,7 +492,13 @@ func (s *Service) processAWSRegistrationRole(ctx context.Context, store db.AWSCo
 		}
 		return s.reconcileAWSConnectorFromOnboardingAttempt(ctx, winner)
 	}
-	return updateErr
+	if updateErr != nil {
+		return updateErr
+	}
+	if attempt.Status == db.AWSConnectorOnboardingAttemptConnected {
+		return s.reconcileAWSConnectorFromOnboardingAttempt(ctx, attempt)
+	}
+	return nil
 }
 
 func (s *Service) validateAWSRegistrationRequest(attempt db.AWSConnectorOnboardingAttempt, topicARN string, request awsCloudFormationCustomResourceRequest, phase string, token string) error {
@@ -897,6 +903,21 @@ func (s *Service) persistAWSRegistrationConnected(ctx context.Context, stored db
 	}
 	if attempt.DeploymentRegion != "" {
 		metadata["region"] = attempt.DeploymentRegion
+	}
+	if templateVersion := strings.TrimSpace(attempt.TemplateVersion); templateVersion != "" {
+		metadata["template_version"] = templateVersion
+	}
+	// A successful registration is the durable proof that the stack now runs
+	// the template used for this launch. Prefer the currently configured
+	// content-addressed template metadata so a legacy stack upgrade cannot
+	// leave the connector offering the same migration again on its next start.
+	if templateChecksum := normalizeAWSConnectorTemplateChecksum(s.AWSCloudFormationTemplateSHA); templateChecksum != "" {
+		metadata["template_checksum"] = templateChecksum
+	} else if templateChecksum := normalizeAWSConnectorTemplateChecksum(attempt.TemplateChecksum); templateChecksum != "" {
+		metadata["template_checksum"] = templateChecksum
+	}
+	if templateURL := strings.TrimSpace(s.AWSCloudFormationTemplateURL); templateURL != "" {
+		metadata["template_url"] = templateURL
 	}
 	delete(metadata, "launch_url")
 	now := s.Now().UTC()

--- a/internal/api/aws_registration.go
+++ b/internal/api/aws_registration.go
@@ -180,43 +180,50 @@ func (s *Service) activeOrNewAWSConnectorOnboardingAttempt(
 		return db.AWSConnectorOnboardingAttempt{}, "", err
 	}
 	now := s.Now().UTC()
-	attempt, err := store.GetActiveAWSConnectorOnboardingAttempt(ctx, stored.Connector.WorkspaceID, stored.Connector.ProjectID, stored.Connector.ConnectorID)
-	if err == nil {
-		if now.Before(attempt.ExpiresAt) &&
-			attempt.ProviderTopicARN == strings.TrimSpace(providerTopicARN) &&
-			attempt.TemplateChecksum == normalizeAWSConnectorTemplateChecksum(templateChecksum) &&
-			attempt.DeploymentRegion == strings.ToLower(strings.TrimSpace(region)) {
-			token, tokenErr := s.awsRegistrationToken(attempt)
-			if tokenErr != nil {
-				return db.AWSConnectorOnboardingAttempt{}, "", tokenErr
-			}
-			return attempt, token, nil
-		}
-		attempt.Status = db.AWSConnectorOnboardingAttemptExpired
-		attempt.FailureCode = "registration_expired"
-		attempt.FailureMessage = "The AWS connection window expired. Start a new connection."
-		attempt.UpdatedAt = now
-		if _, updateErr := store.UpdateAWSConnectorOnboardingAttempt(ctx, attempt, attempt.Version); updateErr != nil && !errors.Is(updateErr, db.ErrConflict) {
-			return db.AWSConnectorOnboardingAttempt{}, "", updateErr
-		}
-	} else if !errors.Is(err, db.ErrNotFound) {
+	active, err := store.GetActiveAWSConnectorOnboardingAttempt(ctx, stored.Connector.WorkspaceID, stored.Connector.ProjectID, stored.Connector.ConnectorID)
+	activeFound := err == nil
+	if err != nil && !errors.Is(err, db.ErrNotFound) {
 		return db.AWSConnectorOnboardingAttempt{}, "", err
 	}
-	// Connected and needs-fix attempts are intentionally excluded from the
-	// active-attempt query, but a completed CloudFormation stack must be resumed
-	// with that same bound attempt. Creating a fresh attempt would produce a
-	// Create URL for a stack that already exists, while an Update would then be
-	// rejected as an unbound lifecycle transition.
-	latest, latestErr := store.GetLatestAWSConnectorOnboardingAttempt(ctx, stored.Connector.WorkspaceID, stored.Connector.ProjectID, stored.Connector.ConnectorID)
-	if latestErr == nil && awsOnboardingAttemptCanResumeBoundStack(latest, providerTopicARN, region) {
-		token, tokenErr := s.awsRegistrationToken(latest)
+	// Prefer the newest attempt that is already bound to a stack. A newer
+	// waiting/expired attempt may have been created by an earlier launch flow,
+	// but it has no durable StackID and cannot safely update the existing stack.
+	resumable, resumableErr := store.GetLatestResumableAWSConnectorOnboardingAttempt(
+		ctx,
+		stored.Connector.WorkspaceID,
+		stored.Connector.ProjectID,
+		stored.Connector.ConnectorID,
+		providerTopicARN,
+		region,
+	)
+	if resumableErr == nil {
+		token, tokenErr := s.awsRegistrationToken(resumable)
 		if tokenErr != nil {
 			return db.AWSConnectorOnboardingAttempt{}, "", tokenErr
 		}
-		return latest, token, nil
+		return resumable, token, nil
 	}
-	if latestErr != nil && !errors.Is(latestErr, db.ErrNotFound) {
-		return db.AWSConnectorOnboardingAttempt{}, "", latestErr
+	if !errors.Is(resumableErr, db.ErrNotFound) {
+		return db.AWSConnectorOnboardingAttempt{}, "", resumableErr
+	}
+	if activeFound {
+		if now.Before(active.ExpiresAt) &&
+			active.ProviderTopicARN == strings.TrimSpace(providerTopicARN) &&
+			active.TemplateChecksum == normalizeAWSConnectorTemplateChecksum(templateChecksum) &&
+			active.DeploymentRegion == strings.ToLower(strings.TrimSpace(region)) {
+			token, tokenErr := s.awsRegistrationToken(active)
+			if tokenErr != nil {
+				return db.AWSConnectorOnboardingAttempt{}, "", tokenErr
+			}
+			return active, token, nil
+		}
+		active.Status = db.AWSConnectorOnboardingAttemptExpired
+		active.FailureCode = "registration_expired"
+		active.FailureMessage = "The AWS connection window expired. Start a new connection."
+		active.UpdatedAt = now
+		if _, updateErr := store.UpdateAWSConnectorOnboardingAttempt(ctx, active, active.Version); updateErr != nil && !errors.Is(updateErr, db.ErrConflict) {
+			return db.AWSConnectorOnboardingAttempt{}, "", updateErr
+		}
 	}
 	created, token, createErr := s.createAWSConnectorOnboardingAttempt(ctx, stored, providerTopicARN, templateChecksum, region, now)
 	if createErr == nil || !errors.Is(createErr, db.ErrConflict) {

--- a/internal/api/aws_registration.go
+++ b/internal/api/aws_registration.go
@@ -22,10 +22,16 @@ import (
 )
 
 const (
-	awsConnectorTemplateVersion    = "2.2.0"
-	awsRegistrationTokenPurpose    = "aws-connector-registration-v1"
-	awsRegistrationAttemptLifetime = 2 * time.Hour
+	awsConnectorTemplateVersion       = "2.2.0"
+	awsLegacyConnectorTemplateVersion = "2.1.0"
+	awsRegistrationTokenPurpose       = "aws-connector-registration-v1"
+	awsRegistrationAttemptLifetime    = 2 * time.Hour
 )
+
+var awsConnectorTemplateVersionOrder = map[string]int{
+	awsLegacyConnectorTemplateVersion: 1,
+	awsConnectorTemplateVersion:       2,
+}
 
 var (
 	awsStackARNPattern = regexp.MustCompile(`^arn:(aws|aws-us-gov|aws-cn):cloudformation:([a-z0-9-]+):([0-9]{12}):stack/[^/]+/[A-Za-z0-9-]+$`)
@@ -331,6 +337,28 @@ func (s *Service) processAWSRegistrationBootstrap(ctx context.Context, store db.
 			return err
 		}
 	}
+	if request.RequestType == "Update" {
+		incomingVersion := awsRegistrationProperty(request.ResourceProperties, "TemplateVersion")
+		if incomingVersion != attempt.TemplateVersion {
+			attempt.TemplateVersion = incomingVersion
+			attempt.UpdatedAt = s.Now().UTC()
+			updated, updateErr := store.UpdateAWSConnectorOnboardingAttempt(ctx, attempt, attempt.Version)
+			if errors.Is(updateErr, db.ErrConflict) {
+				winner, loadErr := store.GetAWSConnectorOnboardingAttempt(ctx, attempt.WorkspaceID, attempt.ProjectID, attempt.AttemptID)
+				if loadErr != nil {
+					return loadErr
+				}
+				if winner.TemplateVersion != incomingVersion {
+					return updateErr
+				}
+				attempt = winner
+			} else if updateErr != nil {
+				return updateErr
+			} else {
+				attempt = updated
+			}
+		}
+	}
 	// NoEcho must be false: the template's IAM trust policy and the Register
 	// resource both consume this via Fn::GetAtt, and CloudFormation masks
 	// NoEcho'd custom-resource attributes in those references, which would
@@ -343,7 +371,7 @@ func (s *Service) processAWSRegistrationRole(ctx context.Context, store db.AWSCo
 	roleARN := awsRegistrationProperty(request.ResourceProperties, "RoleArn")
 	externalID := awsRegistrationProperty(request.ResourceProperties, "ExternalId")
 	templateVersion := awsRegistrationProperty(request.ResourceProperties, "TemplateVersion")
-	if !awsRoleARNPattern.MatchString(roleARN) || templateVersion != attempt.TemplateVersion || accountIDFromRoleARN(roleARN) != attempt.AWSAccountID {
+	if !awsRoleARNPattern.MatchString(roleARN) || !awsRegistrationTemplateVersionCompatible(request.RequestType, attempt.TemplateVersion, templateVersion, request.RequestType == "Update") || accountIDFromRoleARN(roleARN) != attempt.AWSAccountID {
 		return s.failAWSCloudFormationRequest(ctx, request, "The AWS role does not match this connection request.", fmt.Errorf("registration role mismatch"))
 	}
 	stored, err := s.Store.GetTenancyConnector(ctx, attempt.WorkspaceID, attempt.ProjectID, attempt.ConnectorID)
@@ -382,6 +410,7 @@ func (s *Service) processAWSRegistrationRole(ctx context.Context, store db.AWSCo
 		attempt.Status = db.AWSConnectorOnboardingAttemptValidating
 		attempt.RoleARN = roleARN
 		attempt.RegisterRequestID = request.RequestID
+		attempt.TemplateVersion = templateVersion
 		if attempt.RegisteredAt == nil {
 			attempt.RegisteredAt = &now
 		}
@@ -463,6 +492,10 @@ func (s *Service) validateAWSRegistrationRequest(attempt db.AWSConnectorOnboardi
 		boundStack &&
 		(attempt.Status == db.AWSConnectorOnboardingAttemptConnected ||
 			attempt.Status == db.AWSConnectorOnboardingAttemptNeedsFix)
+	templateVersion := awsRegistrationProperty(request.ResourceProperties, "TemplateVersion")
+	if !awsRegistrationTemplateVersionCompatible(request.RequestType, attempt.TemplateVersion, templateVersion, boundLifecycleUpdate) {
+		return fmt.Errorf("unsupported registration template version transition")
+	}
 	if attempt.ProviderTopicARN != strings.TrimSpace(topicARN) ||
 		attempt.Status == db.AWSConnectorOnboardingAttemptExpired ||
 		attempt.Status == db.AWSConnectorOnboardingAttemptFailed ||
@@ -487,6 +520,24 @@ func (s *Service) validateAWSRegistrationRequest(attempt db.AWSConnectorOnboardi
 		return fmt.Errorf("registration stack replay")
 	}
 	return nil
+}
+
+// awsRegistrationTemplateVersionCompatible keeps the one-time registration
+// contract strict for new stacks while allowing an authenticated, stack-bound
+// CloudFormation Update to move a legacy automatic connector forward. Updates
+// can never downgrade or skip to an unknown version.
+func awsRegistrationTemplateVersionCompatible(requestType, storedVersion, incomingVersion string, boundLifecycleUpdate bool) bool {
+	storedVersion = strings.TrimSpace(storedVersion)
+	incomingVersion = strings.TrimSpace(incomingVersion)
+	if requestType == "Create" {
+		return incomingVersion != "" && incomingVersion == storedVersion
+	}
+	if requestType != "Update" || !boundLifecycleUpdate {
+		return incomingVersion == storedVersion
+	}
+	storedOrder, storedKnown := awsConnectorTemplateVersionOrder[storedVersion]
+	incomingOrder, incomingKnown := awsConnectorTemplateVersionOrder[incomingVersion]
+	return storedKnown && incomingKnown && incomingOrder >= storedOrder
 }
 
 func (s *Service) processAWSRegistrationDelete(ctx context.Context, topicARN string, request awsCloudFormationCustomResourceRequest, phase string) error {

--- a/internal/api/aws_registration.go
+++ b/internal/api/aws_registration.go
@@ -366,28 +366,11 @@ func (s *Service) processAWSRegistrationBootstrap(ctx context.Context, store db.
 			return err
 		}
 	}
-	if request.RequestType == "Update" {
-		incomingVersion := awsRegistrationProperty(request.ResourceProperties, "TemplateVersion")
-		if incomingVersion != attempt.TemplateVersion {
-			attempt.TemplateVersion = incomingVersion
-			attempt.UpdatedAt = s.Now().UTC()
-			updated, updateErr := store.UpdateAWSConnectorOnboardingAttempt(ctx, attempt, attempt.Version)
-			if errors.Is(updateErr, db.ErrConflict) {
-				winner, loadErr := store.GetAWSConnectorOnboardingAttempt(ctx, attempt.WorkspaceID, attempt.ProjectID, attempt.AttemptID)
-				if loadErr != nil {
-					return loadErr
-				}
-				if winner.TemplateVersion != incomingVersion {
-					return updateErr
-				}
-				attempt = winner
-			} else if updateErr != nil {
-				return updateErr
-			} else {
-				attempt = updated
-			}
-		}
-	}
+	// Do not persist an Update's template version during Bootstrap. If a later
+	// custom resource fails, CloudFormation sends rollback Updates carrying the
+	// legacy version; recording the new version here would make that legitimate
+	// rollback look like a downgrade. The Register phase persists the upgraded
+	// version only after its callback is accepted.
 	// NoEcho must be false: the template's IAM trust policy and the Register
 	// resource both consume this via Fn::GetAtt, and CloudFormation masks
 	// NoEcho'd custom-resource attributes in those references, which would

--- a/internal/api/aws_registration_test.go
+++ b/internal/api/aws_registration_test.go
@@ -371,6 +371,12 @@ func TestAWSConnectorStartReusesBoundAttemptForExistingStackUpgrade(t *testing.T
 	if !containsAWSLaunchParameter(parsed.Fragment, "param_RegistrationAttemptId="+attempt.AttemptID) {
 		t.Fatalf("expected existing bound attempt %s in upgrade launch URL, got %q", attempt.AttemptID, resumed.LaunchURL)
 	}
+	if !strings.HasPrefix(parsed.Fragment, "/stacks/update/template?") {
+		t.Fatalf("expected resumed bound stack to use the update wizard, got %q", parsed.Fragment)
+	}
+	if !containsAWSLaunchParameter(parsed.Fragment, "stackId="+stackID) {
+		t.Fatalf("expected resumed launch URL to target stack %s, got %q", stackID, resumed.LaunchURL)
+	}
 }
 
 func TestAWSRegistrationRejectsBoundTemplateDowngrade(t *testing.T) {

--- a/internal/api/aws_registration_test.go
+++ b/internal/api/aws_registration_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -186,6 +187,95 @@ func TestAWSRegistrationRenewsAttemptDeadlineOnBoundStackUpdate(t *testing.T) {
 	}
 	if !reloaded.ExpiresAt.After(pastExpiry) {
 		t.Fatalf("expected bound-Update to renew ExpiresAt past %s, got %s", pastExpiry, reloaded.ExpiresAt)
+	}
+}
+
+func TestAWSRegistrationUpgradesLegacyTemplateOnBoundStackUpdate(t *testing.T) {
+	svc, ctx := newAWSRegistrationTestService(t)
+	responder := &recordingAWSCloudFormationResponder{}
+	svc.AWSCloudFormationResponder = responder
+	started, attempt, stackID, externalID := startAndBootstrapAWSRegistration(t, svc, ctx, responder)
+	store := svc.Store.(db.AWSConnectorOnboardingAttemptStore)
+
+	// The stack was created by the previous automatic-registration template.
+	// Keep its one-time attempt bound to 2.1.0 so the test exercises the same
+	// migration path as a real legacy connector.
+	legacyAttempt, err := store.GetAWSConnectorOnboardingAttempt(ctx, "workspace-a", "project-1", attempt.AttemptID)
+	if err != nil {
+		t.Fatalf("reload attempt: %v", err)
+	}
+	legacyAttempt.TemplateVersion = awsLegacyConnectorTemplateVersion
+	legacyAttempt.UpdatedAt = svc.Now().UTC()
+	if _, err := store.UpdateAWSConnectorOnboardingAttempt(ctx, legacyAttempt, legacyAttempt.Version); err != nil {
+		t.Fatalf("seed legacy template version: %v", err)
+	}
+
+	initial := awsRegistrationRequest(stackID, "Create", "registration-create", "Register", attempt.AttemptID)
+	initial.ResourceProperties["ExternalId"] = externalID
+	initial.ResourceProperties["RoleArn"] = "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+	initial.ResourceProperties["TemplateVersion"] = awsLegacyConnectorTemplateVersion
+	if err := svc.ProcessAWSConnectorRegistrationMessage(ctx, awsRegistrationTestMessage(t, testAWSRegistrationTopicARN, initial)); err != nil {
+		t.Fatalf("complete legacy registration: %v", err)
+	}
+
+	currentAttempt, err := store.GetAWSConnectorOnboardingAttempt(ctx, "workspace-a", "project-1", attempt.AttemptID)
+	if err != nil {
+		t.Fatalf("reload connected legacy attempt: %v", err)
+	}
+	bootstrapToken, err := svc.awsRegistrationToken(currentAttempt)
+	if err != nil {
+		t.Fatalf("derive bootstrap token: %v", err)
+	}
+	bootstrapUpdate := awsRegistrationRequest(stackID, "Update", "bootstrap-upgrade", "Bootstrap", attempt.AttemptID)
+	bootstrapUpdate.ResourceProperties["RegistrationToken"] = bootstrapToken
+	bootstrapUpdate.ResourceProperties["TemplateVersion"] = awsConnectorTemplateVersion
+	if err := svc.ProcessAWSConnectorRegistrationMessage(ctx, awsRegistrationTestMessage(t, testAWSRegistrationTopicARN, bootstrapUpdate)); err != nil {
+		t.Fatalf("upgrade legacy bootstrap: %v", err)
+	}
+
+	registrationUpdate := awsRegistrationRequest(stackID, "Update", "registration-upgrade", "Register", attempt.AttemptID)
+	registrationUpdate.ResourceProperties["ExternalId"] = externalID
+	registrationUpdate.ResourceProperties["RoleArn"] = "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+	registrationUpdate.ResourceProperties["TemplateVersion"] = awsConnectorTemplateVersion
+	if err := svc.ProcessAWSConnectorRegistrationMessage(ctx, awsRegistrationTestMessage(t, testAWSRegistrationTopicARN, registrationUpdate)); err != nil {
+		t.Fatalf("complete upgraded registration: %v", err)
+	}
+
+	status, err := svc.PollAWSConnector(ctx, started.ConnectorID, AWSConnectorPollRequest{WorkspaceID: "workspace-a", ProjectID: "project-1"})
+	if err != nil || !status.Connected {
+		t.Fatalf("expected upgraded connector to remain connected, got %+v err=%v", status, err)
+	}
+	upgraded, err := store.GetAWSConnectorOnboardingAttempt(ctx, "workspace-a", "project-1", attempt.AttemptID)
+	if err != nil {
+		t.Fatalf("reload upgraded attempt: %v", err)
+	}
+	if upgraded.TemplateVersion != awsConnectorTemplateVersion {
+		t.Fatalf("expected persisted template upgrade to %s, got %s", awsConnectorTemplateVersion, upgraded.TemplateVersion)
+	}
+}
+
+func TestAWSRegistrationRejectsBoundTemplateDowngrade(t *testing.T) {
+	svc, ctx := newAWSRegistrationTestService(t)
+	responder := &recordingAWSCloudFormationResponder{}
+	svc.AWSCloudFormationResponder = responder
+	_, attempt, stackID, externalID := startAndBootstrapAWSRegistration(t, svc, ctx, responder)
+	registration := awsRegistrationRequest(stackID, "Create", "registration-create", "Register", attempt.AttemptID)
+	registration.ResourceProperties["ExternalId"] = externalID
+	registration.ResourceProperties["RoleArn"] = "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+	registration.ResourceProperties["TemplateVersion"] = awsConnectorTemplateVersion
+	if err := svc.ProcessAWSConnectorRegistrationMessage(ctx, awsRegistrationTestMessage(t, testAWSRegistrationTopicARN, registration)); err != nil {
+		t.Fatalf("complete initial registration: %v", err)
+	}
+
+	bootstrapToken, err := svc.awsRegistrationToken(attempt)
+	if err != nil {
+		t.Fatalf("derive bootstrap token: %v", err)
+	}
+	downgrade := awsRegistrationRequest(stackID, "Update", "bootstrap-downgrade", "Bootstrap", attempt.AttemptID)
+	downgrade.ResourceProperties["RegistrationToken"] = bootstrapToken
+	downgrade.ResourceProperties["TemplateVersion"] = awsLegacyConnectorTemplateVersion
+	if err := svc.ProcessAWSConnectorRegistrationMessage(ctx, awsRegistrationTestMessage(t, testAWSRegistrationTopicARN, downgrade)); err == nil {
+		t.Fatal("expected bound update downgrade to be rejected")
 	}
 }
 
@@ -752,6 +842,9 @@ func TestAWSConnectorRepairHydrationDoesNotRenewAttemptAndExplicitRelaunchResets
 	applyAWSConnectorSetupMetadata(stored.State.Metadata, setup, AWSConnectorOnboardingNeedsFix)
 	stored.Connector.Status = domain.ConnectorStatusDegraded
 	stored.State.HealthStatus = "error"
+	stored.State.Metadata["template_version"] = awsLegacyConnectorTemplateVersion
+	stored.State.Metadata["template_checksum"] = "sha256:" + strings.Repeat("a", 64)
+	stored.State.Metadata["template_url"] = "https://legacy.example/identrail-readonly.yaml"
 	stored.State.LastErrorCode = "assume_role_failed"
 	stored.State.LastErrorMessage = "Repair the trust policy."
 	if err := svc.Store.UpsertTenancyConnector(ctx, stored.Connector, stored.State); err != nil {
@@ -769,6 +862,9 @@ func TestAWSConnectorRepairHydrationDoesNotRenewAttemptAndExplicitRelaunchResets
 	}
 	if hydrated.LaunchURL != "" || hydrated.ExternalID == "" || hydrated.OnboardingStatus != AWSConnectorOnboardingNeedsFix {
 		t.Fatalf("repair hydration must preserve state and omit launch, got %+v", hydrated)
+	}
+	if hydrated.TemplateURL != testAWSCloudFormationTemplateURL || hydrated.TemplateChecksum != testAWSCloudFormationTemplateChecksum {
+		t.Fatalf("repair hydration must use the current connector template, got url=%q checksum=%q", hydrated.TemplateURL, hydrated.TemplateChecksum)
 	}
 	if _, err := attemptStore.GetActiveAWSConnectorOnboardingAttempt(ctx, "workspace-a", "project-1", started.ConnectorID); !errors.Is(err, db.ErrNotFound) {
 		t.Fatalf("repair hydration silently renewed an attempt: %v", err)
@@ -867,8 +963,9 @@ func awsRegistrationRequest(stackID string, requestType string, requestID string
 		ResourceType:      resourceType,
 		LogicalResourceID: logicalID,
 		ResourceProperties: map[string]any{
-			"Phase":     phase,
-			"AttemptId": attemptID,
+			"Phase":           phase,
+			"AttemptId":       attemptID,
+			"TemplateVersion": awsConnectorTemplateVersion,
 		},
 	}
 }

--- a/internal/api/aws_registration_test.go
+++ b/internal/api/aws_registration_test.go
@@ -379,6 +379,83 @@ func TestAWSConnectorStartReusesBoundAttemptForExistingStackUpgrade(t *testing.T
 	}
 }
 
+func TestAWSConnectorStartPrefersOlderBoundAttemptOverNewerUnboundAttempt(t *testing.T) {
+	svc, ctx := newAWSRegistrationTestService(t)
+	responder := &recordingAWSCloudFormationResponder{}
+	svc.AWSCloudFormationResponder = responder
+	started, attempt, stackID, externalID := startAndBootstrapAWSRegistration(t, svc, ctx, responder)
+	store := svc.Store.(db.AWSConnectorOnboardingAttemptStore)
+	registration := awsRegistrationRequest(stackID, "Create", "registration-create", "Register", attempt.AttemptID)
+	registration.ResourceProperties["ExternalId"] = externalID
+	registration.ResourceProperties["RoleArn"] = "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+	registration.ResourceProperties["TemplateVersion"] = awsConnectorTemplateVersion
+	if err := svc.ProcessAWSConnectorRegistrationMessage(ctx, awsRegistrationTestMessage(t, testAWSRegistrationTopicARN, registration)); err != nil {
+		t.Fatalf("complete bound registration: %v", err)
+	}
+	bound, err := store.GetAWSConnectorOnboardingAttempt(ctx, "workspace-a", "project-1", attempt.AttemptID)
+	if err != nil {
+		t.Fatalf("reload bound attempt: %v", err)
+	}
+
+	// A newer attempt can be left waiting by a pre-fix launch flow. It has no
+	// StackID, so selecting it would generate a Create URL and fail to resume
+	// the already-created stack owned by bound.
+	now := svc.Now().UTC()
+	_, err = store.CreateAWSConnectorOnboardingAttempt(ctx, db.AWSConnectorOnboardingAttempt{
+		AttemptID:        "newer-unbound",
+		TenantID:         "tenant-a",
+		WorkspaceID:      "workspace-a",
+		ProjectID:        "project-1",
+		ConnectorID:      started.ConnectorID,
+		Status:           db.AWSConnectorOnboardingAttemptWaiting,
+		TokenHash:        bytes.Repeat([]byte{3}, 32),
+		TokenKeyVersion:  "test-v1",
+		ProviderTopicARN: testAWSRegistrationTopicARN,
+		TemplateVersion:  awsConnectorTemplateVersion,
+		TemplateChecksum: testAWSCloudFormationTemplateChecksum,
+		DeploymentRegion: "us-east-1",
+		ExpiresAt:        now.Add(time.Hour),
+		CreatedAt:        now.Add(time.Minute),
+		UpdatedAt:        now.Add(time.Minute),
+		Version:          1,
+	})
+	if err != nil {
+		t.Fatalf("seed newer unbound attempt: %v", err)
+	}
+	stored, err := svc.Store.GetTenancyConnector(ctx, "workspace-a", "project-1", started.ConnectorID)
+	if err != nil {
+		t.Fatalf("reload connector: %v", err)
+	}
+	selected, _, err := svc.activeOrNewAWSConnectorOnboardingAttempt(ctx, stored, testAWSRegistrationTopicARN, testAWSCloudFormationTemplateChecksum, "us-east-1")
+	if err != nil {
+		t.Fatalf("select resumable attempt: %v", err)
+	}
+	if selected.AttemptID != bound.AttemptID || selected.StackID != stackID {
+		t.Fatalf("expected older bound attempt %s with stack %s, got %+v", bound.AttemptID, stackID, selected)
+	}
+
+	// The same precedence must hold after the stale attempt has expired and is
+	// no longer returned by the active-attempt query.
+	stale, err := store.GetAWSConnectorOnboardingAttempt(ctx, "workspace-a", "project-1", "newer-unbound")
+	if err != nil {
+		t.Fatalf("reload stale attempt: %v", err)
+	}
+	stale.Status = db.AWSConnectorOnboardingAttemptExpired
+	stale.FailureCode = "registration_expired"
+	stale.FailureMessage = "The AWS connection window expired. Start a new connection."
+	stale.UpdatedAt = now.Add(2 * time.Minute)
+	if _, err := store.UpdateAWSConnectorOnboardingAttempt(ctx, stale, stale.Version); err != nil {
+		t.Fatalf("expire stale attempt: %v", err)
+	}
+	selected, _, err = svc.activeOrNewAWSConnectorOnboardingAttempt(ctx, stored, testAWSRegistrationTopicARN, testAWSCloudFormationTemplateChecksum, "us-east-1")
+	if err != nil {
+		t.Fatalf("select bound attempt after stale expiry: %v", err)
+	}
+	if selected.AttemptID != bound.AttemptID || selected.StackID != stackID {
+		t.Fatalf("expected older bound attempt after stale expiry, got %+v", selected)
+	}
+}
+
 func TestAWSRegistrationRejectsBoundTemplateDowngrade(t *testing.T) {
 	svc, ctx := newAWSRegistrationTestService(t)
 	responder := &recordingAWSCloudFormationResponder{}

--- a/internal/api/aws_registration_test.go
+++ b/internal/api/aws_registration_test.go
@@ -254,6 +254,57 @@ func TestAWSRegistrationUpgradesLegacyTemplateOnBoundStackUpdate(t *testing.T) {
 	}
 }
 
+func TestAWSRegistrationTemplateVersionCompatibilityAcceptsDeployedVersions(t *testing.T) {
+	for _, version := range []string{awsOriginalConnectorTemplateVersion, awsLegacyConnectorTemplateVersion} {
+		t.Run(version, func(t *testing.T) {
+			if !awsRegistrationTemplateVersionCompatible("Update", version, awsConnectorTemplateVersion, true) {
+				t.Fatalf("expected bound update from deployed version %s to be accepted", version)
+			}
+		})
+	}
+}
+
+func TestAWSConnectorStartReusesBoundAttemptForExistingStackUpgrade(t *testing.T) {
+	svc, ctx := newAWSRegistrationTestService(t)
+	responder := &recordingAWSCloudFormationResponder{}
+	svc.AWSCloudFormationResponder = responder
+	started, attempt, stackID, externalID := startAndBootstrapAWSRegistration(t, svc, ctx, responder)
+	store := svc.Store.(db.AWSConnectorOnboardingAttemptStore)
+
+	legacyAttempt, err := store.GetAWSConnectorOnboardingAttempt(ctx, "workspace-a", "project-1", attempt.AttemptID)
+	if err != nil {
+		t.Fatalf("reload attempt: %v", err)
+	}
+	legacyAttempt.TemplateVersion = awsLegacyConnectorTemplateVersion
+	legacyAttempt.UpdatedAt = svc.Now().UTC()
+	if _, err := store.UpdateAWSConnectorOnboardingAttempt(ctx, legacyAttempt, legacyAttempt.Version); err != nil {
+		t.Fatalf("seed legacy attempt: %v", err)
+	}
+	registration := awsRegistrationRequest(stackID, "Create", "registration-create", "Register", attempt.AttemptID)
+	registration.ResourceProperties["ExternalId"] = externalID
+	registration.ResourceProperties["RoleArn"] = "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+	registration.ResourceProperties["TemplateVersion"] = awsLegacyConnectorTemplateVersion
+	if err := svc.ProcessAWSConnectorRegistrationMessage(ctx, awsRegistrationTestMessage(t, testAWSRegistrationTopicARN, registration)); err != nil {
+		t.Fatalf("complete legacy registration: %v", err)
+	}
+
+	resumed, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: started.ConnectorID,
+	})
+	if err != nil {
+		t.Fatalf("resume existing connector: %v", err)
+	}
+	parsed, err := url.Parse(resumed.LaunchURL)
+	if err != nil {
+		t.Fatalf("parse resumed launch URL: %v", err)
+	}
+	if !containsAWSLaunchParameter(parsed.Fragment, "param_RegistrationAttemptId="+attempt.AttemptID) {
+		t.Fatalf("expected existing bound attempt %s in upgrade launch URL, got %q", attempt.AttemptID, resumed.LaunchURL)
+	}
+}
+
 func TestAWSRegistrationRejectsBoundTemplateDowngrade(t *testing.T) {
 	svc, ctx := newAWSRegistrationTestService(t)
 	responder := &recordingAWSCloudFormationResponder{}

--- a/internal/api/aws_registration_test.go
+++ b/internal/api/aws_registration_test.go
@@ -209,6 +209,16 @@ func TestAWSRegistrationUpgradesLegacyTemplateOnBoundStackUpdate(t *testing.T) {
 	if _, err := store.UpdateAWSConnectorOnboardingAttempt(ctx, legacyAttempt, legacyAttempt.Version); err != nil {
 		t.Fatalf("seed legacy template version: %v", err)
 	}
+	legacyConnector, err := svc.Store.GetTenancyConnector(ctx, "workspace-a", "project-1", started.ConnectorID)
+	if err != nil {
+		t.Fatalf("reload connector for legacy metadata: %v", err)
+	}
+	legacyConnector.State.Metadata["template_version"] = awsLegacyConnectorTemplateVersion
+	legacyConnector.State.Metadata["template_checksum"] = "sha256:" + strings.Repeat("1", 64)
+	legacyConnector.State.Metadata["template_url"] = "https://legacy.example/identrail-readonly.yaml"
+	if err := svc.Store.UpsertTenancyConnector(ctx, legacyConnector.Connector, legacyConnector.State); err != nil {
+		t.Fatalf("seed legacy connector template metadata: %v", err)
+	}
 
 	initial := awsRegistrationRequest(stackID, "Create", "registration-create", "Register", attempt.AttemptID)
 	initial.ResourceProperties["ExternalId"] = externalID
@@ -251,6 +261,19 @@ func TestAWSRegistrationUpgradesLegacyTemplateOnBoundStackUpdate(t *testing.T) {
 	}
 	if upgraded.TemplateVersion != awsConnectorTemplateVersion {
 		t.Fatalf("expected persisted template upgrade to %s, got %s", awsConnectorTemplateVersion, upgraded.TemplateVersion)
+	}
+	upgradedConnector, err := svc.Store.GetTenancyConnector(ctx, "workspace-a", "project-1", started.ConnectorID)
+	if err != nil {
+		t.Fatalf("reload connector after template upgrade: %v", err)
+	}
+	if got := awsMetadataString(upgradedConnector.State.Metadata, "template_version"); got != awsConnectorTemplateVersion {
+		t.Fatalf("expected connector template version %s after upgrade, got %q", awsConnectorTemplateVersion, got)
+	}
+	if got := awsMetadataString(upgradedConnector.State.Metadata, "template_checksum"); got != testAWSCloudFormationTemplateChecksum {
+		t.Fatalf("expected connector template checksum %s after upgrade, got %q", testAWSCloudFormationTemplateChecksum, got)
+	}
+	if got := awsMetadataString(upgradedConnector.State.Metadata, "template_url"); got != testAWSCloudFormationTemplateURL {
+		t.Fatalf("expected connector template URL %s after upgrade, got %q", testAWSCloudFormationTemplateURL, got)
 	}
 }
 

--- a/internal/api/aws_registration_test.go
+++ b/internal/api/aws_registration_test.go
@@ -264,6 +264,74 @@ func TestAWSRegistrationTemplateVersionCompatibilityAcceptsDeployedVersions(t *t
 	}
 }
 
+func TestAWSRegistrationBootstrapDoesNotPersistUpgradeBeforeRegister(t *testing.T) {
+	svc, ctx := newAWSRegistrationTestService(t)
+	responder := &recordingAWSCloudFormationResponder{}
+	svc.AWSCloudFormationResponder = responder
+	_, attempt, stackID, externalID := startAndBootstrapAWSRegistration(t, svc, ctx, responder)
+	store := svc.Store.(db.AWSConnectorOnboardingAttemptStore)
+	initial := awsRegistrationRequest(stackID, "Create", "registration-create", "Register", attempt.AttemptID)
+	initial.ResourceProperties["ExternalId"] = externalID
+	initial.ResourceProperties["RoleArn"] = "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+	initial.ResourceProperties["TemplateVersion"] = awsConnectorTemplateVersion
+	if err := svc.ProcessAWSConnectorRegistrationMessage(ctx, awsRegistrationTestMessage(t, testAWSRegistrationTopicARN, initial)); err != nil {
+		t.Fatalf("complete initial registration: %v", err)
+	}
+	legacy, err := store.GetAWSConnectorOnboardingAttempt(ctx, "workspace-a", "project-1", attempt.AttemptID)
+	if err != nil {
+		t.Fatalf("reload attempt: %v", err)
+	}
+	legacy.TemplateVersion = awsLegacyConnectorTemplateVersion
+	if _, err := store.UpdateAWSConnectorOnboardingAttempt(ctx, legacy, legacy.Version); err != nil {
+		t.Fatalf("seed legacy template version: %v", err)
+	}
+	token, err := svc.awsRegistrationToken(legacy)
+	if err != nil {
+		t.Fatalf("derive token: %v", err)
+	}
+	bootstrap := awsRegistrationRequest(stackID, "Update", "bootstrap-upgrade", "Bootstrap", attempt.AttemptID)
+	bootstrap.ResourceProperties["RegistrationToken"] = token
+	bootstrap.ResourceProperties["TemplateVersion"] = awsConnectorTemplateVersion
+	if err := svc.ProcessAWSConnectorRegistrationMessage(ctx, awsRegistrationTestMessage(t, testAWSRegistrationTopicARN, bootstrap)); err != nil {
+		t.Fatalf("process bootstrap upgrade: %v", err)
+	}
+	unchanged, err := store.GetAWSConnectorOnboardingAttempt(ctx, "workspace-a", "project-1", attempt.AttemptID)
+	if err != nil {
+		t.Fatalf("reload attempt after bootstrap: %v", err)
+	}
+	if unchanged.TemplateVersion != awsLegacyConnectorTemplateVersion {
+		t.Fatalf("bootstrap must not persist upgraded version before register, got %s", unchanged.TemplateVersion)
+	}
+	rollback := awsRegistrationRequest(stackID, "Update", "bootstrap-rollback", "Bootstrap", attempt.AttemptID)
+	rollback.ResourceProperties["RegistrationToken"] = token
+	rollback.ResourceProperties["TemplateVersion"] = awsLegacyConnectorTemplateVersion
+	if err := svc.ProcessAWSConnectorRegistrationMessage(ctx, awsRegistrationTestMessage(t, testAWSRegistrationTopicARN, rollback)); err != nil {
+		t.Fatalf("process rollback bootstrap: %v", err)
+	}
+	rollbackSafe, err := store.GetAWSConnectorOnboardingAttempt(ctx, "workspace-a", "project-1", attempt.AttemptID)
+	if err != nil {
+		t.Fatalf("reload attempt after rollback: %v", err)
+	}
+	if rollbackSafe.TemplateVersion != awsLegacyConnectorTemplateVersion {
+		t.Fatalf("rollback must remain compatible with stored legacy version, got %s", rollbackSafe.TemplateVersion)
+	}
+
+	registration := awsRegistrationRequest(stackID, "Update", "registration-upgrade", "Register", attempt.AttemptID)
+	registration.ResourceProperties["ExternalId"] = externalID
+	registration.ResourceProperties["RoleArn"] = "arn:aws:iam::123456789012:role/IdentrailReadOnly"
+	registration.ResourceProperties["TemplateVersion"] = awsConnectorTemplateVersion
+	if err := svc.ProcessAWSConnectorRegistrationMessage(ctx, awsRegistrationTestMessage(t, testAWSRegistrationTopicARN, registration)); err != nil {
+		t.Fatalf("process registration upgrade: %v", err)
+	}
+	upgraded, err := store.GetAWSConnectorOnboardingAttempt(ctx, "workspace-a", "project-1", attempt.AttemptID)
+	if err != nil {
+		t.Fatalf("reload attempt after register: %v", err)
+	}
+	if upgraded.TemplateVersion != awsConnectorTemplateVersion {
+		t.Fatalf("register must persist upgraded version after callback acceptance, got %s", upgraded.TemplateVersion)
+	}
+}
+
 func TestAWSConnectorStartReusesBoundAttemptForExistingStackUpgrade(t *testing.T) {
 	svc, ctx := newAWSRegistrationTestService(t)
 	responder := &recordingAWSCloudFormationResponder{}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1285,33 +1285,41 @@ func (s *Service) refreshAWSScanRecordConnection(ctx context.Context, record db.
 	if len(items) == 0 {
 		return source, currentScope, nil
 	}
-	selected, active, err := s.firstActiveAWSConnection(ctx, items)
-	if err != nil {
-		return source, currentScope, err
-	}
-	selectedID := selected.ConnectorID
+	selected, active := s.firstActiveAWSConnector(ctx, items)
+	selectedID := selected.Connector.ConnectorID
 	if !active {
 		// Keep the record bound even when persisted health says every connector
 		// is degraded; the explicit worker lookup below will fail closed rather
 		// than falling back to a different unvalidated connector.
 		selectedID = items[0].Connector.ConnectorID
 	}
-	for _, item := range items {
-		if item.Connector.ConnectorID != selectedID {
-			continue
+	var selectedItem db.TenancyConnectorWithState
+	if active {
+		// Keep the complete row returned by the selector. Connector IDs are
+		// project-scoped and may legitimately repeat across tenants, so looking
+		// the item up again by ID could bind validation to a different row.
+		selectedItem = selected
+	} else {
+		for _, item := range items {
+			if item.Connector.ConnectorID == selectedID {
+				selectedItem = item
+				break
+			}
 		}
+	}
+	if strings.TrimSpace(selectedItem.Connector.ConnectorID) != "" {
 		selectedScope := db.Scope{
-			TenantID:    item.Connector.TenantID,
-			WorkspaceID: item.Connector.WorkspaceID,
+			TenantID:    selectedItem.Connector.TenantID,
+			WorkspaceID: selectedItem.Connector.WorkspaceID,
 		}
 		// Older connector rows may not carry denormalized scope fields. The
 		// state row has the same ownership metadata and is a safe fallback;
 		// retain the worker scope only for legacy rows missing both.
 		if strings.TrimSpace(selectedScope.TenantID) == "" {
-			selectedScope.TenantID = item.State.TenantID
+			selectedScope.TenantID = selectedItem.State.TenantID
 		}
 		if strings.TrimSpace(selectedScope.WorkspaceID) == "" {
-			selectedScope.WorkspaceID = item.State.WorkspaceID
+			selectedScope.WorkspaceID = selectedItem.State.WorkspaceID
 		}
 		if strings.TrimSpace(selectedScope.TenantID) == "" {
 			selectedScope.TenantID = currentScope.TenantID
@@ -1322,8 +1330,8 @@ func (s *Service) refreshAWSScanRecordConnection(ctx context.Context, record db.
 		selectedScope = selectedScope.Normalize()
 		selectedCtx := db.WithScope(ctx, selectedScope)
 		refreshed, err := s.refreshAWSConnectionForScan(selectedCtx, db.ScanSource{
-			ProjectID:   item.Connector.ProjectID,
-			ConnectorID: item.Connector.ConnectorID,
+			ProjectID:   selectedItem.Connector.ProjectID,
+			ConnectorID: selectedItem.Connector.ConnectorID,
 		})
 		return refreshed, selectedScope, err
 	}
@@ -1434,6 +1442,14 @@ func filterEligibleAWSConnectors(items []db.TenancyConnectorWithState, limit int
 }
 
 func (s *Service) firstActiveAWSConnection(ctx context.Context, items []db.TenancyConnectorWithState) (AWSConnectionStatus, bool, error) {
+	selected, ok := s.firstActiveAWSConnector(ctx, items)
+	if !ok {
+		return AWSConnectionStatus{}, false, nil
+	}
+	return s.awsConnectionStatusFromStored(ctx, selected), true, nil
+}
+
+func (s *Service) firstActiveAWSConnector(ctx context.Context, items []db.TenancyConnectorWithState) (db.TenancyConnectorWithState, bool) {
 	sort.SliceStable(items, func(i, j int) bool {
 		left := items[i].Connector
 		right := items[j].Connector
@@ -1448,10 +1464,10 @@ func (s *Service) firstActiveAWSConnection(ctx context.Context, items []db.Tenan
 		}
 		status := s.awsConnectionStatusFromStored(ctx, item)
 		if status.Connected {
-			return status, true, nil
+			return item, true
 		}
 	}
-	return AWSConnectionStatus{}, false, nil
+	return db.TenancyConnectorWithState{}, false
 }
 
 func (s *Service) recordQueueDepth(queue string, depth int) {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1232,23 +1232,29 @@ func (s *Service) scannerForScan(ctx context.Context, record db.ScanRecord) (Sca
 	// Connector health is checked when work is queued, but the role can drift
 	// while a job waits in the queue. Revalidate immediately before constructing
 	// the AWS scanner so queued work never starts with stale permission state.
-	refreshedSource, err := s.refreshAWSScanRecordConnection(ctx, record)
+	refreshedSource, selectedScope, err := s.refreshAWSScanRecordConnection(ctx, record)
 	if err != nil {
 		return nil, err
 	}
+	// Unscoped scheduled selection may choose a connector belonging to a
+	// different tenant/workspace than the worker's default scope. Carry the
+	// selected connector's scope through both validation and the final lookup;
+	// otherwise requireScopedProject can validate the wrong project or reject a
+	// valid connector as not found.
+	selectedCtx := db.WithScope(ctx, selectedScope)
 	// Use the connector that was just validated for the worker lookup too;
 	// otherwise a degraded selected connector could be replaced by a different
 	// connector with stale persisted health.
 	record.ProjectID = refreshedSource.ProjectID
 	record.ConnectorID = refreshedSource.ConnectorID
-	connection, ok, err := s.activeAWSConnectionForScan(ctx, record)
+	connection, ok, err := s.activeAWSConnectionForScan(selectedCtx, record)
 	if err != nil {
 		return nil, err
 	}
 	if !ok {
 		return s.Scanner, nil
 	}
-	scanner, err := s.AWSScannerFactory(ctx, connection)
+	scanner, err := s.AWSScannerFactory(selectedCtx, connection)
 	if err != nil {
 		return nil, fmt.Errorf("initialize aws connector scanner: %w", err)
 	}
@@ -1262,24 +1268,26 @@ func (s *Service) scannerForScan(ctx context.Context, record db.ScanRecord) (Sca
 // would otherwise select for a source-less scheduled scan, then validates it
 // and binds the record to that connector. Scheduled scans are created without
 // project metadata, so checking only record.ProjectID would skip validation.
-func (s *Service) refreshAWSScanRecordConnection(ctx context.Context, record db.ScanRecord) (db.ScanSource, error) {
+func (s *Service) refreshAWSScanRecordConnection(ctx context.Context, record db.ScanRecord) (db.ScanSource, db.Scope, error) {
+	currentScope := db.ScopeFromContext(ctx)
 	source := db.ScanSource{ProjectID: record.ProjectID, ConnectorID: record.ConnectorID}.Normalize()
 	if source.ProjectID != "" {
-		return s.refreshAWSConnectionForScan(ctx, source)
+		refreshed, err := s.refreshAWSConnectionForScan(ctx, source)
+		return refreshed, currentScope, err
 	}
 	if s.AWSConnectorValidator == nil || s.awsBaselineSourceMode() == "fixture" {
-		return source, nil
+		return source, currentScope, nil
 	}
 	items, err := s.listEligibleAWSConnectorsUnscoped(ctx, 25)
 	if err != nil {
-		return source, fmt.Errorf("list aws connectors for scheduled scan: %w", err)
+		return source, currentScope, fmt.Errorf("list aws connectors for scheduled scan: %w", err)
 	}
 	if len(items) == 0 {
-		return source, nil
+		return source, currentScope, nil
 	}
 	selected, active, err := s.firstActiveAWSConnection(ctx, items)
 	if err != nil {
-		return source, err
+		return source, currentScope, err
 	}
 	selectedID := selected.ConnectorID
 	if !active {
@@ -1292,12 +1300,34 @@ func (s *Service) refreshAWSScanRecordConnection(ctx context.Context, record db.
 		if item.Connector.ConnectorID != selectedID {
 			continue
 		}
-		return s.refreshAWSConnectionForScan(ctx, db.ScanSource{
+		selectedScope := db.Scope{
+			TenantID:    item.Connector.TenantID,
+			WorkspaceID: item.Connector.WorkspaceID,
+		}
+		// Older connector rows may not carry denormalized scope fields. The
+		// state row has the same ownership metadata and is a safe fallback;
+		// retain the worker scope only for legacy rows missing both.
+		if strings.TrimSpace(selectedScope.TenantID) == "" {
+			selectedScope.TenantID = item.State.TenantID
+		}
+		if strings.TrimSpace(selectedScope.WorkspaceID) == "" {
+			selectedScope.WorkspaceID = item.State.WorkspaceID
+		}
+		if strings.TrimSpace(selectedScope.TenantID) == "" {
+			selectedScope.TenantID = currentScope.TenantID
+		}
+		if strings.TrimSpace(selectedScope.WorkspaceID) == "" {
+			selectedScope.WorkspaceID = currentScope.WorkspaceID
+		}
+		selectedScope = selectedScope.Normalize()
+		selectedCtx := db.WithScope(ctx, selectedScope)
+		refreshed, err := s.refreshAWSConnectionForScan(selectedCtx, db.ScanSource{
 			ProjectID:   item.Connector.ProjectID,
 			ConnectorID: item.Connector.ConnectorID,
 		})
+		return refreshed, selectedScope, err
 	}
-	return source, nil
+	return source, currentScope, nil
 }
 
 func (s *Service) recordServiceAuthzDenial(ctx context.Context, action string, resourceType string, resourceID string) {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1227,6 +1227,17 @@ func (s *Service) scannerForScan(ctx context.Context, record db.ScanRecord) (Sca
 	if provider != "aws" || s.AWSScannerFactory == nil {
 		return s.Scanner, nil
 	}
+	// Connector health is checked when work is queued, but the role can drift
+	// while a job waits in the queue. Revalidate immediately before constructing
+	// the AWS scanner so queued work never starts with stale permission state.
+	if record.ProjectID != "" {
+		if err := s.refreshAWSConnectionForScan(ctx, db.ScanSource{
+			ProjectID:   record.ProjectID,
+			ConnectorID: record.ConnectorID,
+		}); err != nil {
+			return nil, err
+		}
+	}
 	connection, ok, err := s.activeAWSConnectionForScan(ctx, record)
 	if err != nil {
 		return nil, err

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1232,20 +1232,15 @@ func (s *Service) scannerForScan(ctx context.Context, record db.ScanRecord) (Sca
 	// Connector health is checked when work is queued, but the role can drift
 	// while a job waits in the queue. Revalidate immediately before constructing
 	// the AWS scanner so queued work never starts with stale permission state.
-	if record.ProjectID != "" {
-		refreshedSource, err := s.refreshAWSConnectionForScan(ctx, db.ScanSource{
-			ProjectID:   record.ProjectID,
-			ConnectorID: record.ConnectorID,
-		})
-		if err != nil {
-			return nil, err
-		}
-		// Use the connector that was just validated for the worker lookup too;
-		// otherwise a degraded selected connector could be replaced by a
-		// different connector with stale persisted health.
-		record.ProjectID = refreshedSource.ProjectID
-		record.ConnectorID = refreshedSource.ConnectorID
+	refreshedSource, err := s.refreshAWSScanRecordConnection(ctx, record)
+	if err != nil {
+		return nil, err
 	}
+	// Use the connector that was just validated for the worker lookup too;
+	// otherwise a degraded selected connector could be replaced by a different
+	// connector with stale persisted health.
+	record.ProjectID = refreshedSource.ProjectID
+	record.ConnectorID = refreshedSource.ConnectorID
 	connection, ok, err := s.activeAWSConnectionForScan(ctx, record)
 	if err != nil {
 		return nil, err
@@ -1261,6 +1256,48 @@ func (s *Service) scannerForScan(ctx context.Context, record db.ScanRecord) (Sca
 		return nil, errors.New("aws connector scanner factory returned nil scanner")
 	}
 	return scanner, nil
+}
+
+// refreshAWSScanRecordConnection resolves the same connector that the worker
+// would otherwise select for a source-less scheduled scan, then validates it
+// and binds the record to that connector. Scheduled scans are created without
+// project metadata, so checking only record.ProjectID would skip validation.
+func (s *Service) refreshAWSScanRecordConnection(ctx context.Context, record db.ScanRecord) (db.ScanSource, error) {
+	source := db.ScanSource{ProjectID: record.ProjectID, ConnectorID: record.ConnectorID}.Normalize()
+	if source.ProjectID != "" {
+		return s.refreshAWSConnectionForScan(ctx, source)
+	}
+	if s.AWSConnectorValidator == nil || s.awsBaselineSourceMode() == "fixture" {
+		return source, nil
+	}
+	items, err := s.listEligibleAWSConnectorsUnscoped(ctx, 25)
+	if err != nil {
+		return source, fmt.Errorf("list aws connectors for scheduled scan: %w", err)
+	}
+	if len(items) == 0 {
+		return source, nil
+	}
+	selected, active, err := s.firstActiveAWSConnection(ctx, items)
+	if err != nil {
+		return source, err
+	}
+	selectedID := selected.ConnectorID
+	if !active {
+		// Keep the record bound even when persisted health says every connector
+		// is degraded; the explicit worker lookup below will fail closed rather
+		// than falling back to a different unvalidated connector.
+		selectedID = items[0].Connector.ConnectorID
+	}
+	for _, item := range items {
+		if item.Connector.ConnectorID != selectedID {
+			continue
+		}
+		return s.refreshAWSConnectionForScan(ctx, db.ScanSource{
+			ProjectID:   item.Connector.ProjectID,
+			ConnectorID: item.Connector.ConnectorID,
+		})
+	}
+	return source, nil
 }
 
 func (s *Service) recordServiceAuthzDenial(ctx context.Context, action string, resourceType string, resourceID string) {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -705,7 +705,8 @@ func (s *Service) EnqueueScan(ctx context.Context, requests ...ScanRequest) (db.
 	if err != nil {
 		return db.ScanRecord{}, err
 	}
-	if err := s.ensureAWSPlatformBaselineReadyForScan(ctx, s.Provider, source); err != nil {
+	source, err = s.ensureAWSPlatformBaselineReadyForScan(ctx, s.Provider, source)
+	if err != nil {
 		return db.ScanRecord{}, err
 	}
 	maxPending := s.ScanQueueMaxPending
@@ -809,7 +810,8 @@ func (s *Service) ReplayScan(ctx context.Context, scanID string) (db.ScanRecord,
 		ProjectID:   source.ProjectID,
 		ConnectorID: source.ConnectorID,
 	}
-	if err := s.ensureAWSPlatformBaselineReadyForScan(ctx, source.Provider, sourceContext); err != nil {
+	sourceContext, err = s.ensureAWSPlatformBaselineReadyForScan(ctx, source.Provider, sourceContext)
+	if err != nil {
 		return db.ScanRecord{}, err
 	}
 	if maxPending == 1 {
@@ -1231,12 +1233,18 @@ func (s *Service) scannerForScan(ctx context.Context, record db.ScanRecord) (Sca
 	// while a job waits in the queue. Revalidate immediately before constructing
 	// the AWS scanner so queued work never starts with stale permission state.
 	if record.ProjectID != "" {
-		if err := s.refreshAWSConnectionForScan(ctx, db.ScanSource{
+		refreshedSource, err := s.refreshAWSConnectionForScan(ctx, db.ScanSource{
 			ProjectID:   record.ProjectID,
 			ConnectorID: record.ConnectorID,
-		}); err != nil {
+		})
+		if err != nil {
 			return nil, err
 		}
+		// Use the connector that was just validated for the worker lookup too;
+		// otherwise a degraded selected connector could be replaced by a
+		// different connector with stale persisted health.
+		record.ProjectID = refreshedSource.ProjectID
+		record.ConnectorID = refreshedSource.ConnectorID
 	}
 	connection, ok, err := s.activeAWSConnectionForScan(ctx, record)
 	if err != nil {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -940,7 +940,9 @@ func (s *Service) runScanWithRecord(ctx context.Context, record db.ScanRecord, a
 			s.Metrics.ScanDurationMS.Observe(float64(time.Since(scanStarted).Milliseconds()))
 		}()
 	}
-	scanner, err := s.scannerForScan(ctx, record)
+	scanner, boundRecord, err := s.scannerForScan(ctx, record)
+	record = boundRecord
+	ctx = db.WithScope(ctx, db.Scope{TenantID: record.TenantID, WorkspaceID: record.WorkspaceID})
 	if err != nil {
 		if handleErr := s.handleScanFailure(ctx, record, allowRetry, scanFailureStageConnectorSetup, 0, 0, err, "scan failed while preparing provider connector"); handleErr != nil {
 			return RunScanResult{}, handleErr
@@ -1221,47 +1223,76 @@ func scanRetryBackoff(retryCount int) time.Duration {
 	return backoff
 }
 
-func (s *Service) scannerForScan(ctx context.Context, record db.ScanRecord) (ScannerRunner, error) {
+func (s *Service) scannerForScan(ctx context.Context, record db.ScanRecord) (ScannerRunner, db.ScanRecord, error) {
 	provider := strings.ToLower(strings.TrimSpace(record.Provider))
 	if provider == "" {
 		provider = strings.ToLower(strings.TrimSpace(s.Provider))
 	}
 	if provider != "aws" || s.AWSScannerFactory == nil {
-		return s.Scanner, nil
+		return s.Scanner, record, nil
 	}
 	// Connector health is checked when work is queued, but the role can drift
 	// while a job waits in the queue. Revalidate immediately before constructing
 	// the AWS scanner so queued work never starts with stale permission state.
-	refreshedSource, selectedScope, err := s.refreshAWSScanRecordConnection(ctx, record)
-	if err != nil {
-		return nil, err
-	}
+	refreshedSource, selectedScope, refreshErr := s.refreshAWSScanRecordConnection(ctx, record)
 	// Unscoped scheduled selection may choose a connector belonging to a
 	// different tenant/workspace than the worker's default scope. Carry the
 	// selected connector's scope through both validation and the final lookup;
 	// otherwise requireScopedProject can validate the wrong project or reject a
 	// valid connector as not found.
 	selectedCtx := db.WithScope(ctx, selectedScope)
+	boundRecord, selectedCtx, err := s.bindAWSScanRecordSource(selectedCtx, record, refreshedSource)
+	if err != nil {
+		return nil, boundRecord, err
+	}
+	if refreshErr != nil {
+		return nil, boundRecord, refreshErr
+	}
 	// Use the connector that was just validated for the worker lookup too;
 	// otherwise a degraded selected connector could be replaced by a different
 	// connector with stale persisted health.
-	record.ProjectID = refreshedSource.ProjectID
-	record.ConnectorID = refreshedSource.ConnectorID
-	connection, ok, err := s.activeAWSConnectionForScan(selectedCtx, record)
+	boundRecord.ProjectID = refreshedSource.ProjectID
+	boundRecord.ConnectorID = refreshedSource.ConnectorID
+	connection, ok, err := s.activeAWSConnectionForScan(selectedCtx, boundRecord)
 	if err != nil {
-		return nil, err
+		return nil, boundRecord, err
 	}
 	if !ok {
-		return s.Scanner, nil
+		return s.Scanner, boundRecord, nil
 	}
 	scanner, err := s.AWSScannerFactory(selectedCtx, connection)
 	if err != nil {
-		return nil, fmt.Errorf("initialize aws connector scanner: %w", err)
+		return nil, boundRecord, fmt.Errorf("initialize aws connector scanner: %w", err)
 	}
 	if scanner == nil {
-		return nil, errors.New("aws connector scanner factory returned nil scanner")
+		return nil, boundRecord, errors.New("aws connector scanner factory returned nil scanner")
 	}
-	return scanner, nil
+	return scanner, boundRecord, nil
+}
+
+func (s *Service) bindAWSScanRecordSource(ctx context.Context, record db.ScanRecord, source db.ScanSource) (db.ScanRecord, context.Context, error) {
+	normalizedSource := source.Normalize()
+	if normalizedSource.Empty() {
+		return record, ctx, nil
+	}
+	scope := db.ScopeFromContext(ctx)
+	needsBinding := record.ProjectID != normalizedSource.ProjectID || record.ConnectorID != normalizedSource.ConnectorID || !db.MatchScope(scope, record.TenantID, record.WorkspaceID)
+	record.ProjectID = normalizedSource.ProjectID
+	record.ConnectorID = normalizedSource.ConnectorID
+	record.TenantID = scope.TenantID
+	record.WorkspaceID = scope.WorkspaceID
+	if !needsBinding || strings.TrimSpace(record.ID) == "" {
+		return record, ctx, nil
+	}
+	binder, ok := s.Store.(db.ScanSourceBinder)
+	if !ok {
+		return record, ctx, errors.New("scan store does not support source binding")
+	}
+	bound, err := binder.BindScanSource(ctx, record.ID, normalizedSource)
+	if err != nil {
+		return record, ctx, fmt.Errorf("bind aws scan source: %w", err)
+	}
+	return bound, db.WithScope(ctx, db.Scope{TenantID: bound.TenantID, WorkspaceID: bound.WorkspaceID}), nil
 }
 
 // refreshAWSScanRecordConnection resolves the same connector that the worker

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -6505,8 +6505,12 @@ func TestServiceLockKeyNamespace(t *testing.T) {
 
 func seedAWSConnectorForScanTest(t *testing.T, store db.Store, ctx context.Context, projectID string, connectorID string, status domain.ConnectorStatus, health string, updatedAt time.Time) {
 	t.Helper()
+	scope, err := db.RequireScope(ctx)
+	if err != nil {
+		t.Fatalf("resolve connector scope: %v", err)
+	}
 	if err := store.UpsertTenancyConnector(ctx, db.TenancyConnector{
-		WorkspaceID: "default",
+		WorkspaceID: scope.WorkspaceID,
 		ProjectID:   projectID,
 		ConnectorID: connectorID,
 		Type:        domain.ConnectorTypeAWS,
@@ -6515,7 +6519,7 @@ func seedAWSConnectorForScanTest(t *testing.T, store db.Store, ctx context.Conte
 		CreatedAt:   updatedAt,
 		UpdatedAt:   updatedAt,
 	}, db.TenancyConnectorState{
-		WorkspaceID:  "default",
+		WorkspaceID:  scope.WorkspaceID,
 		ProjectID:    projectID,
 		ConnectorID:  connectorID,
 		HealthStatus: health,

--- a/internal/connectors/aws/cfn.go
+++ b/internal/connectors/aws/cfn.go
@@ -15,9 +15,12 @@ var awsRegionPattern = regexp.MustCompile(`^[a-z]{2}(-gov)?-[a-z]+-[0-9]$`)
 
 // CloudFormationLaunchInput contains the parameters for an AWS console launch URL.
 type CloudFormationLaunchInput struct {
-	TemplateURL             string
-	Region                  string
-	StackName               string
+	TemplateURL string
+	Region      string
+	StackName   string
+	// StackID selects the existing-stack update wizard when set. Leave it
+	// empty for the create-stack quick-create flow.
+	StackID                 string
 	IdentrailAccountID      string
 	ExternalID              string
 	RoleName                string
@@ -57,6 +60,11 @@ func BuildCloudFormationLaunchURL(input CloudFormationLaunchInput) string {
 		values.Set("param_ExternalId", strings.TrimSpace(input.ExternalID))
 	}
 
+	stackID := strings.TrimSpace(input.StackID)
+	if stackID != "" {
+		values.Set("stackId", stackID)
+		return "https://" + consoleHostForRegion(region) + "/cloudformation/home?region=" + url.QueryEscape(region) + "#/stacks/update/template?" + values.Encode()
+	}
 	return "https://" + consoleHostForRegion(region) + "/cloudformation/home?region=" + url.QueryEscape(region) + "#/stacks/create/review?" + values.Encode()
 }
 

--- a/internal/connectors/aws/cfn_test.go
+++ b/internal/connectors/aws/cfn_test.go
@@ -292,6 +292,37 @@ func TestBuildCloudFormationLaunchURLAutomaticRegistration(t *testing.T) {
 	}
 }
 
+func TestBuildCloudFormationLaunchURLForExistingStackUsesUpdateWizard(t *testing.T) {
+	launchURL := BuildCloudFormationLaunchURL(CloudFormationLaunchInput{
+		TemplateURL:             "https://cdn.example.com/identrail-readonly-v2.2.yaml",
+		Region:                  "us-east-1",
+		StackName:               "identrail-prod",
+		StackID:                 "arn:aws:cloudformation:us-east-1:123456789012:stack/identrail-prod/abc123",
+		IdentrailAccountID:      "123456789012",
+		RegistrationProviderARN: "arn:aws:sns:us-east-1:123456789012:identrail-registration",
+		RegistrationAttemptID:   "attempt-abc-123",
+		RegistrationToken:       "token-xyz-789",
+	})
+
+	parsed, err := url.Parse(launchURL)
+	if err != nil {
+		t.Fatalf("parse launch URL: %v", err)
+	}
+	if !strings.HasPrefix(parsed.Fragment, "/stacks/update/template?") {
+		t.Fatalf("expected existing stack update wizard, got %q", parsed.Fragment)
+	}
+	fragmentQuery, err := url.ParseQuery(strings.TrimPrefix(parsed.Fragment, "/stacks/update/template?"))
+	if err != nil {
+		t.Fatalf("parse update wizard query: %v", err)
+	}
+	if got := fragmentQuery.Get("stackId"); got != "arn:aws:cloudformation:us-east-1:123456789012:stack/identrail-prod/abc123" {
+		t.Fatalf("expected existing stack ID, got %q", got)
+	}
+	if got := fragmentQuery.Get("templateURL"); got != "https://cdn.example.com/identrail-readonly-v2.2.yaml" {
+		t.Fatalf("expected update template URL, got %q", got)
+	}
+}
+
 func TestBuildCloudFormationStackSetLaunchURL(t *testing.T) {
 	autoDeploy := false
 	launchURL := BuildCloudFormationStackSetLaunchURL(CloudFormationStackSetLaunchInput{

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -518,6 +518,33 @@ func (m *MemoryStore) GetScan(ctx context.Context, scanID string) (ScanRecord, e
 	return record, nil
 }
 
+// BindScanSource records the connector selected for a queued or running scan.
+// The lookup is intentionally any-scope because the worker claims scans across
+// scopes, then applies the selected connector's scope to the record.
+func (m *MemoryStore) BindScanSource(ctx context.Context, scanID string, source ScanSource) (ScanRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return ScanRecord{}, err
+	}
+	normalizedSource := source.Normalize()
+	if normalizedSource.Empty() {
+		return ScanRecord{}, ErrNotFound
+	}
+	record, exists := m.scans[scanID]
+	if !exists || record.DeadLettered || (record.Status != "queued" && record.Status != "running") {
+		return ScanRecord{}, ErrNotFound
+	}
+	record.TenantID = scope.TenantID
+	record.WorkspaceID = scope.WorkspaceID
+	record.ProjectID = normalizedSource.ProjectID
+	record.ConnectorID = normalizedSource.ConnectorID
+	m.scans[scanID] = record
+	return record, nil
+}
+
 // CompleteScan finalizes persisted scan metadata.
 func (m *MemoryStore) CompleteScan(ctx context.Context, scanID string, status string, finishedAt time.Time, assetCount int, findingCount int, errorMessage string) error {
 	m.mu.Lock()

--- a/internal/db/memory_aws_onboarding.go
+++ b/internal/db/memory_aws_onboarding.go
@@ -91,6 +91,37 @@ func (m *MemoryStore) GetActiveAWSConnectorOnboardingAttempt(ctx context.Context
 	return cloneAWSConnectorOnboardingAttempt(newest), nil
 }
 
+// GetLatestAWSConnectorOnboardingAttempt returns the newest attempt regardless
+// of lifecycle status. Resume flows use it to issue an authenticated
+// CloudFormation Update against an already-bound stack instead of creating a
+// second attempt that cannot claim the existing stack.
+func (m *MemoryStore) GetLatestAWSConnectorOnboardingAttempt(ctx context.Context, workspaceID string, projectID string, connectorID string) (AWSConnectorOnboardingAttempt, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AWSConnectorOnboardingAttempt{}, err
+	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return AWSConnectorOnboardingAttempt{}, err
+	}
+	var newest AWSConnectorOnboardingAttempt
+	for _, attempt := range m.awsOnboardingAttempts {
+		if attempt.TenantID != scope.TenantID || attempt.WorkspaceID != resolvedWorkspaceID || attempt.ProjectID != strings.TrimSpace(projectID) || attempt.ConnectorID != strings.TrimSpace(connectorID) {
+			continue
+		}
+		if newest.AttemptID == "" || attempt.CreatedAt.After(newest.CreatedAt) || (attempt.CreatedAt.Equal(newest.CreatedAt) && attempt.UpdatedAt.After(newest.UpdatedAt)) {
+			newest = attempt
+		}
+	}
+	if newest.AttemptID == "" {
+		return AWSConnectorOnboardingAttempt{}, ErrNotFound
+	}
+	return cloneAWSConnectorOnboardingAttempt(newest), nil
+}
+
 func (m *MemoryStore) UpdateAWSConnectorOnboardingAttempt(ctx context.Context, attempt AWSConnectorOnboardingAttempt, expectedVersion int64) (AWSConnectorOnboardingAttempt, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/db/memory_aws_onboarding.go
+++ b/internal/db/memory_aws_onboarding.go
@@ -122,6 +122,45 @@ func (m *MemoryStore) GetLatestAWSConnectorOnboardingAttempt(ctx context.Context
 	return cloneAWSConnectorOnboardingAttempt(newest), nil
 }
 
+// GetLatestResumableAWSConnectorOnboardingAttempt returns the newest attempt
+// that can safely resume an already-created CloudFormation stack. Unbound
+// attempts are intentionally ignored so a newer draft cannot hide the older
+// attempt that owns the durable stack identity.
+func (m *MemoryStore) GetLatestResumableAWSConnectorOnboardingAttempt(ctx context.Context, workspaceID string, projectID string, connectorID string, providerTopicARN string, region string) (AWSConnectorOnboardingAttempt, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AWSConnectorOnboardingAttempt{}, err
+	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return AWSConnectorOnboardingAttempt{}, err
+	}
+	providerTopicARN = strings.TrimSpace(providerTopicARN)
+	region = strings.ToLower(strings.TrimSpace(region))
+	var newest AWSConnectorOnboardingAttempt
+	for _, attempt := range m.awsOnboardingAttempts {
+		if attempt.TenantID != scope.TenantID ||
+			attempt.WorkspaceID != resolvedWorkspaceID ||
+			attempt.ProjectID != strings.TrimSpace(projectID) ||
+			attempt.ConnectorID != strings.TrimSpace(connectorID) ||
+			attempt.ProviderTopicARN != providerTopicARN ||
+			attempt.DeploymentRegion != region ||
+			!awsOnboardingAttemptHasBoundStack(attempt) {
+			continue
+		}
+		if newest.AttemptID == "" || attempt.CreatedAt.After(newest.CreatedAt) || (attempt.CreatedAt.Equal(newest.CreatedAt) && attempt.UpdatedAt.After(newest.UpdatedAt)) {
+			newest = attempt
+		}
+	}
+	if newest.AttemptID == "" {
+		return AWSConnectorOnboardingAttempt{}, ErrNotFound
+	}
+	return cloneAWSConnectorOnboardingAttempt(newest), nil
+}
+
 func (m *MemoryStore) UpdateAWSConnectorOnboardingAttempt(ctx context.Context, attempt AWSConnectorOnboardingAttempt, expectedVersion int64) (AWSConnectorOnboardingAttempt, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -225,6 +264,15 @@ func awsOnboardingAttemptActive(status string) bool {
 	default:
 		return false
 	}
+}
+
+func awsOnboardingAttemptHasBoundStack(attempt AWSConnectorOnboardingAttempt) bool {
+	if attempt.Status != AWSConnectorOnboardingAttemptConnected && attempt.Status != AWSConnectorOnboardingAttemptNeedsFix {
+		return false
+	}
+	return strings.TrimSpace(attempt.StackID) != "" &&
+		strings.TrimSpace(attempt.BootstrapRequestID) != "" &&
+		strings.TrimSpace(attempt.RegisterRequestID) != ""
 }
 
 func cloneAWSConnectorOnboardingAttempt(attempt AWSConnectorOnboardingAttempt) AWSConnectorOnboardingAttempt {

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -5654,7 +5654,10 @@ func findingsWithTriageFromSQLRows(rows rowsScanner, now time.Time) ([]domain.Fi
 }
 
 func findingEvidenceForPersistence(finding domain.Finding) map[string]any {
-	evidence := make(map[string]any, len(finding.Evidence)+8)
+	// Avoid arithmetic on attacker-influenced map lengths. The metadata fields
+	// below are added lazily, so the map can grow without a preallocation that
+	// could overflow on malformed input.
+	evidence := make(map[string]any, len(finding.Evidence))
 	for key, value := range finding.Evidence {
 		evidence[key] = value
 	}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -755,6 +755,42 @@ func (p *PostgresStore) GetScan(ctx context.Context, scanID string) (ScanRecord,
 	return record, nil
 }
 
+// BindScanSource records the connector selected for a queued or running scan.
+// The any-scope lookup is required because the worker claims scans across
+// tenants before applying the selected connector's scope to the record.
+func (p *PostgresStore) BindScanSource(ctx context.Context, scanID string, source ScanSource) (ScanRecord, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return ScanRecord{}, err
+	}
+	normalizedSource := source.Normalize()
+	if normalizedSource.Empty() {
+		return ScanRecord{}, ErrNotFound
+	}
+	row := p.queryRowContextAnyScope(
+		ctx,
+		`UPDATE scans
+		 SET tenant_id=$2, workspace_id=$3, source_project_id=$4, source_connector_id=$5
+		 WHERE id=$1
+		   AND status IN ('queued', 'running')
+		   AND dead_lettered = FALSE
+		 RETURNING id, tenant_id, workspace_id, COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), provider, status, started_at, finished_at, asset_count, finding_count, COALESCE(error_message, ''), retry_count, max_retry_count, COALESCE(failure_category, ''), next_retry_at, dead_lettered, dead_lettered_at`,
+		scanID,
+		scope.TenantID,
+		scope.WorkspaceID,
+		normalizedSource.ProjectID,
+		normalizedSource.ConnectorID,
+	)
+	record, err := scanScanRecord(row)
+	if err != nil {
+		if errorsIsNoRows(err) {
+			return ScanRecord{}, ErrNotFound
+		}
+		return ScanRecord{}, fmt.Errorf("bind scan source: %w", err)
+	}
+	return record, nil
+}
+
 // CompleteScan updates scan completion metadata.
 func (p *PostgresStore) CompleteScan(ctx context.Context, scanID string, status string, finishedAt time.Time, assetCount int, findingCount int, errorMessage string) error {
 	scope, err := RequireScope(ctx)

--- a/internal/db/postgres_aws_onboarding.go
+++ b/internal/db/postgres_aws_onboarding.go
@@ -152,6 +152,35 @@ func (p *PostgresStore) GetLatestAWSConnectorOnboardingAttempt(ctx context.Conte
 	return attempt, err
 }
 
+func (p *PostgresStore) GetLatestResumableAWSConnectorOnboardingAttempt(ctx context.Context, workspaceID string, projectID string, connectorID string, providerTopicARN string, region string) (AWSConnectorOnboardingAttempt, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AWSConnectorOnboardingAttempt{}, err
+	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return AWSConnectorOnboardingAttempt{}, err
+	}
+	row := p.queryRowContext(ctx, `SELECT `+awsConnectorOnboardingAttemptColumns+`
+        FROM aws_connector_onboarding_attempts
+        WHERE tenant_id = $1 AND workspace_id = $2 AND project_id = $3
+          AND connector_id = $4
+          AND provider_topic_arn = $5
+          AND deployment_region = $6
+          AND status IN ('connected', 'needs_fix')
+          AND NULLIF(stack_id, '') IS NOT NULL
+          AND NULLIF(bootstrap_request_id, '') IS NOT NULL
+          AND NULLIF(register_request_id, '') IS NOT NULL
+        ORDER BY created_at DESC, updated_at DESC
+        LIMIT 1`,
+		scope.TenantID, resolvedWorkspaceID, strings.TrimSpace(projectID), strings.TrimSpace(connectorID), strings.TrimSpace(providerTopicARN), strings.ToLower(strings.TrimSpace(region)))
+	attempt, err := scanAWSConnectorOnboardingAttempt(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AWSConnectorOnboardingAttempt{}, ErrNotFound
+	}
+	return attempt, err
+}
+
 func (p *PostgresStore) UpdateAWSConnectorOnboardingAttempt(ctx context.Context, attempt AWSConnectorOnboardingAttempt, expectedVersion int64) (AWSConnectorOnboardingAttempt, error) {
 	normalized, err := normalizeAWSConnectorOnboardingAttempt(ctx, attempt)
 	if err != nil {

--- a/internal/db/postgres_aws_onboarding.go
+++ b/internal/db/postgres_aws_onboarding.go
@@ -129,6 +129,29 @@ func (p *PostgresStore) GetActiveAWSConnectorOnboardingAttempt(ctx context.Conte
 	return attempt, err
 }
 
+func (p *PostgresStore) GetLatestAWSConnectorOnboardingAttempt(ctx context.Context, workspaceID string, projectID string, connectorID string) (AWSConnectorOnboardingAttempt, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AWSConnectorOnboardingAttempt{}, err
+	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return AWSConnectorOnboardingAttempt{}, err
+	}
+	row := p.queryRowContext(ctx, `SELECT `+awsConnectorOnboardingAttemptColumns+`
+        FROM aws_connector_onboarding_attempts
+        WHERE tenant_id = $1 AND workspace_id = $2 AND project_id = $3
+          AND connector_id = $4
+        ORDER BY created_at DESC, updated_at DESC
+        LIMIT 1`,
+		scope.TenantID, resolvedWorkspaceID, strings.TrimSpace(projectID), strings.TrimSpace(connectorID))
+	attempt, err := scanAWSConnectorOnboardingAttempt(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AWSConnectorOnboardingAttempt{}, ErrNotFound
+	}
+	return attempt, err
+}
+
 func (p *PostgresStore) UpdateAWSConnectorOnboardingAttempt(ctx context.Context, attempt AWSConnectorOnboardingAttempt, expectedVersion int64) (AWSConnectorOnboardingAttempt, error) {
 	normalized, err := normalizeAWSConnectorOnboardingAttempt(ctx, attempt)
 	if err != nil {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -41,6 +41,28 @@ func (m jsonSubsetMatcher) Match(value driver.Value) bool {
 	return true
 }
 
+func TestFindingEvidenceForPersistencePreservesEvidenceAndMetadata(t *testing.T) {
+	finding := domain.Finding{
+		Evidence:             map[string]any{"resource": "role/reader"},
+		ConfidenceScore:      0.9,
+		Actionability:        domain.FindingActionabilityReview,
+		Exploitability:       domain.FindingExploitabilityPlausible,
+		EvidenceCompleteness: "complete",
+		Provenance:           "aws_iam_inventory",
+		AdapterSource:        "aws_iam_rule_engine",
+		ConfidenceState:      "inventory_backed",
+		EvidenceVersion:      "aws-finding-v2",
+	}
+
+	got := findingEvidenceForPersistence(finding)
+	if got["resource"] != "role/reader" || got["confidence_score"] != 0.9 || got["actionability"] != domain.FindingActionabilityReview || got["evidence_version"] != "aws-finding-v2" {
+		t.Fatalf("expected evidence and metadata to be persisted together, got %+v", got)
+	}
+	if len(got) != len(finding.Evidence)+8 {
+		t.Fatalf("expected all eight metadata fields, got %d entries: %+v", len(got), got)
+	}
+}
+
 func TestPostgresStoreCreateAndCompleteScan(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -322,6 +322,13 @@ type ScanSource struct {
 	ConnectorID string
 }
 
+// ScanSourceBinder atomically records the connector selected for a running
+// scan. Worker scans can be created without source metadata and must bind the
+// selected source before execution so retries and history use the same scope.
+type ScanSourceBinder interface {
+	BindScanSource(ctx context.Context, scanID string, source ScanSource) (ScanRecord, error)
+}
+
 // Normalize returns a stable source key.
 func (s ScanSource) Normalize() ScanSource {
 	return ScanSource{

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1240,6 +1240,7 @@ type AWSConnectorOnboardingAttemptStore interface {
 	GetAWSConnectorOnboardingAttempt(ctx context.Context, workspaceID string, projectID string, attemptID string) (AWSConnectorOnboardingAttempt, error)
 	GetAWSConnectorOnboardingAttemptAnyScope(ctx context.Context, attemptID string) (AWSConnectorOnboardingAttempt, error)
 	GetActiveAWSConnectorOnboardingAttempt(ctx context.Context, workspaceID string, projectID string, connectorID string) (AWSConnectorOnboardingAttempt, error)
+	GetLatestAWSConnectorOnboardingAttempt(ctx context.Context, workspaceID string, projectID string, connectorID string) (AWSConnectorOnboardingAttempt, error)
 	UpdateAWSConnectorOnboardingAttempt(ctx context.Context, attempt AWSConnectorOnboardingAttempt, expectedVersion int64) (AWSConnectorOnboardingAttempt, error)
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1248,6 +1248,7 @@ type AWSConnectorOnboardingAttemptStore interface {
 	GetAWSConnectorOnboardingAttemptAnyScope(ctx context.Context, attemptID string) (AWSConnectorOnboardingAttempt, error)
 	GetActiveAWSConnectorOnboardingAttempt(ctx context.Context, workspaceID string, projectID string, connectorID string) (AWSConnectorOnboardingAttempt, error)
 	GetLatestAWSConnectorOnboardingAttempt(ctx context.Context, workspaceID string, projectID string, connectorID string) (AWSConnectorOnboardingAttempt, error)
+	GetLatestResumableAWSConnectorOnboardingAttempt(ctx context.Context, workspaceID string, projectID string, connectorID string, providerTopicARN string, region string) (AWSConnectorOnboardingAttempt, error)
 	UpdateAWSConnectorOnboardingAttempt(ctx context.Context, attempt AWSConnectorOnboardingAttempt, expectedVersion int64) (AWSConnectorOnboardingAttempt, error)
 }
 

--- a/internal/providers/aws/connector_validation.go
+++ b/internal/providers/aws/connector_validation.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
 	api "github.com/identrail/identrail/internal/api"
@@ -42,6 +44,13 @@ type iamValidationAPI interface {
 	ListAttachedRolePolicies(ctx context.Context, params *iam.ListAttachedRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error)
 	GetPolicy(ctx context.Context, params *iam.GetPolicyInput, optFns ...func(*iam.Options)) (*iam.GetPolicyOutput, error)
 	GetPolicyVersion(ctx context.Context, params *iam.GetPolicyVersionInput, optFns ...func(*iam.Options)) (*iam.GetPolicyVersionOutput, error)
+}
+
+// iamPermissionSimulationAPI is kept separate from iamValidationAPI so test
+// adapters and older integrations that only implement the IAM metadata probes
+// continue to work. The AWS SDK client implements both interfaces.
+type iamPermissionSimulationAPI interface {
+	SimulatePrincipalPolicy(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error)
 }
 
 // NewConnectionValidator creates an AWS SDK-backed connector validator.
@@ -160,7 +169,8 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 	if iamClient == nil {
 		iamClient = func(cfg awsv2.Config) iamValidationAPI { return iam.NewFromConfig(cfg) }
 	}
-	iamCheck := validateIAMReadPermissions(ctx, iamClient(assumedCfg))
+	validatedIAMClient := iamClient(assumedCfg)
+	iamCheck := validateIAMReadPermissions(ctx, validatedIAMClient)
 	if !iamCheck.Passed {
 		result.Diagnostics = append(result.Diagnostics, api.AWSConnectionDiagnostic{
 			Code:        classifyAWSError(iamCheckError(iamCheck), "aws_iam_read_failed"),
@@ -169,8 +179,114 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 		})
 	}
 	result.PermissionChecks = append(result.PermissionChecks, iamCheck)
+	if simulator, ok := validatedIAMClient.(iamPermissionSimulationAPI); ok {
+		scopeCheck, _ := validateIAMPermissionScope(ctx, simulator, result.RoleARN)
+		if !scopeCheck.Passed {
+			result.Diagnostics = append(result.Diagnostics, api.AWSConnectionDiagnostic{
+				Code:        "aws_connector_permission_scope_incomplete",
+				Message:     "The connector role does not have the complete read-only collector permission scope.",
+				Remediation: scopeCheck.Remediation,
+			})
+		}
+		result.PermissionChecks = append(result.PermissionChecks, scopeCheck)
+	}
 
 	return result, nil
+}
+
+const iamPermissionSimulationBatchSize = 100
+
+func validateIAMPermissionScope(ctx context.Context, client iamPermissionSimulationAPI, roleARN string) (api.AWSConnectionPermissionCheck, error) {
+	check := api.AWSConnectionPermissionCheck{
+		Name:    "aws:ReadOnlyCollectorScope",
+		Passed:  true,
+		Message: "The connector role grants every required read-only collector action.",
+	}
+	expected, err := expectedConnectorPermissionActions()
+	if err != nil {
+		check.Passed = false
+		check.Message = "Identrail could not determine the required read-only collector permission scope."
+		check.Remediation = "Refresh the Identrail connector policy definition, then validate the AWS connector again."
+		return withIAMScopeCheckError(check, err), err
+	}
+	actions := make([]string, 0, len(expected))
+	for action := range expected {
+		actions = append(actions, action)
+	}
+	sort.Strings(actions)
+	missing := make(map[string]struct{})
+	for start := 0; start < len(actions); start += iamPermissionSimulationBatchSize {
+		end := start + iamPermissionSimulationBatchSize
+		if end > len(actions) {
+			end = len(actions)
+		}
+		batch := actions[start:end]
+		decisions := make(map[string]iamtypes.PolicyEvaluationDecisionType)
+		marker := ""
+		for {
+			input := &iam.SimulatePrincipalPolicyInput{
+				PolicySourceArn: awsv2.String(strings.TrimSpace(roleARN)),
+				ActionNames:     batch,
+				ResourceArns:    []string{"*"},
+				MaxItems:        awsv2.Int32(int32(len(batch))),
+			}
+			if marker != "" {
+				input.Marker = awsv2.String(marker)
+			}
+			output, err := client.SimulatePrincipalPolicy(ctx, input)
+			if err != nil {
+				check.Passed = false
+				check.Message = "The connector role permission scope could not be verified."
+				check.Remediation = "Attach the current Identrail read-only collector policy (template 2.2.0), then validate the connector again. The policy must include iam:SimulatePrincipalPolicy and every action used by the AWS collectors."
+				return withIAMScopeCheckError(check, err), err
+			}
+			if output != nil {
+				for _, evaluation := range output.EvaluationResults {
+					action := strings.ToLower(strings.TrimSpace(awsv2.ToString(evaluation.EvalActionName)))
+					if action != "" {
+						decisions[action] = evaluation.EvalDecision
+					}
+				}
+				if output.IsTruncated && strings.TrimSpace(awsv2.ToString(output.Marker)) != "" {
+					marker = strings.TrimSpace(awsv2.ToString(output.Marker))
+					continue
+				}
+			}
+			break
+		}
+		for _, action := range batch {
+			if decisions[strings.ToLower(action)] != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+				missing[action] = struct{}{}
+			}
+		}
+	}
+	if len(missing) == 0 {
+		return check, nil
+	}
+	missingActions := make([]string, 0, len(missing))
+	for action := range missing {
+		missingActions = append(missingActions, action)
+	}
+	sort.Strings(missingActions)
+	check.Passed = false
+	check.Message = fmt.Sprintf("The connector role is missing %d required read-only collector action(s): %s.", len(missingActions), formatIAMActionSample(missingActions))
+	check.Remediation = "Attach the current Identrail read-only collector policy (template 2.2.0), then validate the connector again. Do not add write permissions or weaken the external-ID trust condition."
+	return check, nil
+}
+
+func formatIAMActionSample(actions []string) string {
+	const sampleSize = 8
+	if len(actions) <= sampleSize {
+		return strings.Join(actions, ", ")
+	}
+	return strings.Join(actions[:sampleSize], ", ") + fmt.Sprintf(", and %d more", len(actions)-sampleSize)
+}
+
+func withIAMScopeCheckError(check api.AWSConnectionPermissionCheck, err error) api.AWSConnectionPermissionCheck {
+	if err != nil {
+		check.Message = strings.TrimSpace(check.Message + " (" + err.Error() + ")")
+	}
+	return check
 }
 
 func validateIAMReadPermissions(ctx context.Context, client iamValidationAPI) api.AWSConnectionPermissionCheck {

--- a/internal/providers/aws/connector_validation.go
+++ b/internal/providers/aws/connector_validation.go
@@ -180,7 +180,7 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 	}
 	result.PermissionChecks = append(result.PermissionChecks, iamCheck)
 	if simulator, ok := validatedIAMClient.(iamPermissionSimulationAPI); ok {
-		scopeCheck, _ := validateIAMPermissionScope(ctx, simulator, result.RoleARN)
+		scopeCheck, _ := validateIAMPermissionScope(ctx, simulator, result.RoleARN, region)
 		if !scopeCheck.Passed {
 			result.Diagnostics = append(result.Diagnostics, api.AWSConnectionDiagnostic{
 				Code:        "aws_connector_permission_scope_incomplete",
@@ -196,7 +196,7 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 
 const iamPermissionSimulationBatchSize = 100
 
-func validateIAMPermissionScope(ctx context.Context, client iamPermissionSimulationAPI, roleARN string) (api.AWSConnectionPermissionCheck, error) {
+func validateIAMPermissionScope(ctx context.Context, client iamPermissionSimulationAPI, roleARN string, region string) (api.AWSConnectionPermissionCheck, error) {
 	check := api.AWSConnectionPermissionCheck{
 		Name:    "aws:ReadOnlyCollectorScope",
 		Passed:  true,
@@ -215,6 +215,7 @@ func validateIAMPermissionScope(ctx context.Context, client iamPermissionSimulat
 	}
 	sort.Strings(actions)
 	missing := make(map[string]struct{})
+	simulationContext := iamPermissionSimulationContext(region)
 	for start := 0; start < len(actions); start += iamPermissionSimulationBatchSize {
 		end := start + iamPermissionSimulationBatchSize
 		if end > len(actions) {
@@ -228,6 +229,7 @@ func validateIAMPermissionScope(ctx context.Context, client iamPermissionSimulat
 				PolicySourceArn: awsv2.String(strings.TrimSpace(roleARN)),
 				ActionNames:     batch,
 				ResourceArns:    []string{"*"},
+				ContextEntries:  simulationContext,
 				MaxItems:        awsv2.Int32(int32(len(batch))),
 			}
 			if marker != "" {
@@ -272,6 +274,22 @@ func validateIAMPermissionScope(ctx context.Context, client iamPermissionSimulat
 	check.Message = fmt.Sprintf("The connector role is missing %d required read-only collector action(s): %s.", len(missingActions), formatIAMActionSample(missingActions))
 	check.Remediation = "Attach the current Identrail read-only collector policy (template 2.2.0), then validate the connector again. Do not add write permissions or weaken the external-ID trust condition."
 	return check, nil
+}
+
+// iamPermissionSimulationContext mirrors the request context that the
+// collector uses for regional AWS calls. Without aws:RequestedRegion, IAM
+// evaluates a policy conditioned on that key as an implicit deny even when
+// the role is authorized in the configured region.
+func iamPermissionSimulationContext(region string) []iamtypes.ContextEntry {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return nil
+	}
+	return []iamtypes.ContextEntry{{
+		ContextKeyName:   awsv2.String("aws:RequestedRegion"),
+		ContextKeyValues: []string{region},
+		ContextKeyType:   iamtypes.ContextKeyTypeEnum("string"),
+	}}
 }
 
 func formatIAMActionSample(actions []string) string {

--- a/internal/providers/aws/connector_validation.go
+++ b/internal/providers/aws/connector_validation.go
@@ -216,6 +216,7 @@ func validateIAMPermissionScope(ctx context.Context, client iamPermissionSimulat
 	sort.Strings(actions)
 	missing := make(map[string]struct{})
 	simulationContext := iamPermissionSimulationContext(region)
+	simulationResources := iamPermissionSimulationResourceARNs(roleARN)
 	for start := 0; start < len(actions); start += iamPermissionSimulationBatchSize {
 		end := start + iamPermissionSimulationBatchSize
 		if end > len(actions) {
@@ -228,7 +229,7 @@ func validateIAMPermissionScope(ctx context.Context, client iamPermissionSimulat
 			input := &iam.SimulatePrincipalPolicyInput{
 				PolicySourceArn: awsv2.String(strings.TrimSpace(roleARN)),
 				ActionNames:     batch,
-				ResourceArns:    []string{"*"},
+				ResourceArns:    simulationResources,
 				ContextEntries:  simulationContext,
 				MaxItems:        awsv2.Int32(int32(len(batch))),
 			}
@@ -246,7 +247,15 @@ func validateIAMPermissionScope(ctx context.Context, client iamPermissionSimulat
 				for _, evaluation := range output.EvaluationResults {
 					action := strings.ToLower(strings.TrimSpace(awsv2.ToString(evaluation.EvalActionName)))
 					if action != "" {
-						decisions[action] = evaluation.EvalDecision
+						// A resource-scoped grant can deny the literal "*" probe
+						// while allowing the representative role ARN. Preserve an
+						// allowed result from any resource instead of letting a later
+						// implicit deny overwrite it.
+						if evaluation.EvalDecision == iamtypes.PolicyEvaluationDecisionTypeAllowed || decisions[action] == iamtypes.PolicyEvaluationDecisionTypeAllowed {
+							decisions[action] = iamtypes.PolicyEvaluationDecisionTypeAllowed
+						} else if _, exists := decisions[action]; !exists {
+							decisions[action] = evaluation.EvalDecision
+						}
 					}
 				}
 				if output.IsTruncated && strings.TrimSpace(awsv2.ToString(output.Marker)) != "" {
@@ -274,6 +283,19 @@ func validateIAMPermissionScope(ctx context.Context, client iamPermissionSimulat
 	check.Message = fmt.Sprintf("The connector role is missing %d required read-only collector action(s): %s.", len(missingActions), formatIAMActionSample(missingActions))
 	check.Remediation = "Attach the current Identrail read-only collector policy (template 2.2.0), then validate the connector again. Do not add write permissions or weaken the external-ID trust condition."
 	return check, nil
+}
+
+// iamPermissionSimulationResourceARNs probes both the account-wide wildcard
+// and the configured connector role. The latter is a representative IAM
+// resource that lets policies such as arn:aws:iam::<account>:role/* evaluate
+// as allowed without weakening the permission check for genuinely missing
+// actions.
+func iamPermissionSimulationResourceARNs(roleARN string) []string {
+	resources := []string{"*"}
+	if trimmed := strings.TrimSpace(roleARN); strings.HasPrefix(trimmed, "arn:") {
+		resources = append(resources, trimmed)
+	}
+	return resources
 }
 
 // iamPermissionSimulationContext mirrors the request context that the

--- a/internal/providers/aws/connector_validation_test.go
+++ b/internal/providers/aws/connector_validation_test.go
@@ -52,15 +52,34 @@ type fakeIAMValidationClient struct {
 
 type fakeIAMPermissionSimulationClient struct {
 	fakeIAMValidationClient
-	output *iam.SimulatePrincipalPolicyOutput
-	err    error
-	calls  int
-	inputs []*iam.SimulatePrincipalPolicyInput
+	output                    *iam.SimulatePrincipalPolicyOutput
+	err                       error
+	calls                     int
+	inputs                    []*iam.SimulatePrincipalPolicyInput
+	resourceScopedPermissions bool
 }
 
 func (f *fakeIAMPermissionSimulationClient) SimulatePrincipalPolicy(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
 	f.calls++
 	f.inputs = append(f.inputs, params)
+	if f.resourceScopedPermissions {
+		resourceScoped := false
+		for _, resource := range params.ResourceArns {
+			if resource != "*" {
+				resourceScoped = true
+				break
+			}
+		}
+		decision := iamtypes.PolicyEvaluationDecisionTypeImplicitDeny
+		if resourceScoped {
+			decision = iamtypes.PolicyEvaluationDecisionTypeAllowed
+		}
+		evaluations := make([]iamtypes.EvaluationResult, 0, len(params.ActionNames))
+		for _, action := range params.ActionNames {
+			evaluations = append(evaluations, iamtypes.EvaluationResult{EvalActionName: awsv2.String(action), EvalDecision: decision})
+		}
+		return &iam.SimulatePrincipalPolicyOutput{EvaluationResults: evaluations}, nil
+	}
 	return f.output, f.err
 }
 
@@ -162,7 +181,8 @@ func TestConnectionValidatorValidatesCompleteCollectorPermissionScope(t *testing
 			getRolePolicyOutput:            &iam.GetRolePolicyOutput{PolicyDocument: awsv2.String("{}")},
 			listAttachedRolePoliciesOutput: &iam.ListAttachedRolePoliciesOutput{},
 		},
-		output: &iam.SimulatePrincipalPolicyOutput{EvaluationResults: evaluations},
+		output:                    &iam.SimulatePrincipalPolicyOutput{EvaluationResults: evaluations},
+		resourceScopedPermissions: true,
 	}
 	validator := testConnectionValidator(&fakeSTSAssumeRoleClient{
 		output: &sts.AssumeRoleOutput{Credentials: &ststypes.Credentials{
@@ -188,6 +208,9 @@ func TestConnectionValidatorValidatesCompleteCollectorPermissionScope(t *testing
 		t.Fatal("expected permission simulation requests")
 	}
 	for _, input := range client.inputs {
+		if len(input.ResourceArns) != 2 || input.ResourceArns[0] != "*" || input.ResourceArns[1] != "arn:aws:iam::123456789012:role/IdentrailReadOnly" {
+			t.Fatalf("expected wildcard and connector-role resource probes, got %+v", input.ResourceArns)
+		}
 		if len(input.ContextEntries) != 1 {
 			t.Fatalf("expected regional simulation context, got %+v", input.ContextEntries)
 		}

--- a/internal/providers/aws/connector_validation_test.go
+++ b/internal/providers/aws/connector_validation_test.go
@@ -50,6 +50,18 @@ type fakeIAMValidationClient struct {
 	getPolicyVersionErr            error
 }
 
+type fakeIAMPermissionSimulationClient struct {
+	fakeIAMValidationClient
+	output *iam.SimulatePrincipalPolicyOutput
+	err    error
+	calls  int
+}
+
+func (f *fakeIAMPermissionSimulationClient) SimulatePrincipalPolicy(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+	f.calls++
+	return f.output, f.err
+}
+
 func (f fakeIAMValidationClient) ListRoles(ctx context.Context, params *iam.ListRolesInput, optFns ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
 	return f.listRolesOutput, f.listRolesErr
 }
@@ -126,6 +138,83 @@ func TestConnectionValidatorValidateAWSConnectionActive(t *testing.T) {
 	}
 	if assume.seen == nil || awsv2.ToString(assume.seen.ExternalId) != "external" || awsv2.ToString(assume.seen.RoleSessionName) != "session" {
 		t.Fatalf("assume role request was not populated correctly: %+v", assume.seen)
+	}
+}
+
+func TestConnectionValidatorValidatesCompleteCollectorPermissionScope(t *testing.T) {
+	expected, err := expectedConnectorPermissionActions()
+	if err != nil {
+		t.Fatalf("load expected connector actions: %v", err)
+	}
+	evaluations := make([]iamtypes.EvaluationResult, 0, len(expected))
+	for action := range expected {
+		evaluations = append(evaluations, iamtypes.EvaluationResult{
+			EvalActionName: awsv2.String(action),
+			EvalDecision:   iamtypes.PolicyEvaluationDecisionTypeAllowed,
+		})
+	}
+	client := &fakeIAMPermissionSimulationClient{
+		fakeIAMValidationClient: fakeIAMValidationClient{
+			listRolesOutput:                &iam.ListRolesOutput{Roles: []iamtypes.Role{{RoleName: awsv2.String("AppRole")}}},
+			listRolePoliciesOutput:         &iam.ListRolePoliciesOutput{PolicyNames: []string{"inline"}},
+			getRolePolicyOutput:            &iam.GetRolePolicyOutput{PolicyDocument: awsv2.String("{}")},
+			listAttachedRolePoliciesOutput: &iam.ListAttachedRolePoliciesOutput{},
+		},
+		output: &iam.SimulatePrincipalPolicyOutput{EvaluationResults: evaluations},
+	}
+	validator := testConnectionValidator(&fakeSTSAssumeRoleClient{
+		output: &sts.AssumeRoleOutput{Credentials: &ststypes.Credentials{
+			AccessKeyId: awsv2.String("access"), SecretAccessKey: awsv2.String("secret"), SessionToken: awsv2.String("token"),
+		}},
+	}, fakeSTSIdentityClient{output: &sts.GetCallerIdentityOutput{
+		Account: awsv2.String("123456789012"),
+		Arn:     awsv2.String("arn:aws:sts::123456789012:assumed-role/IdentrailReadOnly/session"),
+		UserId:  awsv2.String("AROATEST:session"),
+	}}, client)
+
+	result, err := validator.ValidateAWSConnection(context.Background(), api.AWSConnectionValidationRequest{RoleARN: "arn:aws:iam::123456789012:role/IdentrailReadOnly"})
+	if err != nil {
+		t.Fatalf("validate connection: %v", err)
+	}
+	if client.calls < 2 {
+		t.Fatalf("expected permission simulation to use batches, got %d calls", client.calls)
+	}
+	if len(result.PermissionChecks) != 3 || !result.PermissionChecks[2].Passed {
+		t.Fatalf("expected complete collector scope check to pass, got %+v", result.PermissionChecks)
+	}
+}
+
+func TestConnectionValidatorRejectsIncompleteCollectorPermissionScope(t *testing.T) {
+	client := &fakeIAMPermissionSimulationClient{
+		fakeIAMValidationClient: fakeIAMValidationClient{
+			listRolesOutput:                &iam.ListRolesOutput{Roles: []iamtypes.Role{{RoleName: awsv2.String("AppRole")}}},
+			listRolePoliciesOutput:         &iam.ListRolePoliciesOutput{},
+			listAttachedRolePoliciesOutput: &iam.ListAttachedRolePoliciesOutput{},
+		},
+		output: &iam.SimulatePrincipalPolicyOutput{EvaluationResults: []iamtypes.EvaluationResult{{
+			EvalActionName: awsv2.String("iam:GetRole"),
+			EvalDecision:   iamtypes.PolicyEvaluationDecisionTypeAllowed,
+		}}},
+	}
+	validator := testConnectionValidator(&fakeSTSAssumeRoleClient{
+		output: &sts.AssumeRoleOutput{Credentials: &ststypes.Credentials{
+			AccessKeyId: awsv2.String("access"), SecretAccessKey: awsv2.String("secret"), SessionToken: awsv2.String("token"),
+		}},
+	}, fakeSTSIdentityClient{output: &sts.GetCallerIdentityOutput{
+		Account: awsv2.String("123456789012"),
+		Arn:     awsv2.String("arn:aws:sts::123456789012:assumed-role/IdentrailReadOnly/session"),
+		UserId:  awsv2.String("AROATEST:session"),
+	}}, client)
+
+	result, err := validator.ValidateAWSConnection(context.Background(), api.AWSConnectionValidationRequest{RoleARN: "arn:aws:iam::123456789012:role/IdentrailReadOnly"})
+	if err != nil {
+		t.Fatalf("validate connection: %v", err)
+	}
+	if len(result.PermissionChecks) != 3 || result.PermissionChecks[2].Passed {
+		t.Fatalf("expected incomplete collector scope check to fail, got %+v", result.PermissionChecks)
+	}
+	if len(result.Diagnostics) != 1 || result.Diagnostics[0].Code != "aws_connector_permission_scope_incomplete" {
+		t.Fatalf("expected permission scope diagnostic, got %+v", result.Diagnostics)
 	}
 }
 

--- a/internal/providers/aws/connector_validation_test.go
+++ b/internal/providers/aws/connector_validation_test.go
@@ -55,10 +55,12 @@ type fakeIAMPermissionSimulationClient struct {
 	output *iam.SimulatePrincipalPolicyOutput
 	err    error
 	calls  int
+	inputs []*iam.SimulatePrincipalPolicyInput
 }
 
 func (f *fakeIAMPermissionSimulationClient) SimulatePrincipalPolicy(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
 	f.calls++
+	f.inputs = append(f.inputs, params)
 	return f.output, f.err
 }
 
@@ -172,7 +174,7 @@ func TestConnectionValidatorValidatesCompleteCollectorPermissionScope(t *testing
 		UserId:  awsv2.String("AROATEST:session"),
 	}}, client)
 
-	result, err := validator.ValidateAWSConnection(context.Background(), api.AWSConnectionValidationRequest{RoleARN: "arn:aws:iam::123456789012:role/IdentrailReadOnly"})
+	result, err := validator.ValidateAWSConnection(context.Background(), api.AWSConnectionValidationRequest{RoleARN: "arn:aws:iam::123456789012:role/IdentrailReadOnly", Region: "eu-west-1"})
 	if err != nil {
 		t.Fatalf("validate connection: %v", err)
 	}
@@ -181,6 +183,18 @@ func TestConnectionValidatorValidatesCompleteCollectorPermissionScope(t *testing
 	}
 	if len(result.PermissionChecks) != 3 || !result.PermissionChecks[2].Passed {
 		t.Fatalf("expected complete collector scope check to pass, got %+v", result.PermissionChecks)
+	}
+	if len(client.inputs) == 0 {
+		t.Fatal("expected permission simulation requests")
+	}
+	for _, input := range client.inputs {
+		if len(input.ContextEntries) != 1 {
+			t.Fatalf("expected regional simulation context, got %+v", input.ContextEntries)
+		}
+		entry := input.ContextEntries[0]
+		if awsv2.ToString(entry.ContextKeyName) != "aws:RequestedRegion" || len(entry.ContextKeyValues) != 1 || entry.ContextKeyValues[0] != "eu-west-1" || entry.ContextKeyType != iamtypes.ContextKeyTypeEnum("string") {
+			t.Fatalf("unexpected regional simulation context: %+v", entry)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- validate the connector role against the complete read-only collector action set with IAM simulation
- refresh connector health before enqueue and again before worker scanner creation so stale health cannot produce partial scans
- migrate authenticated stack-bound legacy template updates to the current policy and force repair/relaunch to use the current template
- keep trust, external-ID, account, and monotonic template-version checks intact

## Regression coverage

- complete and incomplete effective permission scopes
- scan enqueue and worker-time permission drift
- legacy template upgrade and downgrade rejection
- repair hydration with stale template metadata

## Verification

- `go test ./...`
- `go vet ./internal/providers/aws ./internal/api`
- repository security diff scan: complete, no reportable findings

This change never edits customer IAM automatically; it blocks the scan with the exact remediation until the current read-only policy is applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks AWS scans when the connector role doesn't grant the complete read-only collector permission scope, and revalidates the connector via IAM simulation when a scan is queued and again when the worker starts — including source-less scheduled scans — so stale or drifted health can't produce a partial scan.

- Simulates the assumed role against the complete read-only collector action set with the connector's region as `aws:RequestedRegion`, reporting the missing actions.
- Source-less scheduled scans revalidate and start in the chosen connector's own tenant/workspace scope, carrying the selected connector's full row across scopes and persisting the selection on the scan record so retries and history stay bound to it.
- Migrates authenticated, stack-bound legacy template updates to the current policy; repair and relaunch always target the current template, opening the existing stack's CloudFormation update wizard and reusing the bound onboarding attempt instead of a create flow, even when a newer unbound attempt exists.
- Rejects template downgrades and unknown versions while preserving trust, external-ID, and account checks; Bootstrap defers recording an upgrade until Register accepts the callback so CloudFormation rollback updates aren't treated as downgrades.
- Finding evidence persistence no longer preallocates its map from input length, closing an overflow on malformed input.
- Never edits customer IAM automatically; scans are blocked with remediation guidance until the current policy is applied.

<sup>Written for commit a9af0b86c69b8b23cced9e5c3d3c79d4abdb2efb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

