### PR TITLE
Add Vercel Web Analytics to the web app

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "identrail-web",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
         "input-otp": "^1.5.0",
         "lucide-react": "^1.33.0",
         "react": "^19.2.7",
@@ -1484,6 +1485,48 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "perf:bundle": "vite build --mode production"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "input-otp": "^1.5.0",
     "lucide-react": "^1.33.0",
     "react": "^19.2.7",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { createContext, FormEvent, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { BrowserRouter, Link, Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router';
+import { Analytics } from '@vercel/analytics/react';
 import { SafeLink } from './components/SafeLink';
 import { HeroProductReveal } from './components/home/HeroProductReveal';
 import { HeroOpenSourceProofPills } from './components/home/HeroOpenSourceProofPills';
@@ -4921,6 +4922,7 @@ export function App() {
       <ScanIntakeModalProvider>
         <RoutedSite />
       </ScanIntakeModalProvider>
+      <Analytics />
     </BrowserRouter>
   );
 }


### PR DESCRIPTION
## Summary

- Add `@vercel/analytics` to the Vite React web app.
- Mount the generic React `<Analytics />` component at the app root so Vercel can collect initial visits and SPA route changes.

## Why

Vercel Web Analytics is enabled for the project, but the site must load the analytics integration before visitor and page-view data can appear.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed: low, client-side analytics script only

## Validation

- `npm run test:ci` from `web/` — 619 tests passed.
- `npm run build` from `web/` — production build and prerender passed for 40 routes.
- Git hooks passed, including Vercel artifact hygiene.

## Checklist

- [ ] Tests added/updated for behavior changes — vendor wiring is covered by the production build.
- [ ] Docs updated for user/operator-facing changes — dashboard enablement is documented in the PR context.
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: none
- Areas where used: none
- Human verification performed: repository tests, production build, prerender, and hooks

## Related Issues

No issue: Vercel project setup requested this integration, and no tracked issue was supplied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@vercel/analytics` to the Vite web app and mounts the `<Analytics />` component at the app root. This enables Vercel Web Analytics, which previously collected no data because the integration wasn't loaded. The change is client-side only and has no impact on existing functionality.

<sup>Written for commit 25bb613403b6376532ff6d0ee80c9edd89c8dbed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

