### PR TITLE
Fix dark marketing card hover state

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -19875,6 +19875,20 @@ html[data-theme='light'] .idt-marketing-page .idt-pricing-card {
   box-shadow: none;
 }
 
+/* Keep the dark marketing tiles dark when the shared interactive-card hover
+   treatment runs. */
+.idt-marketing-page .idt-card:has(a, button):hover,
+.idt-marketing-page .idt-card:has(a, button):focus-within,
+.idt-marketing-page .idt-pricing-card:has(a, button):hover,
+.idt-marketing-page .idt-pricing-card:has(a, button):focus-within,
+html[data-theme='light'] .idt-marketing-page .idt-card:has(a, button):hover,
+html[data-theme='light'] .idt-marketing-page .idt-card:has(a, button):focus-within,
+html[data-theme='light'] .idt-marketing-page .idt-pricing-card:has(a, button):hover,
+html[data-theme='light'] .idt-marketing-page .idt-pricing-card:has(a, button):focus-within {
+  background: #080808;
+  box-shadow: none;
+}
+
 .idt-marketing-page .idt-card h2,
 .idt-marketing-page .idt-pricing-card h2,
 html[data-theme='light'] .idt-marketing-page .idt-card h2,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -19889,6 +19889,17 @@ html[data-theme='light'] .idt-marketing-page .idt-pricing-card:not(.is-featured)
   box-shadow: none;
 }
 
+.idt-marketing-page .idt-card:has(a, button):hover::after,
+.idt-marketing-page .idt-card:has(a, button):focus-within::after,
+.idt-marketing-page .idt-pricing-card:not(.is-featured):has(a, button):hover::after,
+.idt-marketing-page .idt-pricing-card:not(.is-featured):has(a, button):focus-within::after,
+html[data-theme='light'] .idt-marketing-page .idt-card:has(a, button):hover::after,
+html[data-theme='light'] .idt-marketing-page .idt-card:has(a, button):focus-within::after,
+html[data-theme='light'] .idt-marketing-page .idt-pricing-card:not(.is-featured):has(a, button):hover::after,
+html[data-theme='light'] .idt-marketing-page .idt-pricing-card:not(.is-featured):has(a, button):focus-within::after {
+  color: rgba(255, 255, 255, 0.6);
+}
+
 .idt-marketing-page .idt-card h2,
 .idt-marketing-page .idt-pricing-card h2,
 html[data-theme='light'] .idt-marketing-page .idt-card h2,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -19879,12 +19879,12 @@ html[data-theme='light'] .idt-marketing-page .idt-pricing-card {
    treatment runs. */
 .idt-marketing-page .idt-card:has(a, button):hover,
 .idt-marketing-page .idt-card:has(a, button):focus-within,
-.idt-marketing-page .idt-pricing-card:has(a, button):hover,
-.idt-marketing-page .idt-pricing-card:has(a, button):focus-within,
+.idt-marketing-page .idt-pricing-card:not(.is-featured):has(a, button):hover,
+.idt-marketing-page .idt-pricing-card:not(.is-featured):has(a, button):focus-within,
 html[data-theme='light'] .idt-marketing-page .idt-card:has(a, button):hover,
 html[data-theme='light'] .idt-marketing-page .idt-card:has(a, button):focus-within,
-html[data-theme='light'] .idt-marketing-page .idt-pricing-card:has(a, button):hover,
-html[data-theme='light'] .idt-marketing-page .idt-pricing-card:has(a, button):focus-within {
+html[data-theme='light'] .idt-marketing-page .idt-pricing-card:not(.is-featured):has(a, button):hover,
+html[data-theme='light'] .idt-marketing-page .idt-pricing-card:not(.is-featured):has(a, button):focus-within {
   background: #080808;
   box-shadow: none;
 }


### PR DESCRIPTION
## Summary

- Keep interactive cards on the dark marketing surface during hover and keyboard focus.
- Preserve the existing lift and arrow affordances while removing the white-on-white contrast failure.

## Root cause

The shared `.idt-card:has(a, button)` hover rule applied `background: rgba(255, 255, 255, 0.96)` after the marketing-page card styling, so the page-specific dark background lost the cascade on hover and focus.

## Validation

- `npm test -- --run App.test.tsx` (94 passed)
- `npm test -- --run` (622 passed)
- `npm run build` (40 routes prerendered)
- Browser verification at `/docs`: hover and keyboard focus both remain `rgb(8, 8, 8)` with white text
- `git diff --check`