### PR TITLE
Revert "build(deps): Bump the docker-version-updates group in /deploy/docker with 2 updates"

### DIFF
--- a/deploy/docker/Dockerfile.web
+++ b/deploy/docker/Dockerfile.web
@@ -1,4 +1,4 @@
-FROM node:26-bookworm-slim@sha256:367679cf9792759492a486e4aa4b421764d71a9546a6dae8aab81a99eb797b3e AS builder
+FROM node:26-bookworm-slim@sha256:cd565714d4da3e84bfd341e31448f81d47c6362198f152345297c9c1154e6341 AS builder
 WORKDIR /web
 
 COPY web/package*.json ./
@@ -26,7 +26,7 @@ ENV VITE_FEATURE_ONBOARDING_WIZARD=${VITE_FEATURE_ONBOARDING_WIZARD}
 
 RUN npm run build
 
-FROM nginxinc/nginx-unprivileged:1.31-alpine@sha256:d9083fe47768377ef55dedafd67d4da7c2f2bc2bece7554954f29359deb0dce9
+FROM nginxinc/nginx-unprivileged:1.31-alpine@sha256:59ccf0943b0b8e8d9e6ea9039a39555730f544701a655c596f7df7d096c593f5
 ARG NGINX_CONF=default.conf
 COPY deploy/docker/nginx/${NGINX_CONF} /etc/nginx/conf.d/default.conf
 COPY --from=builder /web/dist /usr/share/nginx/html


### PR DESCRIPTION
Reverts identrail/identrail#1848

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Docker base image bump from #1848, restoring the previously pinned `node:26-bookworm-slim` and `nginxinc/nginx-unprivileged:1.31-alpine` digest hashes in `deploy/docker/Dockerfile.web`.

<sup>Written for commit cbc5be1ca8e420bd77bb153be139c5a57656399e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

