### PR TITLE
Remove noisy header keyboard shortcuts

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -434,17 +434,16 @@ describe('App', () => {
     expect(screen.getByRole('dialog', { name: /Verify company identity/i })).toBeInTheDocument();
   });
 
-  it.each([
-    ['l', '/signin'],
-    ['S', '/signup']
-  ])('routes the %s header keyboard shortcut to %s', async (key, expectedPath) => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(authConfig(false, true)));
+  it('removes auth keycap hints and single-key header navigation', () => {
     setCurrentPath('/');
     render(<App />);
 
-    fireEvent.keyDown(document, { key });
+    expect(document.querySelectorAll('.idt-header-keycap')).toHaveLength(0);
 
-    await waitFor(() => expect(window.location.pathname).toBe(expectedPath));
+    fireEvent.keyDown(document, { key: 'l' });
+    fireEvent.keyDown(document, { key: 's' });
+
+    expect(window.location.pathname).toBe('/');
   });
 
   it('reuses loaded auth options when switching between log in and sign up', async () => {
@@ -469,24 +468,6 @@ describe('App', () => {
     ).length;
     expect(authCallsAfterNavigation).toBe(authCallsBeforeNavigation);
   });
-
-  it.each([
-    ['nested textbox role', <span role="textbox"><span data-testid="editable-shortcut-target">sale note</span></span>],
-    ['plaintext contenteditable', <span contentEditable="plaintext-only"><span data-testid="editable-shortcut-target">login note</span></span>]
-  ])('keeps header shortcuts inactive inside %s editors', async (_name, editor) => {
-    setCurrentPath('/');
-    render(
-      <>
-        <App />
-        {editor}
-      </>
-    );
-
-    fireEvent.keyDown(screen.getByTestId('editable-shortcut-target'), { key: 's' });
-
-    expect(window.location.pathname).toBe('/');
-  });
-
 
   it('resets scroll when a routed hash target is missing', async () => {
     setCurrentPath('/pricing');

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, NavLink, useLocation, useNavigate } from 'react-router';
+import { Link, NavLink, useLocation } from 'react-router';
 import { preloadAuthConfig } from '../../authConfigCache';
 import { siteLinks } from '../../siteConfig';
 
@@ -7,23 +7,6 @@ type NavLinkItem = {
   to: string;
   label: string;
 };
-
-function isEditableShortcutTarget(target: EventTarget | null) {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-
-  if (target.closest('input, textarea, select')) {
-    return true;
-  }
-
-  const editableHost = target.closest('[contenteditable]');
-  if (editableHost instanceof HTMLElement && editableHost.contentEditable !== 'false') {
-    return true;
-  }
-
-  return Boolean(target.closest('[role="textbox"], [role="searchbox"], [role="combobox"], [role="spinbutton"]'));
-}
 
 export function Header({
   navLinks
@@ -33,7 +16,6 @@ export function Header({
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const location = useLocation();
-  const navigate = useNavigate();
 
   useEffect(() => {
     setMenuOpen(false);
@@ -53,32 +35,6 @@ export function Header({
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [menuOpen]);
-
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey || event.repeat) {
-        return;
-      }
-
-      const target = event.target;
-      if (isEditableShortcutTarget(target)) {
-        return;
-      }
-
-      const key = event.key.toLowerCase();
-      if (key !== 'l' && key !== 's') {
-        return;
-      }
-
-      event.preventDefault();
-      setMenuOpen(false);
-      preloadAuthConfig();
-      navigate(key === 'l' ? siteLinks.signIn : '/signup');
-    };
-
-    document.addEventListener('keydown', onKeyDown);
-    return () => document.removeEventListener('keydown', onKeyDown);
-  }, [navigate]);
 
   return (
     <header className="idt-header">
@@ -122,9 +78,6 @@ export function Header({
             onPointerDown={preloadAuthConfig}
           >
             <span>Log in</span>
-            <span className="idt-header-keycap" aria-hidden="true">
-              L
-            </span>
           </Link>
           <Link
             to="/signup"
@@ -135,9 +88,6 @@ export function Header({
             onPointerDown={preloadAuthConfig}
           >
             <span>Sign up</span>
-            <span className="idt-header-keycap" aria-hidden="true">
-              S
-            </span>
           </Link>
         </div>
       </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -14153,7 +14153,6 @@ html[data-theme='light'] .idt-nav a.is-active,
   min-height: 44px;
   display: inline-flex;
   align-items: center;
-  gap: 0.68rem;
   border: 1px solid rgba(5, 5, 5, 0.22);
   border-radius: 999px;
   background: #ffffff;
@@ -14186,30 +14185,6 @@ html[data-theme='light'] .idt-nav a.is-active,
 .idt-header-auth-chip.is-primary:focus-visible {
   background: #171717;
   color: #ffffff;
-}
-
-.idt-header-keycap {
-  display: inline-grid;
-  place-items: center;
-  width: 1.7rem;
-  height: 1.7rem;
-  border: 1px solid rgba(5, 5, 5, 0.18);
-  border-radius: 0.42rem;
-  background: #ededed;
-  color: #050505;
-  font-family: var(--idt-nav-font);
-  font-size: 0.86rem;
-  font-weight: 820;
-  line-height: 1;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.85),
-    0 1px 2px rgba(15, 23, 42, 0.16);
-}
-
-.idt-header-auth-chip.is-primary .idt-header-keycap {
-  border-color: rgba(255, 255, 255, 0.28);
-  background: #f6f6f6;
-  color: #050505;
 }
 
 .idt-header-demo {
@@ -27969,12 +27944,11 @@ html[data-theme='light'] .idt-app-console-layout .idt-source-onboarding.is-sourc
   }
 }
 
-/* Header auth shortcut polish. */
+/* Header auth chip polish. */
 .idt-header-utility.idt-header-auth-chip {
   min-height: 44px;
   display: inline-flex;
   align-items: center;
-  gap: 0.68rem;
   border: 1px solid rgba(5, 5, 5, 0.22);
   border-radius: 999px;
   background: #ffffff;
@@ -28008,30 +27982,6 @@ html[data-theme='light'] .idt-app-console-layout .idt-source-onboarding.is-sourc
   border-color: #050505;
   background: #171717;
   color: #ffffff;
-}
-
-.idt-header-keycap {
-  display: inline-grid;
-  place-items: center;
-  width: 1.7rem;
-  height: 1.7rem;
-  border: 1px solid rgba(5, 5, 5, 0.18);
-  border-radius: 0.42rem;
-  background: #ededed;
-  color: #050505;
-  font-family: var(--idt-nav-font);
-  font-size: 0.86rem;
-  font-weight: 820;
-  line-height: 1;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.85),
-    0 1px 2px rgba(15, 23, 42, 0.16);
-}
-
-.idt-header-auth-chip.is-primary .idt-header-keycap {
-  border-color: rgba(255, 255, 255, 0.28);
-  background: #f6f6f6;
-  color: #050505;
 }
 
 @media (max-width: 880px) {
@@ -28102,25 +28052,10 @@ html[data-theme='light'] .idt-app-console-layout .idt-source-onboarding.is-sourc
 
 .idt-header-utility.idt-header-auth-chip {
   flex: 0 0 auto;
-  justify-content: space-between;
-  min-width: 7.1rem;
-  gap: 0.72rem;
-  padding: 0.2rem 0.46rem 0.2rem 1rem;
+  justify-content: center;
+  min-width: 0;
+  padding: 0.2rem 1rem;
   white-space: nowrap;
-}
-
-.idt-header-utility.idt-header-auth-chip.is-primary {
-  min-width: 7.7rem;
-}
-
-.idt-header-auth-chip > span:first-child {
-  display: inline-block;
-  white-space: nowrap;
-}
-
-.idt-header-keycap {
-  flex: 0 0 auto;
-  pointer-events: none;
 }
 
 @media (max-width: 880px) {


### PR DESCRIPTION
## Summary

- Remove the noisy L and S keycap badges from the public header.
- Remove the document-level single-key navigation and its editable-target guard.
- Keep explicit Log in and Sign up links, preload behavior, and responsive layout.

## Validation

- `npm test -- --run` (619 passed across 16 files)
- `npm run build` (40 routes prerendered)
- `git diff --check`
- Browser verification at `/`: no keycaps, bare L/S do not navigate, desktop/mobile header layout has no horizontal overflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the L and S keyboard shortcuts from the public header so pressing those keys no longer navigates to sign in or sign up, and drops the keycap badges from the Log in and Sign up buttons. Explicit links, preload behavior, and responsive layout stay unchanged.

- Removes the document-level single-key navigation and its editable-target guard.
- Updates tests to confirm bare L and S keys do not navigate and no keycap hints render.

<sup>Written for commit 1b4295ae2225f7f7a2af1b34d4799864242e7c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

